### PR TITLE
Makefile.rules_generic: Add metadata in app.elf noload sections

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -80,6 +80,12 @@ bin/app.elf: $(OBJECT_FILES) $(SCRIPT_LD)
 	$(L)$(GCCPATH)arm-none-eabi-objcopy -O ihex -S bin/app.elf bin/app.hex
 	$(L)cp bin/app.elf obj
 	$(L)$(GCCPATH)arm-none-eabi-objdump -S -d bin/app.elf > debug/app.asm
+	$(L)$(call objcopy_add_section_cmdline,$(TARGET), ledger.target)
+	$(L)$(call objcopy_add_section_cmdline,$(TARGET_NAME), ledger.target_name)
+	$(L)$(call objcopy_add_section_cmdline,$(TARGET_ID), ledger.target_id)
+	$(L)$(call objcopy_add_section_cmdline,$(APPNAME), ledger.app_name)
+	$(L)$(call objcopy_add_section_cmdline,$(APPVERSION), ledger.app_version)
+	$(L)$(call objcopy_add_section_cmdline,$(API_LEVEL), ledger.api_level)
 
 bin/app.apdu bin/app.sha256: bin/app.elf
 	$(L)python3 -m ledgerblue.loadApp $(APP_LOAD_PARAMS) --offline bin/app.apdu | grep "Application" | cut -f5 -d' ' > bin/app.sha256
@@ -97,6 +103,13 @@ endif
 cc_cmdline = $(CC) -c $(CFLAGS) -MMD -MT obj/$(basename $(notdir $(4))).o -MF dep/$(basename $(notdir $(4))).d $(addprefix -D,$(2)) $(addprefix -I,$(1)) -o $(4) $(3)
 
 as_cmdline = $(AS) -c $(AFLAGS) $(addprefix -D,$(2)) $(addprefix -I,$(1)) -o $(4) $(3)
+
+# objcopy_add_section_cmdline(data,section_name)
+TMPFILE := $(shell mktemp)
+objcopy_add_section_cmdline = echo $(1) > $(TMPFILE) && \
+    $(GCCPATH)arm-none-eabi-objcopy --add-section $(2)="$(TMPFILE)" \
+	--set-section-flags $(2)=noload,readonly bin/app.elf bin/app.elf && \
+	rm $(TMPFILE)
 
 ### END GCC COMPILER RULES
 


### PR DESCRIPTION
## Description

Update Makefile `bin/app.elf` target to add metadata in `app.elf` `noload` sections.

## Changes include

- Adding multiples sections in the generated `app.elf`:

1. ledger.target: TARGET
2. ledger.target_name: TARGET_NAME
3. ledger.target_id: TARGET_ID
4. ledger.app_name: APPNAME
5. ledger.app_version: APPVERSION
6. ledger.api_level: API_LEVEL

Probably some are not really useful, but they adding them doesn't cost anything...

## Additional comments

Tested on boilerplate, it doesn't result in any change in `bin/app/sha256`.

It can then be used to retrieved the data using for example `objdump` (or `elftools` in Python):
```
$objdump -sj ledger.target bin/app.elf     

bin/app.elf:     file format elf32-little

Contents of section ledger.target:
 0000 6e616e6f 730a                        nanos.          
$objdump -sj ledger.target_name bin/app.elf

bin/app.elf:     file format elf32-little

Contents of section ledger.target_name:
 0000 54415247 45545f4e 414e4f53 0a        TARGET_NANOS.   
$objdump -sj ledger.target_id bin/app.elf  

bin/app.elf:     file format elf32-little

Contents of section ledger.target_id:
 0000 30783331 31303030 30340a             0x31100004.     
$objdump -sj ledger.app_name bin/app.elf 

bin/app.elf:     file format elf32-little

Contents of section ledger.app_name:
 0000 426f696c 6572706c 6174650a           Boilerplate.    
$objdump -sj ledger.app_version bin/app.elf

bin/app.elf:     file format elf32-little

Contents of section ledger.app_version:
 0000 312e302e 310a                        1.0.1.          
$objdump -sj ledger.api_level bin/app.elf  

bin/app.elf:     file format elf32-little

Contents of section ledger.api_level:
 0000 310a                                 1.
```