### PR TITLE
Perform CBC mode in hardware

### DIFF
--- a/include/ox_aes.h
+++ b/include/ox_aes.h
@@ -112,5 +112,4 @@ SYSCALL void cx_aes_reset_hw(void);
  */
 SYSCALL cx_err_t cx_aes_block_hw(const unsigned char *inblock PLENGTH(16), unsigned char  *outblock PLENGTH(16));
 
-
 #endif

--- a/lib_cxng/include/lcx_cipher.h
+++ b/lib_cxng/include/lcx_cipher.h
@@ -50,8 +50,8 @@ typedef struct {
 
 /** Base cipher information */
 typedef struct {
-    cx_err_t (*enc_func)(const cipher_key_t *ctx_key, const uint8_t *in_block, uint8_t *out_block); ///< Encryption function
-    cx_err_t (*dec_func)(const cipher_key_t *ctx_key, const uint8_t *in_block, uint8_t *out_block); ///< Decryption function
+    cx_err_t (*enc_func)(const uint8_t *in_block, uint8_t *out_block); ///< Encryption function
+    cx_err_t (*dec_func)(const uint8_t *in_block, uint8_t *out_block); ///< Decryption function
     cx_err_t (*ctr_func)(const cipher_key_t *ctx_key, size_t len, size_t *nc_off, uint8_t *nonce_counter,
                          uint8_t *stream_block, const uint8_t *input, uint8_t *output);             ///< Encryption in CTR mode
     cx_err_t (*setkey_func)(const cipher_key_t *ctx_key, uint32_t operation, const uint8_t *key,

--- a/lib_cxng/src/cx_aes.c
+++ b/lib_cxng/src/cx_aes.c
@@ -78,7 +78,9 @@ cx_err_t cx_aes_iv_no_throw(const cx_aes_key_t *key,
   ctx->key_bitlen = key->size * 8;
   ctx->operation  = operation;
   ctx->cipher_key = (const cipher_key_t*)key;
+  operation      |= mode & CX_MASK_CHAIN;
   CX_CHECK(cx_cipher_setup(ctx, type, mode & CX_MASK_CHAIN));
+  CX_CHECK(cx_aes_set_key_hw(key, operation));
   CX_CHECK(cx_cipher_set_padding(ctx, mode & CX_MASK_PAD));
   CX_CHECK(cx_cipher_enc_dec(ctx, iv, iv_len, in, in_len, out, out_len));
 
@@ -96,10 +98,11 @@ cx_err_t aes_ctr(cx_aes_key_t *ctx_key, size_t len, size_t *nc_off, uint8_t *non
   uint8_t  c;
   size_t   n     = *nc_off;
   cx_err_t error = CX_INVALID_PARAMETER;
+  UNUSED(ctx_key);
 
   while (len--) {
     if (n == 0) {
-      CX_CHECK(cx_aes_enc_block(ctx_key, nonce_counter, stream_block));
+      CX_CHECK(cx_aes_block_hw(nonce_counter, stream_block));
         for (int i = CX_AES_BLOCK_SIZE; i > 0; i--) {
           if (++nonce_counter[i - 1] != 0) {
             break;
@@ -126,11 +129,11 @@ cx_err_t aes_setkey(cx_aes_key_t *ctx_key, uint32_t operation, const uint8_t *ke
 }
 
 static const cx_cipher_base_t aes_base = {
-  (cx_err_t (*) (const cipher_key_t *ctx_key, const uint8_t *inblock, uint8_t *outblock))cx_aes_enc_block,
-  (cx_err_t (*) (const cipher_key_t *ctx_key, const uint8_t *inblock, uint8_t *outblock))cx_aes_dec_block,
+  (cx_err_t (*) (const uint8_t *inblock, uint8_t *outblock))cx_aes_block_hw,
+  (cx_err_t (*) (const uint8_t *inblock, uint8_t *outblock))cx_aes_block_hw,
   (cx_err_t(*) (const cipher_key_t *ctx_key, size_t len, size_t *nc_off, uint8_t *nonce_counter, uint8_t *stream_block, const uint8_t *input, uint8_t *output))aes_ctr,
   (cx_err_t(*) (const cipher_key_t *ctx_key, uint32_t operation, const uint8_t *key, uint32_t key_bitlen))aes_setkey,
-  (cx_err_t(*)(void))cx_aes_reset_hw
+  (cx_err_t(*)(void))cx_aes_reset_hw,
 };
 
 const cx_cipher_info_t cx_aes_128_info = {


### PR DESCRIPTION
## Description

The CBC mode of AES and DES is not implemented in libcxng anymore. The CBC mode is done by the corresponding accelerator.

## Changes include

- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Breaking changes

The code in cx_cipher.c is simplified with regard to CBC encryption.
