### PR TITLE
Fat: Fix GZLIB_UNCOMPRESSED_CHUNK value

### DIFF
--- a/lib_nbgl/include/nbgl_types.h
+++ b/lib_nbgl/include/nbgl_types.h
@@ -126,7 +126,7 @@ typedef enum {
  * @brief size of gzlib uncompression buffer in bytes
  *
  */
-#define GZLIB_UNCOMPRESSED_CHUNK 2048
+#define GZLIB_UNCOMPRESSED_CHUNK 2049
 
 /**
  * @brief Represents a rectangle area of the screen


### PR DESCRIPTION
- Ledger image uncompressed chunks are specified to be 2048 bytes long maximum
- Uzlib library requires to reserve one more byte (see https://github.com/pfalcon/uzlib/blob/master/examples/tgunzip/tgunzip.c#L108)