### PR TITLE
Weird relocation error fix

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -70,7 +70,7 @@ endif
 
 # optimization and debug levels
 ifneq ($(DEBUG),0)
-OPTI_LVL  = -O0
+OPTI_LVL  = -Og
 OPTI_ALVL = $(OPTI_LVL)
 DBG_LVL   = -g3
 else


### PR DESCRIPTION
## Description

Introduced in #21, compiling apps with the SDK in debug mode (DEBUG = 1), would trigger some weird relocation errors coming from the SDK, it was coming from -O0, any other optimization level (-O1 and others) would fix this. Debug builds now use -Og which is supposedly just as good for debugging but with some light optimizations.
Also removed gdwarf settings which were of no use with current gdb versions.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)