### PR TITLE
Use compression for glyphs bigger or equal to 64px

### DIFF
--- a/lib_nbgl/include/nbgl_types.h
+++ b/lib_nbgl/include/nbgl_types.h
@@ -191,6 +191,7 @@ typedef struct PACKED__ nbgl_icon_details_s {
     uint16_t width;   ///< width of the icon, in pixels
     uint16_t height;  ///< height of the icon, in pixels
     nbgl_bpp_t bpp;   ///< bits per pixel for this area
+    bool isFile;      ///< if true, the bitmap buffer contains an image file
     const uint8_t *bitmap;  ///< buffer containing pixel values
 } nbgl_icon_details_t;
 

--- a/lib_nbgl/src/nbgl_draw.c
+++ b/lib_nbgl/src/nbgl_draw.c
@@ -52,12 +52,12 @@ typedef struct {
 static const uint8_t quarter_disc_4px_1bpp[] = {
   0x13, 0xFF
 };
-static const nbgl_icon_details_t C_quarter_disc_4px_1bpp= { 4, 4, NBGL_BPP_1, quarter_disc_4px_1bpp};
+static const nbgl_icon_details_t C_quarter_disc_4px_1bpp= { 4, 4, NBGL_BPP_1, false, quarter_disc_4px_1bpp};
 
 static const uint8_t quarter_circle_4px_1bpp[] = {
   0x13, 0xFF
 };
-static const nbgl_icon_details_t C_quarter_circle_4px_1bpp= { 4, 4, NBGL_BPP_1, quarter_circle_4px_1bpp};
+static const nbgl_icon_details_t C_quarter_circle_4px_1bpp= { 4, 4, NBGL_BPP_1, false, quarter_circle_4px_1bpp};
 
 // indexed by nbgl_radius_t (except RADIUS_0_PIXELS)
 static const uint8_t radiusValues[] = {

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -385,6 +385,7 @@ static void draw_line(nbgl_line_t* obj, nbgl_obj_t *prevObj, bool computePositio
 
 static void draw_image(nbgl_image_t* obj, nbgl_obj_t *prevObj, bool computePosition) {
   const nbgl_icon_details_t *iconDetails;
+  nbgl_color_map_t colorMap;
 
   // if buffer is NULL, let's try to call onDrawCallback, if not NULL, to get it
   if (obj->buffer == NULL) {
@@ -410,13 +411,19 @@ static void draw_image(nbgl_image_t* obj, nbgl_obj_t *prevObj, bool computePosit
   // inherit background from parent
   obj->backgroundColor = obj->parent->backgroundColor;
   if (obj->bpp == NBGL_BPP_1) {
-    nbgl_frontDrawImage((nbgl_area_t*)obj, (uint8_t*)iconDetails->bitmap,NO_TRANSFORMATION, obj->foregroundColor);
+    colorMap = obj->foregroundColor;
   }
   else if (obj->bpp == NBGL_BPP_2) {
-    nbgl_frontDrawImage((nbgl_area_t*)obj, (uint8_t*)iconDetails->bitmap,NO_TRANSFORMATION, ((WHITE<<6)|(LIGHT_GRAY<<4)|(DARK_GRAY<<2)|BLACK));
+    colorMap = ((WHITE<<6)|(LIGHT_GRAY<<4)|(DARK_GRAY<<2)|BLACK);
   }
   else {
-    nbgl_frontDrawImage((nbgl_area_t*)obj, (uint8_t*)iconDetails->bitmap,NO_TRANSFORMATION, INVALID_COLOR_MAP);
+    colorMap = INVALID_COLOR_MAP;
+  }
+  if (!iconDetails->isFile) {
+    nbgl_frontDrawImage((nbgl_area_t*)obj, (uint8_t*)iconDetails->bitmap, NO_TRANSFORMATION, colorMap);
+  }
+  else {
+    nbgl_frontDrawImageFile((nbgl_area_t*)obj, (uint8_t*)iconDetails->bitmap, colorMap, ramBuffer);
   }
 }
 


### PR DESCRIPTION
In order to save flash, both in FW and in Apps, all glyphs bigger or equal to 64px will now be compressed