### PR TITLE
AES-GCM: set const qualifier for input data

### DIFF
--- a/lib_cxng/include/lcx_aes_gcm.h
+++ b/lib_cxng/include/lcx_aes_gcm.h
@@ -58,7 +58,7 @@ cx_err_t cx_aes_gcm_set_key(cx_aes_gcm_context_t *ctx, const uint8_t *raw_key, s
 cx_err_t cx_aes_gcm_start(cx_aes_gcm_context_t *ctx, uint32_t mode,
                           const uint8_t *iv, size_t iv_len);
 cx_err_t cx_aes_gcm_update_aad(cx_aes_gcm_context_t *ctx, const uint8_t *aad, size_t aad_len);
-cx_err_t cx_aes_gcm_update(cx_aes_gcm_context_t *ctx, uint8_t *in, uint8_t *out, size_t len);
+cx_err_t cx_aes_gcm_update(cx_aes_gcm_context_t *ctx, const uint8_t *in, uint8_t *out, size_t len);
 cx_err_t cx_aes_gcm_finish(cx_aes_gcm_context_t *ctx, uint8_t *tag, size_t tag_len);
 cx_err_t cx_aes_gcm_encrypt_and_tag(cx_aes_gcm_context_t *ctx, uint8_t *in, size_t len,
                                     const uint8_t *iv, size_t iv_len, const uint8_t *aad, size_t aad_len,

--- a/lib_cxng/src/cx_aes_gcm.c
+++ b/lib_cxng/src/cx_aes_gcm.c
@@ -235,7 +235,7 @@ cx_err_t cx_aes_gcm_update_aad(cx_aes_gcm_context_t *ctx, const uint8_t *aad, si
     return error;
 }
 
-cx_err_t cx_aes_gcm_update(cx_aes_gcm_context_t *ctx, uint8_t *in, uint8_t *out, size_t len) {
+cx_err_t cx_aes_gcm_update(cx_aes_gcm_context_t *ctx, const uint8_t *in, uint8_t *out, size_t len) {
   cx_err_t error = CX_INVALID_PARAMETER;
   size_t   i, block_len;
   uint8_t  tmp[AES_BLOCK_BYTES];


### PR DESCRIPTION
Input parameter of `cx_aes_gcm_update` should be `const`.