### PR TITLE
Cherry-pick: API_LEVEL_1: Remove warning about unused parameter: text_encoding

### DIFF
--- a/lib_bagl/src/bagl.c
+++ b/lib_bagl/src/bagl.c
@@ -289,6 +289,8 @@ int bagl_draw_string(unsigned short font_id, unsigned int fgcolor, unsigned int 
 #if defined(HAVE_UNICODE_SUPPORT)
   // Make sure font_unicode is recomputed using current language pack
   font_unicode = NULL;
+#else //defined(HAVE_UNICODE_SUPPORT)
+  UNUSED(text_encoding);
 #endif //defined(HAVE_UNICODE_SUPPORT)
 
   const bagl_font_t *font = bagl_get_font(font_id);


### PR DESCRIPTION
(cherry picked from commit 40d9bbfe43c7778bd59886f78e4b472e75ead8a5)

## Description

This was merged in https://github.com/LedgerHQ/ledger-secure-sdk/pull/176 and not cherry-picked in API_LEVEL_1 branch which needs it.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)
