### PR TITLE
Fix FWEO-557 - Play tune on touch press in keypad

### DIFF
--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -142,6 +142,7 @@ typedef enum {
     LONG_TOUCHED, ///< corresponding to an object touched and released at least LONG_TOUCH_DURATION ms later.
     TOUCHING, ///< corresponding to an object that is currently touched
     OUT_OF_TOUCH, ///< corresponding to an object that was touched but that has lost the focus (the finger has moved)
+    TOUCH_PRESSED, ///< corresponding to an object that was not touched and where the finger has been pressed.
     TOUCH_RELEASED, ///< corresponding to an object that was touched and where the finger has been released.
     VALUE_CHANGED ///< corresponding to a change of state of the object (indirect event)
 } nbgl_touchType_t;

--- a/lib_nbgl/src/nbgl_touch.c
+++ b/lib_nbgl/src/nbgl_touch.c
@@ -48,7 +48,7 @@ static nbgl_touchStatePosition_t firstTouchedPosition,lastTouchedPosition;
  * @param eventType type of touchscreen event
  */
 static void applytouchStatePosition(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
-  //LOG_DEBUG(TOUCH_LOGGER,"Apply event %s on object of type %d\n",touchTypeStrings[eventType],obj->type);
+  LOG_DEBUG(TOUCH_LOGGER,"Apply event %d on object of type %d\n",eventType,obj->type);
   if (!obj) {
     return;
   }
@@ -193,6 +193,7 @@ void nbgl_touchHandler(nbgl_touchStatePosition_t *touchStatePosition, uint32_t c
       // newly touched object
       lastPressedObj = foundObj;
       lastPressedTime = currentTime;
+      applytouchStatePosition(foundObj,TOUCH_PRESSED);
       applytouchStatePosition(foundObj,TOUCHING);
     }
   }

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -552,7 +552,7 @@ void nbgl_useCaseStatus(char *message, bool isSuccess, nbgl_callback_t quitCallb
   nbgl_screenTickerConfiguration_t ticker = {
     .tickerCallback = &tickerCallback,
     .tickerIntervale = 0, // not periodic
-    .tickerValue = 1000 // 1 second
+    .tickerValue = 3000 // 3 seconds
   };
   onQuit = quitCallback;
   if (isSuccess) {


### PR DESCRIPTION
Fixes https://ledgerhq.atlassian.net/browse/FWEO-557 by playing tune in keypad object management, for all keys except validate.
Also set duration of status page to 3 seconds to align with FW