### PR TITLE
 Makefile.rules_generic: Add metadata in app.elf noload sections

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -89,6 +89,14 @@ bin/app.elf: $(OBJECT_FILES) $(SCRIPT_LD)
 	$(L)$(GCCPATH)arm-none-eabi-objcopy -O ihex -S bin/app.elf bin/app.hex
 	$(L)cp bin/app.elf obj
 	$(L)$(GCCPATH)arm-none-eabi-objdump -S -d bin/app.elf > debug/app.asm
+	$(L)$(call objcopy_add_section_cmdline,$(TARGET), ledger.target)
+	$(L)$(call objcopy_add_section_cmdline,$(TARGET_NAME), ledger.target_name)
+	$(L)$(call objcopy_add_section_cmdline,$(TARGET_ID), ledger.target_id)
+	$(L)$(call objcopy_add_section_cmdline,$(APPNAME), ledger.app_name)
+	$(L)$(call objcopy_add_section_cmdline,$(APPVERSION), ledger.app_version)
+	$(L)$(call objcopy_add_section_cmdline,$(API_LEVEL), ledger.api_level)
+	$(L)$(call objcopy_add_section_cmdline,$(SDK_NAME), ledger.sdk_name)
+	$(L)$(call objcopy_add_section_cmdline,$(SDK_HASH), ledger.sdk_hash)
 
 bin/app.apdu bin/app.sha256: bin/app.elf
 	$(L)python3 -m ledgerblue.loadApp $(APP_LOAD_PARAMS) --offline bin/app.apdu | grep "Application" | cut -f5 -d' ' > bin/app.sha256
@@ -106,6 +114,13 @@ endif
 cc_cmdline = $(CC) -c $(CFLAGS) -MMD -MT obj/$(basename $(notdir $(4))).o -MF dep/$(basename $(notdir $(4))).d $(addprefix -D,$(2)) $(addprefix -I,$(1)) -o $(4) $(3)
 
 as_cmdline = $(AS) -c $(AFLAGS) $(addprefix -D,$(2)) $(addprefix -I,$(1)) -o $(4) $(3)
+
+# objcopy_add_section_cmdline(data,section_name)
+TMPFILE := $(shell mktemp)
+objcopy_add_section_cmdline = echo $(1) > $(TMPFILE) && \
+    $(GCCPATH)arm-none-eabi-objcopy --add-section $(2)="$(TMPFILE)" \
+	--set-section-flags $(2)=noload,readonly bin/app.elf bin/app.elf && \
+	rm $(TMPFILE)
 
 ### END GCC COMPILER RULES
 


### PR DESCRIPTION
## Description

Update Makefile `bin/app.elf` target to add metadata in `app.elf` `noload` sections.

## Changes include

- Adding multiples sections in the generated `app.elf`:

1. ledger.target: TARGET
2. ledger.target_name: TARGET_NAME
3. ledger.target_id: TARGET_ID
4. ledger.app_name: APPNAME
5. ledger.app_version: APPVERSION
6. ledger.api_level: API_LEVEL

Probably some are not really useful, but they adding them doesn't cost anything...

## Additional comments

Tested on boilerplate, it doesn't result in any change in `bin/app/sha256`.

It can then be used to retrieved the data using for example `objdump` (or `elftools` in Python):
```
In [18]: ELF_METADATA_SECTIONS = [ 
    ...:     "target", 
    ...:     "target_name", 
    ...:     "target_id", 
    ...:     "app_name", 
    ...:     "app_version", 
    ...:     "api_level", 
    ...:     "sdk_name", 
    ...:     "sdk_hash" 
    ...: ]                                          

In [19]: with open(app_path, 'rb') as fp: 
    ...:     elf = ELFFile(fp) 
    ...:     data = {} 
    ...:     for section_name in ELF_METADATA_SECTIONS: 
    ...:         section = elf.get_section_by_name(f"ledger.{section_name}") 
    ...:         if section: 
    ...:             data[section_name] = section.data().decode("utf-8").strip() 
    ...:                                            

In [20]:                                            

In [20]: data                                       
Out[20]: 
{'target': 'nanos2',
 'target_name': 'TARGET_NANOS2',
 'target_id': '0x33100004',
 'app_name': 'Boilerplate',
 'app_version': '1.0.1',
 'api_level': '0',
 'sdk_name': 'ledger-secure-sdk',
 'sdk_hash': 'a9e60637ba4ec5ee10c68c1dcf59ec266c622c30'}
```