### PR TITLE
Fix bad behavior when dismissing address as QR code

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -142,7 +142,9 @@ static void pageModalCallback(int token, uint8_t index) {
 
 // generic callback for all pages except modal
 static void pageCallback(int token, uint8_t index) {
-  if ((token < FIRST_USER_TOKEN) && (token != SKIP_TOKEN)) {
+  if ((token < FIRST_USER_TOKEN) &&
+      (token != SKIP_TOKEN) &&
+      (token != BUTTON_TOKEN)) {
     nbgl_pageRelease(pageContext);
     pageContext = NULL;
   }


### PR DESCRIPTION
Fix not responding screen after having dismissed modal screen with address as QR code, when using nbgl_useCaseAddressConfirmationExt()