### PR TITLE
Remove useless info from make output

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -160,10 +160,5 @@ endif
 # include builtin CX libs options
 -include $(BOLOS_SDK)/Makefile.conf.cx
 
-ifneq ($(BOLOS_ENV),)
-CLANGPATH := $(BOLOS_ENV)/clang-arm-fropi/bin/
-GCCPATH := $(BOLOS_ENV)/gcc-arm-none-eabi-5_3-2016q1/bin/
-endif
-
 # define the default makefile target (high in include to avoid glyph.h or what not specific target to be the default one when no target passed on the make command line)
 all: default


### PR DESCRIPTION
BOLOS_ENV is not set by ledger-app-builder, resulting in the following messages being printed for every build:

```
  BOLOS_ENV=$(BOLOS_ENV)
  BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH
  CLANGPATH is not set: clang will be used from PATH
  GCCPATH is not set: arm-none-eabi-* will be used from PATH
```