### PR TITLE
Stax - Entered text (with keyboard) should be left justified 

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -296,6 +296,7 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, char *text, bool fixed);
 /* layout objects for page with keyboard */
 int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, nbgl_layoutKbd_t *kbdInfo);
 int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout, uint8_t index, uint32_t keyMask, bool updateCasing, keyboardCase_t casing);
+bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index);
 int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout, uint8_t nbUsedButtons,
                                     char *buttonTexts[NB_MAX_SUGGESTION_BUTTONS],
                                     int firstButtonToken, tune_index_e tuneId);

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -409,6 +409,7 @@ typedef struct PACKED__ nbgl_keyboard_s {
     color_t textColor; ///< color set to letters.
     color_t borderColor; ///< color set to key borders
     bool lettersOnly; ///< if true, only display letter keys and Backspace
+    bool needsRefresh; ///< if true, means that the keyboard has been redrawn and needs a refresh
     keyboardCase_t casing; ///< keyboard casing mode (lower, upper once or upper locked)
     keyboardMode_t mode; ///< keyboard mode to start with
     uint32_t keyMask; ///< mask used to disable some keys in letters only mod. The 26 LSB bits of mask are used, for the 26 letters of a QWERTY keyboard. Bit[0] for Q, Bit[1] for W and so on

--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -163,6 +163,7 @@ static void keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
       keyboard->casing = LOWER_CASE;
       // just redraw, refresh will be done by client (user of keyboard)
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
+      keyboard->needsRefresh = true;
     }
     if ((firstIndex<26)&&((keyboard->keyMask&(1<<firstIndex))==0)) {
       keyboard->callback((cur_casing != LOWER_CASE)?kbd_chars_upper[firstIndex]:kbd_chars[firstIndex]);
@@ -563,6 +564,7 @@ static void keyboardDraw(nbgl_keyboard_t *keyboard) {
 void nbgl_objDrawKeyboard(nbgl_keyboard_t *kbd) {
   kbd->touchMask = (1 << TOUCHED);
   kbd->touchCallback = (nbgl_touchCallback_t)&keyboardTouchCallback;
+  kbd->needsRefresh = false;
 
   keyboardDraw(kbd);
 }


### PR DESCRIPTION
## Description

Implements https://ledgerhq.atlassian.net/browse/FWEO-822 by using left-justified entered text in screens using Keyboard in layout API

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
