### PR TITLE
Makefile: Remove useless info from make output

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -26,8 +26,6 @@ TARGET_PATH := $(BOLOS_SDK)/target/$(TARGET)
 TARGET_ID   := $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ID | cut -f3 -d' ')
 TARGET_NAME := $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ | grep -v TARGET_ID | cut -f2 -d' ')
 
-$(info TARGET_NAME=$(TARGET_NAME) TARGET_ID=$(TARGET_ID))
-
 # extra load parameters for loadApp script
 ifneq ($(SCP_PRIVKEY),)
 PARAM_SCP+=--rootPrivateKey $(SCP_PRIVKEY)
@@ -171,20 +169,6 @@ endif
 
 # include builtin CX libs options
 -include $(BOLOS_SDK)/Makefile.conf.cx
-
-ifneq ($(BOLOS_ENV),)
-$(info BOLOS_ENV=$(BOLOS_ENV))
-CLANGPATH := $(BOLOS_ENV)/clang-arm-fropi/bin/
-GCCPATH := $(BOLOS_ENV)/gcc-arm-none-eabi-5_3-2016q1/bin/
-else
-$(info BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH)
-endif
-ifeq ($(CLANGPATH),)
-$(info CLANGPATH is not set: clang will be used from PATH)
-endif
-ifeq ($(GCCPATH),)
-$(info GCCPATH is not set: arm-none-eabi-* will be used from PATH)
-endif
 
 # define the default makefile target (high in include to avoid glyph.h or what not specific target to be the default one when no target passed on the make command line)
 all: default

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -38,7 +38,6 @@ LD := $(CC)
 ifneq ($(shell [ `$(CC) -v 2>&1 | grep -o "version .*" | cut -f2 -d' ' | cut -f1 -d'.'` -ge 7 ] && echo ok),ok)
 $(error Requires at least CLANG 7 to link correctly with -fropi -frwpi)
 endif
-$(info Linker changed to CLANG)
 endif
 endif
 


### PR DESCRIPTION
## Description

This is an updated version of https://github.com/LedgerHQ/ledger-secure-sdk/pull/98/
The idea is to removes verbose logs that are not used and that are always printed...

## Changes include

- [x] Other (for changes that might not fit in any category)
