### PR TITLE
Fat: Generate app icon as a glyph

### DIFF
--- a/Makefile.glyphs
+++ b/Makefile.glyphs
@@ -29,6 +29,7 @@ ifeq ($(TARGET_NAME),TARGET_FATSTACKS)
 # Fatstacks glyphs files and generation script
 GLYPH_FILES += $(addprefix $(BOLOS_SDK)/lib_nbgl/glyphs/,$(sort $(notdir $(shell find $(BOLOS_SDK)/lib_nbgl/glyphs/))))
 GLYPH_FILES += $(addprefix glyphs/,$(sort $(notdir $(shell find glyphs/))))
+GLYPH_FILES += $(ICONNAME)
 ICON_SCRIPT = $(BOLOS_SDK)/lib_nbgl/tools/icon2glyph.py
 GENERATE_GLYPHS_CMD = python3 $(ICON_SCRIPT) --glyphcfile $(GLYPH_FILES) > $(GLYPH_DESTC)
 else


### PR DESCRIPTION
In Nanos, the app icon was not displayed inside the app. Thus, it was not generated as a glyph.
In Stax, the app is now displayed on the Welcome page of the app. This commits enables the generation of the app icon glyphs, as soon as the app is built.