### PR TITLE
Fix FWEO-829 - Add missing UX_WAKE_UP() support for Stax

### DIFF
--- a/lib_ux_stax/ux.h
+++ b/lib_ux_stax/ux.h
@@ -76,6 +76,18 @@ extern void ux_process_default_event(void);
 #endif //HAVE_BOLOS
 
 /**
+ * Request a wake up of the device (pin lock screen, ...) to display a new interface to the user.
+ * Wake up prevents power-off features. Therefore, security wise, this function shall only
+ * be called to request direct user interaction.
+ */
+#define UX_WAKE_UP() \
+  G_ux_params.ux_id = BOLOS_UX_WAKE_UP; \
+  G_ux_params.len = 0; \
+  os_ux(&G_ux_params); \
+  G_ux_params.len = os_sched_last_status(TASK_BOLOS_UX);
+
+
+/**
  * forward the finger_event to the os ux handler. if not used by it, it will
  * be used by App controls
  */


### PR DESCRIPTION
## Description

Add missing UX_WAKE_UP() support for Stax, fixes https://ledgerhq.atlassian.net/browse/FWEO-829

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
