### PR TITLE
Proper optimization and debug levels

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -40,6 +40,9 @@ DEFINES += gcc __IO=volatile
 # no assert by default
 DEFINES += NDEBUG
 
+# Debug mode disabled by default
+DEBUG:=0
+
 # default is not to display make commands
 log = $(if $(strip $(VERBOSE)),$1,@$1) # kept for retrocompat
 L = $(if $(strip $(VERBOSE)),,@)
@@ -55,8 +58,17 @@ else
 CFLAGS   += --sysroot="$(SYSROOT)"
 endif
 
+# optimization and debug levels
+ifneq ($(DEBUG),0)
+OPTI_LVL  = -O0
+DBG_LVL   = -g3
+else
+OPTI_LVL  = -Oz
+DBG_LVL   = -g0
+endif
+
 CFLAGS   += -gdwarf-2  -gstrict-dwarf
-CFLAGS   += -O3 -Os
+CFLAGS   += $(OPTI_LVL) $(DBG_LVL)
 CFLAGS   += -fomit-frame-pointer -momit-leaf-frame-pointer
 CFLAGS   += -mcpu=cortex-m0plus -mthumb
 CFLAGS   += -fno-common -mtune=cortex-m0plus -mlittle-endian
@@ -68,10 +80,11 @@ CFLAGS   += -fropi
 CFLAGS   += -fno-jump-tables # avoid jump tables for switch to avoid problems with invalid PIC access
 CFLAGS   += -nostdlib -nodefaultlibs
 
-AFLAGS   += -ggdb2 -O3 -Os -mcpu=cortex-m0plus -fno-common -mtune=cortex-m0plus
+# this does not handle -Oz, force -Os instead
+AFLAGS   += -Os $(DBG_LVL) -mcpu=cortex-m0plus -fno-common -mtune=cortex-m0plus
 
 LDFLAGS  += -gdwarf-2  -gstrict-dwarf
-LDFLAGS  += -O3 -Os
+LDFLAGS  += $(OPTI_LVL) $(DBG_LVL)
 LDFLAGS  += -fomit-frame-pointer
 LDFLAGS  += -Wall
 LDFLAGS  += -mcpu=cortex-m0plus -mthumb


### PR DESCRIPTION
For debug builds:
* Completely disables optimizations (fixes weird behaviors while step-by-step debugging and \<optimized out\> variables)
* Enables the highest level of debugging information

For release builds:
* Completely disables debugging information
* Enables the proper optimization level (instead of defining two which will ultimately replaced by the one defined by the apps)

With this, apps should not have to worry about redefining their own.