### PR TITLE
Stax - Move touch callback at screen level instead of obj level

### DIFF
--- a/lib_nbgl/doc/nbgl_api.dox
+++ b/lib_nbgl/doc/nbgl_api.dox
@@ -64,8 +64,7 @@ For example:
         .alignmentMarginY = 20,                   // Vertical margin (see layout & alignment)
         .alignment = TOP_LEFT,                    // Type of alignment (see layout & alignment)
         .alignTo = NULL,                          // Alignment reference, if NULL, use parent (see layout & alignment)
-        .touchMask = (1<<VALUE_CHANGED),          // Types of touchscreen events that we want to receive
-        .touchCallback = (nbgl_touchCallback_t)&touchCallback // Callback to be called on touchscreen events.
+        .touchMask = (1<<VALUE_CHANGED)           // Types of touchscreen events that we want to receive
         };
 @endcode
 
@@ -102,7 +101,7 @@ For example, with a static allocation of objects (not recommended, see @ref nbgl
         /*....*/
     };
     // allocate screen 0 for 2 children
-    nbgl_screenSet(&screenChildren, 2, NULL);
+    nbgl_screenSet(&screenChildren, 2, NULL, &touchCallback);
     // set children of screen
     screenChildren[0] = (nbgl_obj_t*)&backButton;
     screenChildren[1] = (nbgl_obj_t*)&container;
@@ -116,7 +115,7 @@ The same example with dynamic  allocation of objects:
     uint8_t layer = 0;
 
     /* allocate layer 0 for 2 children (it also releases any objects/containers allocated previously in layer 0) */
-    nbgl_screenSet(&screenChildren, 2, NULL);
+    nbgl_screenSet(&screenChildren, 2, NULL, &touchCallback);
 
     /* allocate backButton dynamically */
     nbgl_button_t *backButton = nbgl_objPoolGet(BUTTON, layer);

--- a/lib_nbgl/fonts/nbgl_font_rom.inc
+++ b/lib_nbgl/fonts/nbgl_font_rom.inc
@@ -20,7 +20,6 @@
 #include "nbgl_font_inter_regular_24.inc"
 #include "nbgl_font_inter_semibold_24.inc"
 #include "nbgl_font_inter_regular_32.inc"
-#include "nbgl_font_hmalpha_mono_medium_32_1bpp.inc"
 #include "nbgl_font_inter_regular_24_1bpp.inc"
 #include "nbgl_font_inter_semibold_24_1bpp.inc"
 #include "nbgl_font_inter_regular_32_1bpp.inc"

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -195,7 +195,6 @@ typedef struct PACKED__ nbgl_obj_s {
     int16_t alignmentMarginX; ///< horizontal margin when aligning
     int16_t alignmentMarginY; ///< vertical margin when aligning
     uint8_t touchMask; ///< bit mask to tell engine which touch events are handled by this object
-    nbgl_touchCallback_t touchCallback; ///< function to be called on events defined in @ref touchMask
 } nbgl_obj_t;
 
 /**
@@ -457,13 +456,15 @@ void nbgl_containerPoolRelease(uint8_t layer);
 nbgl_obj_t** nbgl_containerPoolGet(uint8_t nbObjs, uint8_t layer);
 uint8_t nbgl_containerPoolGetNbUsed(uint8_t layer);
 
-nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, bool withExitKey, nbgl_touchCallback_t callback, uint8_t layer);
-uint8_t nbgl_navigationGetActivePage(void);
-nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, nbgl_touchCallback_t callback, bool separationLine, uint8_t layer);
+nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, bool withExitKey, uint8_t layer);
+void nbgl_navigationCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType, uint8_t nbPages, uint8_t *activePage);
+nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, bool separationLine, uint8_t layer);
 
 // for internal use
 void nbgl_objDrawKeyboard(nbgl_keyboard_t *kbd);
 void nbgl_objDrawKeypad(nbgl_keypad_t *kbd);
+void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType);
+void nbgl_keypadTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType);
 
 /**********************
  *      MACROS

--- a/lib_nbgl/include/nbgl_screen.h
+++ b/lib_nbgl/include/nbgl_screen.h
@@ -36,6 +36,7 @@ typedef void (*nbgl_tickerCallback_t)(void);
  *
  */
 typedef struct PACKED__ nbgl_screenTickerConfiguration_s {
+  nbgl_touchCallback_t touchCallback; ///< function to be called on events defined in touchMask field in each sub-object
   nbgl_tickerCallback_t tickerCallback; ///< callback called when ticker timer is fired. Set to NULL for no ticker
   uint32_t tickerValue; ///< timer initial value, in ms (should be multiple of 100 ms). Set to 0 for no ticker
   uint32_t tickerIntervale; ///< for periodic timers, the intervale in ms to rearm the timer (should be multiple of 100 ms). Set to 0 for one-shot timers
@@ -71,13 +72,13 @@ nbgl_obj_t *nbgl_screenGetTop(void);
 uint8_t nbgl_screenGetCurrentStackSize(void);
 bool nbgl_screenContainsObj(nbgl_obj_t *obj);
 
-int nbgl_screenSet(nbgl_obj_t*** elements, uint8_t nbElements, nbgl_screenTickerConfiguration_t *ticker);
+int nbgl_screenSet(nbgl_obj_t*** elements, uint8_t nbElements, nbgl_screenTickerConfiguration_t *ticker, nbgl_touchCallback_t touchCallback);
 int nbgl_screenUpdateNbElements(uint8_t screenIndex, uint8_t nbElements);
 int nbgl_screenUpdateBackgroundColor(uint8_t screenIndex, color_t color);
 int nbgl_screenUpdateTicker(uint8_t screenIndex, nbgl_screenTickerConfiguration_t *ticker);
 nbgl_obj_t **nbgl_screenGetElements(uint8_t screenIndex);
 int nbgl_screenRelease(void);
-int nbgl_screenPush(nbgl_obj_t*** elements, uint8_t nbElements, nbgl_screenTickerConfiguration_t *ticker);
+int nbgl_screenPush(nbgl_obj_t*** elements, uint8_t nbElements, nbgl_screenTickerConfiguration_t *ticker, nbgl_touchCallback_t touchCallback);
 int nbgl_screenPop(uint8_t screenIndex);
 int nbgl_screenReset(void);
 void nbgl_screenHandler(uint32_t intervaleMs);

--- a/lib_nbgl/src/nbgl_bottom_button.c
+++ b/lib_nbgl/src/nbgl_bottom_button.c
@@ -38,33 +38,20 @@ enum {
  *      VARIABLES
  **********************/
 
-/**********************
- *  STATIC PROTOTYPES
- **********************/
-static nbgl_touchCallback_t buttonCallback = NULL;
 
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-static void touchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
-  if (eventType != TOUCHED) {
-    return;
-  }
-  if (buttonCallback != NULL) {
-    buttonCallback(obj->parent,TOUCHED);
-  }
-}
 
 /**
- * @brief This function creates a bottom area with a centered button and a top line returns it as a container
+ * @brief This function creates a bottom area with a centered button and a top line. Returns it as a container
  *
  * @param icon icon to place in centered button
- * @param callback the callback called when the centered button is pressed
  * @param separationLine if set to true, adds a light gray separation line on top of the container
  * @param layer screen layer to use
  * @return the created container object
  */
-nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, nbgl_touchCallback_t callback, bool separationLine, uint8_t layer) {
+nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, bool separationLine, uint8_t layer) {
   nbgl_button_t *button;
   nbgl_container_t *container;
 
@@ -74,8 +61,6 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, nbg
   container->layout = HORIZONTAL ;
   container->nbChildren = NB_MAX_CHILDREN;
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren, layer);
-  container->alignmentMarginX = 0;
-  container->alignmentMarginY = 0;
   container->alignment = NO_ALIGNMENT;
 
   button = (nbgl_button_t*)nbgl_objPoolGet(BUTTON,layer);
@@ -84,14 +69,9 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, nbg
   button->width = BUTTON_DIAMETER;
   button->height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
-  button->text = NULL;
   button->icon = icon;
-  button->alignmentMarginX = 0;
-  button->alignmentMarginY = 0;
   button->alignment = CENTER;
-  button->alignTo = NULL;
   button->touchMask = (1<<TOUCHED);
-  button->touchCallback = (nbgl_touchCallback_t)&touchCallback;
   container->children[QUIT_BUTTON_INDEX] = (nbgl_obj_t*)button;
 
   if (separationLine) {
@@ -103,14 +83,11 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, nbg
     line->height = 4;
     line->direction = HORIZONTAL;
     line->thickness = 1;
-    line->alignmentMarginX = 0;
     line->alignmentMarginY = BORDER_MARGIN-4;
     line->alignTo = (nbgl_obj_t*)button;
     line->alignment = TOP_MIDDLE;
     container->children[LINE_INDEX] = (nbgl_obj_t*)line;
   }
-
-  buttonCallback = callback;
 
   return container;
 }

--- a/lib_nbgl/src/nbgl_touch.c
+++ b/lib_nbgl/src/nbgl_touch.c
@@ -48,13 +48,31 @@ static nbgl_touchStatePosition_t firstTouchedPosition,lastTouchedPosition;
  * @param eventType type of touchscreen event
  */
 static void applytouchStatePosition(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
+  nbgl_screen_t *screen = (nbgl_screen_t*)nbgl_screenGetTop();
   LOG_DEBUG(TOUCH_LOGGER,"Apply event %d on object of type %d\n",eventType,obj->type);
   if (!obj) {
     return;
   }
   /* the first action is the one provided by the application */
-  if (((obj->touchMask&(1<<eventType)) != 0) && (obj->touchCallback != NULL)) {
-    ((nbgl_touchCallback_t)PIC(obj->touchCallback))((void *)obj,eventType);
+  if ((obj->touchMask & (1<<eventType)) != 0) {
+    // for some specific objects, call directly a specific callback
+    switch (obj->type) {
+#ifdef NBGL_KEYBOARD
+    case KEYBOARD:
+      nbgl_keyboardTouchCallback(obj,eventType);
+      break;
+#endif // NBGL_KEYBOARD
+#ifdef NBGL_KEYPAD
+    case KEYPAD:
+      nbgl_keypadTouchCallback(obj,eventType);
+      break;
+#endif // NBGL_KEYPAD
+    default:
+      if (screen->touchCallback != NULL)
+        ((nbgl_touchCallback_t)PIC(screen->touchCallback))((void *)obj, eventType);
+      break;
+    }
+
   }
 }
 


### PR DESCRIPTION
## Description

The goal is to move the touch callback at screen level instead of obj level, to save RAM (and flash), and because keeping it at object level is most of the time useless, as callback are most of the time already declared for a given screen.
The High-Level API of NBGL is not affected by this change.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ *] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
