### PR TITLE
Adjust NDEF buffers size

### DIFF
--- a/include/errors.h
+++ b/include/errors.h
@@ -617,6 +617,7 @@ enum generic_identifiers {
 #define SWO_APD_LEN_2E                    (ERR_APD_LEN + ERR_GEN_ID_2E)    // 0x672E
 #define SWO_APD_LEN_2F                    (ERR_APD_LEN + ERR_GEN_ID_2F)    // 0x672F
 #define SWO_APD_LEN_30                    (ERR_APD_LEN + ERR_GEN_ID_30)    // 0x6730
+#define SWO_APD_LEN_31                    (ERR_APD_LEN + ERR_GEN_ID_31)    // 0x6731
 
 #define SWO_APD_DAT_01                    (ERR_APD_DAT + ERR_GEN_ID_01)    // 0x6801
 #define SWO_APD_DAT_02                    (ERR_APD_DAT + ERR_GEN_ID_02)    // 0x6802

--- a/lib_nfc/include/nfc.h
+++ b/lib_nfc/include/nfc.h
@@ -82,9 +82,10 @@
 #define URI_ID_0x22_STRING          "urn:epc:\0"
 #define URI_ID_0x23_STRING          "urn:nfc:\0"
 
+#define URI_ID_STRING_MAX_LEN       27 //strlen(URI_ID_0x07_STRING)+1
 
-#define NFC_TEXT_MAX_LEN            70
-#define NFC_INFO_MAX_LEN        70
+#define NFC_TEXT_MAX_LEN            217
+#define NFC_INFO_MAX_LEN            30
 
 #define NFC_NDEF_TYPE_TEXT          0x01
 #define NFC_NDEF_TYPE_URI           0x02

--- a/lib_nfc/include/nfc.h
+++ b/lib_nfc/include/nfc.h
@@ -84,7 +84,7 @@
 
 #define URI_ID_STRING_MAX_LEN       27 //strlen(URI_ID_0x07_STRING)+1
 
-#define NFC_TEXT_MAX_LEN            217
+#define NFC_TEXT_MAX_LEN            215
 #define NFC_INFO_MAX_LEN            30
 
 #define NFC_NDEF_TYPE_TEXT          0x01
@@ -101,8 +101,8 @@
 typedef struct __attribute__((packed)) ndef_struct_s {
   uint8_t ndef_type;           // NDEF message type NFC_NDEF_TYPE_TEXT / NFC_NDEF_TYPE_URI
   uint8_t uri_id;              // URI string id (only applicable for NFC_NDEF_TYPE_URI)
-  char text[NFC_TEXT_MAX_LEN]; // String to store NDEF text/uri
-  char info[NFC_INFO_MAX_LEN]; // String to store NDEF uri information
+  char text[NFC_TEXT_MAX_LEN+1]; // String to store NDEF text/uri +1 for \0
+  char info[NFC_INFO_MAX_LEN+1]; // String to store NDEF uri information +1 for \0
 } ndef_struct_t;
 
 
@@ -110,7 +110,7 @@ typedef struct __attribute__((packed)) ndef_struct_s {
  * GLOBAL PROTOTYPES
  **********************/
 uint16_t os_get_uri_header(uint8_t uri_id, char *uri_header);
-bolos_err_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed);
+uint8_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed);
 uint16_t os_ndef_to_string(ndef_struct_t *ndef_message, char * out_string);
 
 #endif

--- a/lib_nfc/include/nfc.h
+++ b/lib_nfc/include/nfc.h
@@ -87,6 +87,8 @@
 #define NFC_TEXT_MAX_LEN            215
 #define NFC_INFO_MAX_LEN            30
 
+#define NFC_NDEF_MAX_SIZE           (URI_ID_STRING_MAX_LEN+NFC_TEXT_MAX_LEN+NFC_INFO_MAX_LEN+1)
+
 #define NFC_NDEF_TYPE_TEXT          0x01
 #define NFC_NDEF_TYPE_URI           0x02
 

--- a/lib_nfc/src/nfc.c
+++ b/lib_nfc/src/nfc.c
@@ -164,17 +164,29 @@ uint8_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed) {
  */
 uint16_t os_ndef_to_string(ndef_struct_t *ndef_message, char * out_string) {
     uint16_t tot_length = 0;
+    uint16_t length_internal = 0;
     if (ndef_message->ndef_type == NFC_NDEF_TYPE_TEXT) {
+        if (strlen(ndef_message->text) > NFC_TEXT_MAX_LEN) {
+          return 0;
+        }
         strcpy(out_string, ndef_message->text);
     }
     else if (ndef_message->ndef_type == NFC_NDEF_TYPE_URI) {
         tot_length += os_get_uri_header(ndef_message->uri_id, out_string);
+        length_internal = strlen(ndef_message->text);
+        if (tot_length + length_internal > URI_ID_STRING_MAX_LEN + NFC_TEXT_MAX_LEN) {
+          return 0;
+        }
         strcpy(&out_string[tot_length], ndef_message->text);
-        tot_length += strlen(ndef_message->text);
+        tot_length += length_internal;
         if (ndef_message->info[0] != '\0') {
             out_string[tot_length++] = '\n';
+            length_internal = strlen(ndef_message->info);
+            if (tot_length + length_internal > NFC_NDEF_MAX_SIZE) {
+              return 0;
+            }
             strcpy(&out_string[tot_length], ndef_message->info);
-            tot_length += strlen(ndef_message->info);
+            tot_length += length_internal;
         }
     }
     return tot_length;

--- a/lib_nfc/src/nfc.c
+++ b/lib_nfc/src/nfc.c
@@ -145,12 +145,14 @@ uint8_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed) {
         return 1;
     }
     memcpy(parsed->text, &in_buffer[APDU_OFF_DATA+1], text_length);
+    parsed->text[text_length] = '\0';
     info_length = in_buffer[APDU_OFF_DATA+1+text_length];
     if (info_length > NFC_INFO_MAX_LEN) {
         return 1;
     }
     if (info_length) {
         memcpy(parsed->info, &in_buffer[APDU_OFF_DATA+1+text_length+1], info_length);
+        parsed->info[info_length] = '\0';
     }
     return 0;
 }

--- a/lib_nfc/src/nfc.c
+++ b/lib_nfc/src/nfc.c
@@ -141,12 +141,14 @@ bolos_err_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed) {
     parsed->ndef_type = in_buffer[APDU_OFF_P1];
     parsed->uri_id = in_buffer[APDU_OFF_P2];
     text_length = in_buffer[APDU_OFF_DATA];
-    if (text_length > NFC_TEXT_MAX_LEN) {
+    // -1 for '\0'
+    if (text_length > NFC_TEXT_MAX_LEN-1) {
         return SWO_APD_LEN_2F;
     }
     memcpy(parsed->text, &in_buffer[APDU_OFF_DATA+1], text_length);
     info_length = in_buffer[APDU_OFF_DATA+1+text_length];
-    if (info_length > NFC_INFO_MAX_LEN) {
+    // -1 for '\0'
+    if (info_length > NFC_INFO_MAX_LEN-1) {
         return SWO_APD_LEN_30;
     }
     if (info_length) {

--- a/lib_nfc/src/nfc.c
+++ b/lib_nfc/src/nfc.c
@@ -136,25 +136,23 @@ uint16_t os_get_uri_header(uint8_t uri_id, char *uri_header) {
  * @param parsed deserialized output
  * @return bolos error
  */
-bolos_err_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed) {
+uint8_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed) {
     uint8_t text_length, info_length;
     parsed->ndef_type = in_buffer[APDU_OFF_P1];
     parsed->uri_id = in_buffer[APDU_OFF_P2];
     text_length = in_buffer[APDU_OFF_DATA];
-    // -1 for '\0'
-    if (text_length > NFC_TEXT_MAX_LEN-1) {
-        return SWO_APD_LEN_2F;
+    if (text_length > NFC_TEXT_MAX_LEN) {
+        return 1;
     }
     memcpy(parsed->text, &in_buffer[APDU_OFF_DATA+1], text_length);
     info_length = in_buffer[APDU_OFF_DATA+1+text_length];
-    // -1 for '\0'
-    if (info_length > NFC_INFO_MAX_LEN-1) {
-        return SWO_APD_LEN_30;
+    if (info_length > NFC_INFO_MAX_LEN) {
+        return 1;
     }
     if (info_length) {
         memcpy(parsed->info, &in_buffer[APDU_OFF_DATA+1+text_length+1], info_length);
     }
-    return SWO_OK;
+    return 0;
 }
 
 /**


### PR DESCRIPTION
## Description

Set NFC_TEXT_MAX_LEN to 215
Set NFC_INFO_MAX_LEN to 30
limit text_length and info_length to respectively NFC_TEXT_MAX_LEN-1 and NFC_INFO_MAX_LEN-1 in os_parse_ndef to take into account '\0' termination character

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

