### PR TITLE
Fix issue with UTF-8 decoding (ticket #1749)

### DIFF
--- a/lib_bagl/src/bagl.c
+++ b/lib_bagl/src/bagl.c
@@ -358,21 +358,57 @@ int bagl_draw_string(unsigned short font_id, unsigned int fgcolor, unsigned int 
 
 #if defined(HAVE_UNICODE_SUPPORT)
     if (text_encoding == BAGL_ENCODING_UTF8) {
-      // Handle UTF-8 decoding:
-      if (ch > 0xF0 && text_length >= 3) {        // 4 bytes
+      // Handle UTF-8 decoding (RFC3629): (https://www.ietf.org/rfc/rfc3629.txt
+      // Char. number range  |        UTF-8 octet sequence
+      // (hexadecimal)    |              (binary)
+      // --------------------+---------------------------------------------
+      // 0000 0000-0000 007F | 0xxxxxxx
+      // 0000 0080-0000 07FF | 110xxxxx 10xxxxxx
+      // 0000 0800-0000 FFFF | 1110xxxx 10xxxxxx 10xxxxxx
+      // 0001 0000-0010 FFFF | 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+      //
+      // ISO-10646 mention 6 bytes UTF-8 encoding
+      // https://www.cl.cam.ac.uk/~mgk25/ucs/ISO-10646-UTF-8.html
+      // (but 21-bit unicode characters only need 4 bytes of UTF-8)
+      // I leave the code handling 6 bytes UTF-8, for an eventual future use
+
+      // 6 bytes UTF-8, Unicode 0x400 0000 to 0x7FFF FFFF
+      /*if (ch >= 0xFC && text_length >= 5) {
+        unicode = (ch - 0xFC) << 30;
+        unicode |= (*txt++ - 0x80) << 24;
+        unicode |= (*txt++ - 0x80) << 18;
+        unicode |= (*txt++ - 0x80) << 12;
+        unicode |= (*txt++ - 0x80) << 6;
+        unicode |= (*txt++ - 0x80);
+        text_length -= 5;
+
+      // 5 bytes UTF-8, Unicode 0x20 0000 to 0x3FF FFFF
+      } else if (ch >= 0xF8 && text_length >= 4) {
+        unicode = (ch - 0xF8) << 24;
+        unicode |= (*txt++ - 0x80) << 18;
+        unicode |= (*txt++ - 0x80) << 12;
+        unicode |= (*txt++ - 0x80) << 6;
+        unicode |= (*txt++ - 0x80);
+        text_length -= 4;
+
+      // 4 bytes UTF-8, Unicode 0x1000 to 0x1FFFF
+      } else*/ if (ch >= 0xF0 && text_length >= 3) {
         unicode = (ch - 0xF0) << 18;
         unicode |= (*txt++ - 0x80) << 12;
         unicode |= (*txt++ - 0x80) << 6;
         unicode |= (*txt++ - 0x80);
         text_length -= 3;
 
-      } else if (ch > 0xE0 && text_length >= 2) { // 3 bytes
+      // 3 bytes UTF-8, Unicode 0x800 to 0xFFFF
+      } else if (ch >= 0xE0 && text_length >= 2) {
         unicode = (ch - 0xE0) << 12;
         unicode |= (*txt++ - 0x80) << 6;
         unicode |= (*txt++ - 0x80);
         text_length -= 2;
 
-      } else if (ch > 0xC0 && text_length >= 1) { // 2 bytes
+      // 2 bytes UTF-8, Unicode 0x80 to 0x7FF
+      // (0xC0 & 0xC1 are unused and can be used to store something else)
+      } else if (ch >= 0xC2 && text_length >= 1) {
         unicode = (ch - 0xC0) << 6;
         unicode |= (*txt++ - 0x80);
         text_length -= 1;

--- a/lib_nbgl/fonts/nbgl_fonts.c
+++ b/lib_nbgl/fonts/nbgl_fonts.c
@@ -124,21 +124,25 @@ uint32_t nbgl_popUnicodeChar(uint8_t **text, uint16_t *textLen, bool *is_unicode
   uint32_t unicode;
 
   *is_unicode = true;
-  // Handle UTF-8 decoding:
-  if ((cur_char >= 0xF0) && (*textLen >= 3)) {        // 4 bytes
+  // Handle UTF-8 decoding (bagl.c contains full explanations)
+  // 4 bytes, from 0x1000 to 0x1FFFF
+  if ((cur_char >= 0xF0) && (*textLen >= 4)) {
     unicode = (cur_char - 0xF0) << 18;
-    unicode |= (*txt++ & 0x7F) << 12;
-    unicode |= (*txt++ & 0x7F) << 6;
-    unicode |= (*txt++ & 0x7F);
+    unicode |= (*txt++ - 0x80) << 12;
+    unicode |= (*txt++ - 0x80) << 6;
+    unicode |= (*txt++ - 0x80);
 
-  } else if ((cur_char >= 0xE0) && (*textLen >= 2)) { // 3 bytes
+  // 3 bytes, from 0x800 to 0xFFFF
+  } else if ((cur_char >= 0xE0) && (*textLen >= 3)) {
     unicode = (cur_char - 0xE0) << 12;
-    unicode |= (*txt++ & 0x7F) << 6;
-    unicode |= (*txt++ & 0x7F);
+    unicode |= (*txt++ - 0x80) << 6;
+    unicode |= (*txt++ - 0x80);
 
-  } else if ((cur_char >= 0xC0) && (*textLen >= 1)) { // 2 bytes
+  // 2 bytes UTF-8, Unicode 0x80 to 0x7FF
+  // (0xC0 & 0xC1 are unused and can be used to store something else)
+  } else if ((cur_char >= 0xC2) && (*textLen >= 2)) {
     unicode = (cur_char - 0xC0) << 6;
-    unicode |= (*txt++ & 0x7F);
+    unicode |= (*txt++ - 0x80);
 
   } else {
     *is_unicode = false;

--- a/lib_ux/src/ux_layout_paging_compute.c
+++ b/lib_ux/src/ux_layout_paging_compute.c
@@ -234,8 +234,9 @@ STATIC_IF_NOT_INDEXED unsigned int se_compute_line_width_light(const char* text,
 #if defined(HAVE_UNICODE_SUPPORT)
     unsigned int unicode;
 
-    // Handle UTF-8 decoding:
-    if (ch > 0xF0 && text_length >= 3) {        // 4 bytes
+    // Handle UTF-8 decoding (bagl.c contains full explanations)
+    // 4 bytes, from 0x1000 to 0x1FFFF
+    if (ch >= 0xF0 && text_length >= 3) {
       unicode = (ch - 0xF0) << 18;
       unicode |= (*((const unsigned char*)text+0) - 0x80) << 12;
       unicode |= (*((const unsigned char*)text+1) - 0x80) << 6;
@@ -243,14 +244,17 @@ STATIC_IF_NOT_INDEXED unsigned int se_compute_line_width_light(const char* text,
       text += 3;
       text_length -= 3;
 
-    } else if (ch > 0xE0 && text_length >= 2) { // 3 bytes
+    // 3 bytes, from 0x800 to 0xFFFF
+    } else if (ch >= 0xE0 && text_length >= 2) {
       unicode = (ch - 0xE0) << 12;
       unicode |= (*((const unsigned char*)text+0) - 0x80) << 6;
       unicode |= (*((const unsigned char*)text+1) - 0x80);
       text += 2;
       text_length -= 2;
 
-    } else if (ch > 0xC0 && text_length >= 1) { // 2 bytes
+    // 2 bytes UTF-8, Unicode 0x80 to 0x7FF
+    // (0xC0 & 0xC1 are unused and can be used to store something else)
+    } else if (ch >= 0xC2 && text_length >= 1) {
       unicode = (ch - 0xC0) << 6;
       unicode |= (*((const unsigned char*)text+0) - 0x80);
       ++text;


### PR DESCRIPTION
## Description

This PR fixes an issue in UTF-8 decoding (testing > 0xF0 instead of testing >= 0xF0 for exemple).

Bolos related ticket: https://git.donjon.ledger.fr/gitea/ledger-core/bolos-ng/issues/1749

## Additional comments

For info, Wikipedia page about UTF-8 encoding: https://fr.wikipedia.org/wiki/UTF-8
A very convenient URL to test unicodes/utf-8 values: https://www.cogsci.ed.ac.uk/~richard/utf-8.cgi?input=80&mode=hex  

Other UTF-8 related resources:
https://www.cl.cam.ac.uk/~mgk25/ucs/ISO-10646-UTF-8.html
https://www.ietf.org/rfc/rfc3629.txt
