### PR TITLE
Perform CBC mode in hardware

### DIFF
--- a/include/ox_aes.h
+++ b/include/ox_aes.h
@@ -112,5 +112,6 @@ SYSCALL void cx_aes_reset_hw(void);
  */
 SYSCALL cx_err_t cx_aes_block_hw(const unsigned char *inblock PLENGTH(16), unsigned char  *outblock PLENGTH(16));
 
+SYSCALL void cx_aes_enable_cbc(const uint8_t *iv, size_t iv_len);
 
 #endif

--- a/include/ox_des.h
+++ b/include/ox_des.h
@@ -79,5 +79,6 @@ SYSCALL void cx_des_reset_hw(void);
  */
 SYSCALL void cx_des_block_hw(const unsigned char *inblock PLENGTH(8), unsigned char  *outblock PLENGTH(8));
 
+SYSCALL void cx_des_enable_cbc(const uint8_t *iv, size_t iv_len);
 
 #endif

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -10,9 +10,11 @@
 #define SYSCALL_cx_aes_set_key_hw_ID                               0x020000b2
 #define SYSCALL_cx_aes_reset_hw_ID                                 0x000000b3
 #define SYSCALL_cx_aes_block_hw_ID                                 0x020000b4
+#define SYSCALL_cx_aes_enable_cbc_ID                               0x020000b5
 #define SYSCALL_cx_des_set_key_hw_ID                               0x020000af
 #define SYSCALL_cx_des_reset_hw_ID                                 0x000000b0
 #define SYSCALL_cx_des_block_hw_ID                                 0x020000b1
+#define SYSCALL_cx_des_enable_cbc_ID                               0x020000b8
 #define SYSCALL_cx_bn_lock_ID                                      0x02000112
 #define SYSCALL_cx_bn_unlock_ID                                    0x000000b6
 #define SYSCALL_cx_bn_is_locked_ID                                 0x000000b7

--- a/lib_cxng/include/lcx_cipher.h
+++ b/lib_cxng/include/lcx_cipher.h
@@ -54,13 +54,14 @@ typedef struct {
 
 /** Base cipher information */
 typedef struct {
-    cx_err_t (*enc_func)(const cipher_key_t *ctx_key, const uint8_t *in_block, uint8_t *out_block); ///< Encryption function
-    cx_err_t (*dec_func)(const cipher_key_t *ctx_key, const uint8_t *in_block, uint8_t *out_block); ///< Decryption function
+    cx_err_t (*enc_func)(const uint8_t *in_block, uint8_t *out_block); ///< Encryption function
+    cx_err_t (*dec_func)(const uint8_t *in_block, uint8_t *out_block); ///< Decryption function
     cx_err_t (*ctr_func)(const cipher_key_t *ctx_key, size_t len, size_t *nc_off, uint8_t *nonce_counter,
                          uint8_t *stream_block, const uint8_t *input, uint8_t *output);             ///< Encryption in CTR mode
     cx_err_t (*setkey_func)(const cipher_key_t *ctx_key, uint32_t operation, const uint8_t *key,
                             uint32_t key_bitlen);                                                   ///< Set key for encryption or decryption
     cx_err_t (*ctx_reset)(void);                                                                    ///< Reset
+    void     (*enable_cbc_func)(const uint8_t *iv, size_t iv_len);                                  ///< Activate CBC mode
 } cx_cipher_base_t;
 
 /** Cipher information */

--- a/lib_cxng/src/cx_aes.c
+++ b/lib_cxng/src/cx_aes.c
@@ -79,6 +79,7 @@ cx_err_t cx_aes_iv_no_throw(const cx_aes_key_t *key,
   ctx->operation  = operation;
   ctx->cipher_key = (const cipher_key_t*)key;
   CX_CHECK(cx_cipher_setup(ctx, type, mode & CX_MASK_CHAIN));
+  CX_CHECK(cx_aes_set_key_hw(key, operation));
   CX_CHECK(cx_cipher_set_padding(ctx, mode & CX_MASK_PAD));
   CX_CHECK(cx_cipher_enc_dec(ctx, iv, iv_len, in, in_len, out, out_len));
 
@@ -96,10 +97,11 @@ cx_err_t aes_ctr(cx_aes_key_t *ctx_key, size_t len, size_t *nc_off, uint8_t *non
   uint8_t  c;
   size_t   n     = *nc_off;
   cx_err_t error = CX_INVALID_PARAMETER;
+  UNUSED(ctx_key);
 
   while (len--) {
     if (n == 0) {
-      CX_CHECK(cx_aes_enc_block(ctx_key, nonce_counter, stream_block));
+      CX_CHECK(cx_aes_block_hw(nonce_counter, stream_block));
         for (int i = CX_AES_BLOCK_SIZE; i > 0; i--) {
           if (++nonce_counter[i - 1] != 0) {
             break;
@@ -126,11 +128,12 @@ cx_err_t aes_setkey(cx_aes_key_t *ctx_key, uint32_t operation, const uint8_t *ke
 }
 
 static const cx_cipher_base_t aes_base = {
-  (cx_err_t (*) (const cipher_key_t *ctx_key, const uint8_t *inblock, uint8_t *outblock))cx_aes_enc_block,
-  (cx_err_t (*) (const cipher_key_t *ctx_key, const uint8_t *inblock, uint8_t *outblock))cx_aes_dec_block,
+  (cx_err_t (*) (const uint8_t *inblock, uint8_t *outblock))cx_aes_block_hw,
+  (cx_err_t (*) (const uint8_t *inblock, uint8_t *outblock))cx_aes_block_hw,
   (cx_err_t(*) (const cipher_key_t *ctx_key, size_t len, size_t *nc_off, uint8_t *nonce_counter, uint8_t *stream_block, const uint8_t *input, uint8_t *output))aes_ctr,
   (cx_err_t(*) (const cipher_key_t *ctx_key, uint32_t operation, const uint8_t *key, uint32_t key_bitlen))aes_setkey,
-  (cx_err_t(*)(void))cx_aes_reset_hw
+  (cx_err_t(*)(void))cx_aes_reset_hw,
+  (void(*)(const uint8_t *iv, size_t iv_len))cx_aes_enable_cbc,
 };
 
 const cx_cipher_info_t cx_aes_128_info = {

--- a/lib_cxng/src/cx_cipher.c
+++ b/lib_cxng/src/cx_cipher.c
@@ -142,9 +142,9 @@ static cx_err_t ecb_func(cx_cipher_context_t *ctx, uint32_t operation, size_t le
   }
   while (len > 0) {
     if (CX_ENCRYPT == operation) {
-      CX_CHECK(ctx->cipher_info->base->enc_func(ctx->cipher_key, input, output));
+      CX_CHECK(ctx->cipher_info->base->enc_func(input, output));
     } else if (CX_DECRYPT == operation) {
-      CX_CHECK(ctx->cipher_info->base->dec_func(ctx->cipher_key, input, output));
+      CX_CHECK(ctx->cipher_info->base->dec_func(input, output));
     }
     else {
       return CX_INVALID_PARAMETER_VALUE;
@@ -159,11 +159,10 @@ static cx_err_t ecb_func(cx_cipher_context_t *ctx, uint32_t operation, size_t le
     return error;
 }
 
-static cx_err_t cbc_func(cx_cipher_context_t *ctx, uint32_t operation, size_t len, uint8_t *iv,
+static cx_err_t cbc_func(cx_cipher_context_t *ctx, uint32_t operation, size_t len,
                          const uint8_t *input, uint8_t *output) {
 
   uint8_t  block[CX_MAX_BLOCK_SIZE];
-  uint8_t  tmp[CX_MAX_BLOCK_SIZE];
   uint32_t block_size = ctx->cipher_info->block_size;
   cx_err_t error      = CX_INTERNAL_ERROR;
 
@@ -172,27 +171,20 @@ static cx_err_t cbc_func(cx_cipher_context_t *ctx, uint32_t operation, size_t le
   }
   while (len > 0) {
     if (CX_DECRYPT == operation) {
-      CX_CHECK(ctx->cipher_info->base->dec_func(ctx->cipher_key, input, block));
-      for (uint32_t i = 0; i < block_size; i++) {
-        tmp[i] = block[i] ^ iv[i];
-      }
-      memcpy(iv, input, block_size);
+      CX_CHECK(ctx->cipher_info->base->dec_func(input, output));
+      output += block_size;
     }
     else {
-      for (uint32_t i = 0; i < block_size; i++) {
-        block[i] = input[i] ^ iv[i];
+      CX_CHECK(ctx->cipher_info->base->enc_func(input, block));
+      if (CX_ENCRYPT == operation) {
+        memcpy(output, block, block_size);
+        output += block_size;
       }
-      CX_CHECK(ctx->cipher_info->base->enc_func(ctx->cipher_key, block, tmp));
-      memcpy(iv, tmp, block_size);
-    }
-    if ((CX_ENCRYPT == operation) || (CX_DECRYPT == operation)) {
-      memcpy(output, tmp, block_size);
-      output += block_size;
     }
     input  += block_size;
     len    -= block_size;
   }
-  memcpy(ctx->sig, tmp, block_size);
+  memcpy(ctx->sig, block, block_size);
   error = CX_OK;
 
   end:
@@ -279,6 +271,10 @@ cx_err_t cx_cipher_setiv(cx_cipher_context_t *ctx, const uint8_t *iv, size_t iv_
 
     memcpy(ctx->iv, iv, iv_len);
     ctx->iv_size = iv_len;
+
+    if (CX_CHAIN_CBC == ctx->mode) {
+      ctx->cipher_info->base->enable_cbc_func(ctx->iv, ctx->iv_size);
+    }
     return CX_OK;
 }
 
@@ -336,7 +332,7 @@ cx_err_t cx_cipher_update(cx_cipher_context_t *ctx, const uint8_t *input, size_t
           if (CX_CHAIN_ECB == ctx->mode) {
             CX_CHECK(ecb_func(ctx, ctx->operation, block_size, ctx->unprocessed_data, output));
           } else {
-            CX_CHECK(cbc_func(ctx, ctx->operation, block_size, ctx->iv, ctx->unprocessed_data, output));
+            CX_CHECK(cbc_func(ctx, ctx->operation, block_size, ctx->unprocessed_data, output));
           }
           if (ctx->operation != CX_SIGN) {
             output += block_size;
@@ -348,7 +344,7 @@ cx_err_t cx_cipher_update(cx_cipher_context_t *ctx, const uint8_t *input, size_t
         }
         if (in_len != 0) {
           remain_len = in_len % block_size;
-          if ((remain_len == 0) && (ctx->operation == CX_DECRYPT)) {
+          if ((remain_len == 0) && (ctx->operation == CX_DECRYPT) && (ctx->add_padding != NULL)) {
             remain_len = block_size;
           }
           memcpy(ctx->unprocessed_data, &(input[in_len - remain_len]), remain_len);
@@ -360,7 +356,7 @@ cx_err_t cx_cipher_update(cx_cipher_context_t *ctx, const uint8_t *input, size_t
             CX_CHECK(ecb_func(ctx, ctx->operation, in_len, input, output));
           }
           else {
-            CX_CHECK(cbc_func(ctx, ctx->operation, in_len, ctx->iv, input, output));
+            CX_CHECK(cbc_func(ctx, ctx->operation, in_len, input, output));
           }
         }
         *out_len = in_len;
@@ -387,41 +383,51 @@ cx_err_t cx_cipher_finish(cx_cipher_context_t *ctx, uint8_t *output, size_t *out
   *out_len = 0;
   switch (ctx->mode) {
     case CX_CHAIN_CTR:
-      return CX_OK;
+      error = CX_OK;
+      break;
     case CX_CHAIN_ECB:
     case CX_CHAIN_CBC:
       if ((CX_ENCRYPT == ctx->operation) || (CX_SIGN == ctx->operation) || (CX_VERIFY == ctx->operation)) {
         if (NULL == ctx->add_padding) {
           if (ctx->unprocessed_len != 0) {
-            return CX_INTERNAL_ERROR;
+            goto end;
           }
-          return CX_OK;
+          error = CX_OK;
+          goto end;
         }
         if ((add_zeros_padding == ctx->add_padding) && (ctx->unprocessed_len == 0)) {
           *out_len = 0;
-          return CX_OK;
+          error = CX_OK;
+          goto end;
         }
         ctx->add_padding(ctx->unprocessed_data, ctx->cipher_info->block_size,
                          ctx->unprocessed_len);
       }
+      if (get_no_padding != ctx->get_padding) {
+        ctx->unprocessed_len = ctx->cipher_info->block_size;
+      }
       if (CX_CHAIN_ECB == ctx->mode) {
-        CX_CHECK(ecb_func(ctx, ctx->operation, ctx->cipher_info->block_size, ctx->unprocessed_data, output));
+        CX_CHECK(ecb_func(ctx, ctx->operation, ctx->unprocessed_len, ctx->unprocessed_data, output));
       }
       else {
-        CX_CHECK(cbc_func(ctx, ctx->operation, ctx->cipher_info->block_size, ctx->iv,
+        CX_CHECK(cbc_func(ctx, ctx->operation, ctx->unprocessed_len,
                         ctx->unprocessed_data, output));
       }
 
-      if (CX_DECRYPT == ctx->operation ) {
-        return ctx->get_padding(output, ctx->cipher_info->block_size, out_len);
+      if ((CX_DECRYPT == ctx->operation) && (NULL != ctx->get_padding)) {
+        error = ctx->get_padding(output, ctx->unprocessed_len, out_len);
+        goto end;
       }
 
-      *out_len = ctx->cipher_info->block_size;
-      return CX_OK;
+      *out_len = ctx->unprocessed_len;
+      error = CX_OK;
+      break;
     default:
-      return CX_INVALID_PARAMETER_VALUE;
+      error = CX_INVALID_PARAMETER_VALUE;
+      break;
   }
   end:
+    ctx->cipher_info->base->ctx_reset();
     return error;
 }
 
@@ -449,7 +455,10 @@ cx_err_t cx_cipher_enc_dec(cx_cipher_context_t *ctx, const uint8_t *iv, size_t i
 
   CX_CHECK(cx_cipher_setiv(ctx, iv, iv_len));
   CX_CHECK(cx_cipher_update(ctx, input, in_len, output, out_len));
-  CX_CHECK(cx_cipher_finish(ctx, output + *out_len, &finish_len));
+  if (ctx->add_padding != NULL) {
+    finish_len = *out_len;
+  }
+  CX_CHECK(cx_cipher_finish(ctx, output + finish_len, &finish_len));
   CX_CHECK(cx_cipher_mac(ctx, output, out_len, &finish_len));
   *out_len += finish_len;
 

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -192,6 +192,13 @@ cx_err_t cx_aes_block_hw ( const unsigned char * inblock, unsigned char * outblo
   return SVC_cx_call(SYSCALL_cx_aes_block_hw_ID, parameters);
 }
 
+void cx_aes_enable_cbc(const uint8_t *iv, size_t iv_len) {
+  unsigned int parameters[2];
+  parameters[0] = (unsigned int)iv;
+  parameters[1] = (unsigned int)iv_len;
+  SVC_cx_call(SYSCALL_cx_aes_enable_cbc_ID, parameters);
+}
+
 cx_err_t cx_des_set_key_hw ( const cx_des_key_t * keys, uint32_t mode ) {
   unsigned int parameters[2];
   parameters[0] = (unsigned int)keys;
@@ -210,6 +217,13 @@ void cx_des_block_hw ( const unsigned char * inblock, unsigned char * outblock )
   parameters[0] = (unsigned int)inblock;
   parameters[1] = (unsigned int)outblock;
   SVC_cx_call(SYSCALL_cx_des_block_hw_ID, parameters);
+}
+
+void cx_des_enable_cbc(const uint8_t *iv, size_t iv_len) {
+  unsigned int parameters[2];
+  parameters[0] = (unsigned int)iv;
+  parameters[1] = (unsigned int)iv_len;
+  SVC_cx_call(SYSCALL_cx_des_enable_cbc_ID, parameters);
 }
 
 cx_err_t cx_bn_lock ( size_t word_nbytes, uint32_t flags ) {


### PR DESCRIPTION
## Description

The CBC mode of AES and DES is not implemented in libcxng anymore. The CBC mode is done by the corresponding accelerator.

## Changes include

- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Breaking changes

A syscall is added to enable the CBC mode and initialize the internal register with the Initialization vector. The code in cx_cipher.c is simplified with regard to CBC encryption.

