### PR TITLE
Cherry-pick: API_LEVEL_1: Fix build warnings when printf

### DIFF
--- a/.github/workflows/check_clang_static_analyzer.yml
+++ b/.github/workflows/check_clang_static_analyzer.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [nanos, nanox, nanos2, stax]
+        target: [nanos, nanox, nanos2]
         debug: [0, 1]
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/check_clang_static_analyzer.yml
+++ b/.github/workflows/check_clang_static_analyzer.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - name: nanos
-          - name: nanox
-          - name: nanos2
-          - name: stax
+        target: [nanos, nanox, nanos2, stax]
+        debug: [0, 1]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
@@ -36,9 +33,11 @@ jobs:
 
       - name: Build with Clang Static Analyzer
         run: |
-          TARGET=${{ matrix.target.name }} \
+          TARGET=${{ matrix.target }} \
           BOLOS_SDK=sdk \
-          scan-build --use-cc=clang -analyze-headers -enable-checker security -enable-checker unix -enable-checker valist -o scan-build --status-bugs make default
+          scan-build --use-cc=clang -analyze-headers -enable-checker security \
+            -enable-checker unix -enable-checker valist -o scan-build --status-bugs \
+            make default DEBUG=${{ matrix.debug }}
 
       - name: Upload scan result
         uses: actions/upload-artifact@v3

--- a/src/os.c
+++ b/src/os.c
@@ -21,6 +21,7 @@
 #include "os_helpers.h"
 #include "os_io.h"
 #include "os_utils.h"
+#include "os.h"
 #include <string.h>
 
 // apdu buffer must hold a complete apdu to avoid troubles

--- a/src/os_printf.c
+++ b/src/os_printf.c
@@ -19,15 +19,11 @@
 #include <stdarg.h>
 #include <string.h>
 #include "decorators.h"
+#include "os_math.h"
 
 #if defined(HAVE_BOLOS)
 # include "bolos_target.h"
-# include "os_math.h"
 #endif // HAVE_BOLOS
-
-#if !defined(MIN)
-# define MIN(x,y) ((x)<(y)?(x):(y))
-#endif // MIN
 
 #if defined(HAVE_PRINTF) || defined(HAVE_SPRINTF)
 


### PR DESCRIPTION
## Description

Cherry-picks from https://github.com/LedgerHQ/ledger-secure-sdk/pull/206
Disable clang static analyzer on stax as on API_LEVEL_1 stax is named fatstacks.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)
