### PR TITLE
Stax - Fixes backward navigation in details view use case

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -483,7 +483,8 @@ static void displayDetailsPage(uint8_t detailsPage, bool forceFullRefresh) {
   if (detailsPage <= detailsContext.currentPage) {
     // recompute current start from beginning
     currentPair.value = getDetailsPageAt(detailsPage);
-    }
+    forceFullRefresh = true;
+  }
   // else move forward
   else {
     currentPair.value = detailsContext.nextPageStart;


### PR DESCRIPTION
## Description

When displaying a details view (with nbgl_useCaseViewDetails() for example), it was impossible to navigate backward if more
than 3 pages. It is now fixed

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
