### PR TITLE
Change max number of supported chars for QRCode V4

### DIFF
--- a/lib_nbgl/src/nbgl_draw.c
+++ b/lib_nbgl/src/nbgl_draw.c
@@ -496,7 +496,7 @@ void nbgl_drawQrCode(nbgl_area_t *area, uint8_t version, const char *text, color
     nbgl_frontDrawQrInternal(area, foregroundColor);
   }
   else {
-    LOG_WARN("Impossible to draw QRCode text %s with version %d\n",text, version);
+    LOG_WARN(DRAW_LOGGER,"Impossible to draw QRCode text %s with version %d\n",text, version);
   }
 }
 #endif // NBGL_QRCODE

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1183,8 +1183,8 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, nbgl_layoutQRCode_t *info) {
   container->nbChildren = 0;
 
   qrcode = (nbgl_qrcode_t *)nbgl_objPoolGet(QR_CODE,layoutInt->layer);
-  // version is forced to V10 if url is longer than 114 characters
-  if (strlen(PIC(info->url))>=114) {
+  // version is forced to V10 if url is longer than 62 characters
+  if (strlen(PIC(info->url))>62) {
     qrcode->version = QRCODE_V10;
   }
   else {


### PR DESCRIPTION
Change max of supported chars from 113 to 62 for QRCode V4