### PR TITLE
Fat: Remove DEBUG_PIEZO define from BOLOS

### DIFF
--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -260,7 +260,7 @@ void io_seproxyhal_disable_io(void);
 
 #ifdef HAVE_PIEZO_SOUND
 typedef enum tune_index_e {
-    TUNE_CUSTOM, // Active only if DEBUG_PIEZO
+    TUNE_RESERVED,
     TUNE_BOOT,
     TUNE_CHARGING,
     TUNE_LEDGER_MOMENT,

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -482,13 +482,6 @@ void io_seproxyhal_play_tune(tune_index_e tune_index) {
     return;
   }
 
-  #ifndef DEBUG_PIEZO
-  // Tune custom is not allowed
-  if(tune_index == TUNE_CUSTOM) {
-    return;
-  }
-  #endif
-
   uint32_t sound_setting = os_setting_get(OS_SETTING_PIEZO_SOUND, NULL, 0);
 
   if ((!IS_NOTIF_ENABLED(sound_setting)) && (tune_index < TUNE_TAP_CASUAL)) {


### PR DESCRIPTION
TUNE_CUSTOM is now TUNE_RESERVED.
TUNE_RESERVED is active only if the MCU firmware enables DEBUG_PIEZO.