### PR TITLE
Fix missing include when compiling syscalls.c for apps

### DIFF
--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -26,6 +26,7 @@
 #endif //defined(HAVE_LANGUAGE_PACK)
 #ifdef HAVE_NBGL
 #include "nbgl_types.h"
+#include "nbgl_fonts.h"
 #include "os_pic.h"
 #endif
 #if defined(HAVE_VSS)


### PR DESCRIPTION
## Description

syscalls.c was not compiling when building an app, because of a missing include

## Changes include

- [* ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
