### PR TITLE
[add] const qualifiers on nbgl_pageBarsList_s

### DIFF
--- a/lib_nbgl/include/nbgl_page.h
+++ b/lib_nbgl/include/nbgl_page.h
@@ -125,8 +125,8 @@ typedef struct nbgl_pageInfoList_s {
  * @brief This structure contains data to build a @ref BARS_LIST page content
  */
 typedef struct nbgl_pageBarsList_s {
-    const char **barTexts; ///< array of texts for each bar (nbBars items, in black/bold)
-    uint8_t *tokens; ///< array of tokens, one for each bar (nbBars items)
+    const char * const *barTexts; ///< array of texts for each bar (nbBars items, in black/bold)
+    const uint8_t *tokens; ///< array of tokens, one for each bar (nbBars items)
     uint8_t nbBars; ///< number of elements in barTexts and tokens array
     tune_index_e tuneId; ///< if not @ref NBGL_NO_TUNE, a tune will be played when a bar is touched
 } nbgl_pageBarsList_t;


### PR DESCRIPTION
## Description

Adding some `const` on the `nbgl_pageBarsList_s` so that developers are not mislead to use non-const array which would lead to a `SBREL relocation` error during compilation.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)