### PR TITLE
Stax - Entered text (with keyboard) should be left justified instead …

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -296,6 +296,7 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, char *text, bool fixed);
 /* layout objects for page with keyboard */
 int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, nbgl_layoutKbd_t *kbdInfo);
 int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout, uint8_t index, uint32_t keyMask, bool updateCasing, keyboardCase_t casing);
+bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index);
 int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout, uint8_t nbUsedButtons,
                                     char *buttonTexts[NB_MAX_SUGGESTION_BUTTONS],
                                     int firstButtonToken, tune_index_e tuneId);

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -420,6 +420,7 @@ typedef struct PACKED__ nbgl_keyboard_s {
     color_t textColor; ///< color set to letters.
     color_t borderColor; ///< color set to key borders
     bool lettersOnly; ///< if true, only display letter keys and Backspace
+    bool needsRefresh; ///< if true, means that the keyboard has been redrawn and needs a refresh
     keyboardCase_t casing; ///< keyboard casing mode (lower, upper once or upper locked)
     keyboardMode_t mode; ///< keyboard mode to start with
     uint32_t keyMask; ///< mask used to disable some keys in letters only mod. The 26 LSB bits of mask are used, for the 26 letters of a QWERTY keyboard. Bit[0] for Q, Bit[1] for W and so on

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -2020,6 +2020,34 @@ int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout, uint8_t index, uint32_t key
 }
 
 /**
+ * @brief function called to know whether the keyboard has been redrawn and needs a refresh
+ *
+ * @param layout the current layout
+ * @param index index returned by @ref nbgl_layoutAddKeyboard()
+ * @return true if keyboard needs a refresh
+ */
+bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index) {
+  nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *)layout;
+  nbgl_keyboard_t *keyboard;
+
+  LOG_DEBUG(LAYOUT_LOGGER,"nbgl_layoutKeyboardNeedsRefresh(): \n");
+  if (layout == NULL)
+    return -1;
+
+  // get keyboard at given index
+  keyboard = (nbgl_keyboard_t*)layoutInt->container->children[index];
+  if ((keyboard == NULL) || (keyboard->type != KEYBOARD)) {
+    return -1;
+  }
+  if (keyboard->needsRefresh) {
+    keyboard->needsRefresh = false;
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * @brief Adds up to 4 black suggestion buttons under the previously added object
  *
  * @param layout the current layout
@@ -2165,7 +2193,7 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
   line->alignmentMarginY = offsetY;
   line->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
   line->alignment = TOP_MIDDLE;
-  line->width = SCREEN_WIDTH-2*44;
+  line->width = SCREEN_WIDTH-2*32;
   line->height = 4;
   line->direction = HORIZONTAL;
   line->thickness = 2;
@@ -2194,7 +2222,7 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
   textArea = (nbgl_text_area_t*)nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
   textArea->textColor = grayedOut ? LIGHT_GRAY:BLACK;
   textArea->text = text;
-  textArea->textAlignment = CENTER;
+  textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_REGULAR_32px;
   textArea->alignmentMarginY = 12;
   textArea->alignTo = (nbgl_obj_t*)line;
@@ -2203,7 +2231,7 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
     textArea->width = line->width - 2*50;
   }
   else {
-    textArea->width = SCREEN_WIDTH-2*BORDER_MARGIN;
+    textArea->width = line->width;
   }
   textArea->height = nbgl_getFontLineHeight(textArea->fontId);
   textArea->autoHideLongLine = true;
@@ -2232,7 +2260,8 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
  * @param number if numbered is true, number used to build 'number.' text
  * @param text string to display in the area
  * @param grayedOut if true, the text is grayed out (but not the potential number)
- * @return >= 0 if OK
+ * @return <0 if error, 0 if OK with text fitting the area, 1 of 0K with text
+ * not fitting the area
  */
 int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout, uint8_t index, bool numbered, uint8_t number, char *text, bool grayedOut) {
   nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *)layout;
@@ -2248,7 +2277,8 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout, uint8_t index, bool numb
     return -1;
   }
   textArea->text = text;
-  textArea->textColor = grayedOut ? LIGHT_GRAY:BLACK;
+  textArea->textColor = grayedOut ? LIGHT_GRAY : BLACK;
+  textArea->textAlignment = MID_LEFT;
   nbgl_redrawObject((nbgl_obj_t*)textArea,NULL,false);
 
   // update number text area
@@ -2258,7 +2288,10 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout, uint8_t index, bool numb
     snprintf(textArea->text,5,"%d.",number);
     nbgl_redrawObject((nbgl_obj_t*)textArea,NULL,false);
   }
-
+  // if the text doesn't fit, indicate it by returning 1 instead of 0, for different refresh
+  if (nbgl_getSingleLineTextWidth(textArea->fontId, text) > textArea->width) {
+    return 1;
+  }
   return 0;
 }
 
@@ -2295,8 +2328,8 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout, bool active, char *t
     button->touchMask = (1 << TOUCHED);
   }
   else {
-    button->borderColor = DARK_GRAY;
-    button->innerColor = DARK_GRAY;
+    button->borderColor = LIGHT_GRAY;
+    button->innerColor = LIGHT_GRAY;
   }
   button->text = PIC(text);
   button->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
@@ -2342,8 +2375,8 @@ int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout, uint8_t index, bo
     button->touchMask = (1 << TOUCHED);
   }
   else {
-    button->borderColor = DARK_GRAY;
-    button->innerColor = DARK_GRAY;
+    button->borderColor = LIGHT_GRAY;
+    button->innerColor = LIGHT_GRAY;
   }
   nbgl_redrawObject((nbgl_obj_t*)button,NULL,false);
   return 0;

--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -163,6 +163,7 @@ static void keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
       keyboard->casing = LOWER_CASE;
       // just redraw, refresh will be done by client (user of keyboard)
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
+      keyboard->needsRefresh = true;
     }
     if ((firstIndex<26)&&((keyboard->keyMask&(1<<firstIndex))==0)) {
       keyboard->callback((cur_casing != LOWER_CASE)?kbd_chars_upper[firstIndex]:kbd_chars[firstIndex]);
@@ -563,6 +564,7 @@ static void keyboardDraw(nbgl_keyboard_t *keyboard) {
 void nbgl_objDrawKeyboard(nbgl_keyboard_t *kbd) {
   kbd->touchMask = (1 << TOUCHED);
   kbd->touchCallback = (nbgl_touchCallback_t)&keyboardTouchCallback;
+  kbd->needsRefresh = false;
 
   keyboardDraw(kbd);
 }


### PR DESCRIPTION
## Description

Implements https://ledgerhq.atlassian.net/browse/FWEO-822 by using left-justified entered text in screens using Keyboard in layout API (report on API_LEVEL_3)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
