### PR TITLE
Makefile: Add SDK version info based on tags

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -26,10 +26,17 @@ TARGET_PATH := $(BOLOS_SDK)/target/$(TARGET)
 TARGET_ID   := $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ID | cut -f3 -d' ')
 TARGET_NAME := $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ | grep -v TARGET_ID | cut -f2 -d' ')
 SDK_NAME    := "ledger-secure-sdk"
+SDK_VERSION := $(shell git -C $(BOLOS_SDK) describe --tags --exact-match  --match "v[0-9]*" --dirty)
 SDK_HASH    := $(shell git -C $(BOLOS_SDK) describe --always --dirty --exclude '*' --abbrev=40)
+ifeq ($(SDK_VERSION),)
+SDK_VERSION := "None"
+endif
 ifeq ($(SDK_HASH),)
 SDK_HASH := "None"
 endif
+# Expose SDK_VERSION and SDK_HASH to the app.
+DEFINES += SDK_VERSION=\"$(SDK_VERSION)\"
+DEFINES += SDK_HASH=\"$(SDK_HASH)\"
 
 # extra load parameters for loadApp script
 ifneq ($(SCP_PRIVKEY),)

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -53,6 +53,7 @@ listinfo:
 	@echo APPVERSION=$(APPVERSION)
 	@echo API_LEVEL=$(API_LEVEL)
 	@echo SDK_NAME=$(SDK_NAME)
+	@echo SDK_VERSION=$(SDK_VERSION)
 	@echo SDK_HASH=$(SDK_HASH)
 
 clean:
@@ -96,6 +97,7 @@ bin/app.elf: $(OBJECT_FILES) $(SCRIPT_LD)
 	$(L)$(call objcopy_add_section_cmdline,$(APPVERSION), ledger.app_version)
 	$(L)$(call objcopy_add_section_cmdline,$(API_LEVEL), ledger.api_level)
 	$(L)$(call objcopy_add_section_cmdline,$(SDK_NAME), ledger.sdk_name)
+	$(L)$(call objcopy_add_section_cmdline,$(SDK_VERSION), ledger.sdk_version)
 	$(L)$(call objcopy_add_section_cmdline,$(SDK_HASH), ledger.sdk_hash)
 
 bin/app.apdu bin/app.sha256: bin/app.elf


### PR DESCRIPTION
## Description

Add an SDK version info based on git tag. This info is available in `listinfo` target and in elf metadata.

## Changes include

- [x] New feature (non-breaking change that adds functionality)

## Additional comments

Here is the output of `make listinfo` in multiple situations:

Tag available:
```
make TARGET=nanox listinfo
BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH
CLANGPATH is not set: clang will be used from PATH
GCCPATH is not set: arm-none-eabi-* will be used from PATH
TARGET=nanox
TARGET_NAME=TARGET_NANOX
TARGET_ID=0x33000004
APPNAME=Boilerplate
APPVERSION=1.0.1
API_LEVEL=0
SDK_NAME=ledger-secure-sdk
SDK_VERSION=v2.0.0
SDK_HASH=f5f3db94d9f1265e32c2a0f0858ff555e9a29032
```

No tag:
```
make TARGET=nanox listinfo
fatal: no tag exactly matches 'f5f3db94d9f1265e32c2a0f0858ff555e9a29032'
BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH
CLANGPATH is not set: clang will be used from PATH
GCCPATH is not set: arm-none-eabi-* will be used from PATH
TARGET=nanox
TARGET_NAME=TARGET_NANOX
TARGET_ID=0x33000004
APPNAME=Boilerplate
APPVERSION=1.0.1
API_LEVEL=0
SDK_NAME=ledger-secure-sdk
SDK_VERSION=None
SDK_HASH=f5f3db94d9f1265e32c2a0f0858ff555e9a29032
```

With tag but dirty repository:
```
make TARGET=nanox listinfo
BOLOS_ENV is not set: falling back to CLANGPATH and GCCPATH
CLANGPATH is not set: clang will be used from PATH
GCCPATH is not set: arm-none-eabi-* will be used from PATH
TARGET=nanox
TARGET_NAME=TARGET_NANOX
TARGET_ID=0x33000004
APPNAME=Boilerplate
APPVERSION=1.0.1
API_LEVEL=0
SDK_NAME=ledger-secure-sdk
SDK_VERSION=v2.0.0-dirty
SDK_HASH=3ed4e830c5d998095c143e0b47d536781abd5e54-dirty
```