### PR TITLE
Rename touch_set_state syscall

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -74,7 +74,7 @@ typedef struct io_touch_info_s {
 } io_touch_info_t;
 
 SYSCALL void touch_get_last_info(io_touch_info_t *info);
-SYSCALL void touch_set_state( bool state );
+SYSCALL void standby( bool state );
 #ifdef HAVE_SE_TOUCH
 #ifdef HAVE_TOUCH_DEBUG
 SYSCALL void touch_read_sensitivity(uint8_t *sensi_data);

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -304,7 +304,7 @@
 
 #ifdef HAVE_SE_TOUCH
 #define SYSCALL_touch_get_last_info_ID                                   0x01fa000b
-#define SYSCALL_set_touch_state_ID                                       0x01fa000e
+#define SYSCALL_standby_ID                                       0x01fa000e
 #ifdef HAVE_TOUCH_DEBUG
 #define SYSCALL_touch_read_sensi_ID                                      0x01fa000f
 #endif

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1782,9 +1782,9 @@ void touch_get_last_info( io_touch_info_t *info ) {
   SVC_Call(SYSCALL_touch_get_last_info_ID, parameters);
 }
 
-void touch_set_state( bool state ) {
+void standby( bool state ) {
   unsigned int parameters[1] = {(unsigned int) state};
-  SVC_Call(SYSCALL_set_touch_state_ID, parameters);
+  SVC_Call(SYSCALL_standby_ID, parameters);
 }
 
 #ifdef HAVE_TOUCH_DEBUG


### PR DESCRIPTION
## Description

Rename syscall touch_set_state -> standby

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
