### PR TITLE
Rename touch_set_state() to os_enter_standby()/os_leave_standby()

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -74,7 +74,8 @@ typedef struct io_touch_info_s {
 } io_touch_info_t;
 
 SYSCALL void touch_get_last_info(io_touch_info_t *info);
-SYSCALL void touch_set_state( bool state );
+SYSCALL void os_enter_standby(void);
+SYSCALL void os_leave_standby(void);
 #ifdef HAVE_SE_TOUCH
 #ifdef HAVE_TOUCH_DEBUG
 SYSCALL void touch_read_sensitivity(uint8_t *sensi_data);

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -304,7 +304,7 @@
 
 #ifdef HAVE_SE_TOUCH
 #define SYSCALL_touch_get_last_info_ID                                   0x01fa000b
-#define SYSCALL_set_touch_state_ID                                       0x01fa000e
+#define SYSCALL_os_configure_standby_ID                                         0x01fa000e
 #ifdef HAVE_TOUCH_DEBUG
 #define SYSCALL_touch_read_sensi_ID                                      0x01fa000f
 #endif

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1782,9 +1782,17 @@ void touch_get_last_info( io_touch_info_t *info ) {
   SVC_Call(SYSCALL_touch_get_last_info_ID, parameters);
 }
 
-void touch_set_state( bool state ) {
+static void os_configure_standby( bool state ) {
   unsigned int parameters[1] = {(unsigned int) state};
-  SVC_Call(SYSCALL_set_touch_state_ID, parameters);
+  SVC_Call(SYSCALL_os_configure_standby_ID, parameters);
+}
+
+void os_enter_standby(void) {
+  os_configure_standby(true);
+}
+
+void os_leave_standby(void) {
+  os_configure_standby(false);
 }
 
 #ifdef HAVE_TOUCH_DEBUG


### PR DESCRIPTION
## Description

Rename touch_set_state() to os_enter_standby()/os_leave_standby()

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
