### PR TITLE
Add syscall to configure excluded borders for touch

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -73,10 +73,16 @@ typedef struct io_touch_info_s {
     uint8_t h;
 } io_touch_info_t;
 
+// bitfield for exclusion borders, for touch_exclude_borders() (if a bit is set, means that pixels on this border are not taken into account)
+#define LEFT_BORDER   1
+#define RIGHT_BORDER  2
+#define TOP_BORDER    4
+#define BOTTOM_BORDER 8
 
 #ifdef HAVE_SE_TOUCH
 SYSCALL void touch_get_last_info(io_touch_info_t *info);
 SYSCALL void touch_set_state(bool enable);
+SYSCALL uint8_t touch_exclude_borders(uint8_t excluded_borders);
 #ifdef HAVE_TOUCH_DEBUG
 SYSCALL void touch_read_sensitivity(uint8_t *sensi_data);
 #endif

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -309,7 +309,8 @@
 
 #ifdef HAVE_SE_TOUCH
 #define SYSCALL_touch_get_last_info_ID                                   0x01fa000b
-#define SYSCALL_touch_set_state_ID                                         0x01fa000e
+#define SYSCALL_touch_exclude_borders_ID                                 0x01fa000d
+#define SYSCALL_touch_set_state_ID                                       0x01fa000e
 #ifdef HAVE_TOUCH_DEBUG
 #define SYSCALL_touch_read_sensi_ID                                      0x01fa000f
 #endif

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1912,7 +1912,7 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, char *text, bool fixed) {
   textArea->textColor = BLACK;
   textArea->text = (char*)PIC(text);
   textArea->textAlignment = CENTER;
-  textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
+  textArea->fontId = BAGL_FONT_INTER_REGULAR_24px_1bpp;
   textArea->alignmentMarginY = 36;
   textArea->alignTo = (nbgl_obj_t*)spinner;
   textArea->alignment = BOTTOM_MIDDLE;
@@ -2074,7 +2074,7 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout, uint8_t nbUsedButtons
     choiceButtons[i]->width = (SCREEN_WIDTH-2*BORDER_MARGIN-8)/2;
     choiceButtons[i]->height = 64;
     choiceButtons[i]->radius = RADIUS_32_PIXELS;
-    choiceButtons[i]->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
+    choiceButtons[i]->fontId = BAGL_FONT_INTER_SEMIBOLD_24px_1bpp;
     choiceButtons[i]->icon = NULL;
     if ((i%2) == 0) {
       choiceButtons[i]->alignmentMarginX = BORDER_MARGIN;
@@ -2190,7 +2190,7 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
     snprintf(numText,sizeof(numText),"%d.",number);
     textArea->text = numText;
     textArea->textAlignment = MID_LEFT;
-    textArea->fontId = BAGL_FONT_INTER_REGULAR_32px;
+    textArea->fontId = BAGL_FONT_INTER_REGULAR_32px_1bpp;
     textArea->alignmentMarginY = 12;
     textArea->alignTo = (nbgl_obj_t*)line;
     textArea->alignment = TOP_LEFT;
@@ -2205,7 +2205,7 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
   textArea->textColor = grayedOut ? LIGHT_GRAY:BLACK;
   textArea->text = text;
   textArea->textAlignment = MID_LEFT;
-  textArea->fontId = BAGL_FONT_INTER_REGULAR_32px;
+  textArea->fontId = BAGL_FONT_INTER_REGULAR_32px_1bpp;
   textArea->alignmentMarginY = 12;
   textArea->alignTo = (nbgl_obj_t*)line;
   textArea->alignment = TOP_MIDDLE;
@@ -2313,7 +2313,7 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout, bool active, char *t
     button->innerColor = LIGHT_GRAY;
   }
   button->text = PIC(text);
-  button->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
+  button->fontId = BAGL_FONT_INTER_SEMIBOLD_24px_1bpp;
   button->width = GET_AVAILABLE_WIDTH(layoutInt);
   button->height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;

--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -17,6 +17,7 @@
 #include "nbgl_fonts.h"
 #include "nbgl_touch.h"
 #include "glyphs.h"
+#include "os_io.h"
 
 /*********************
  *      DEFINES
@@ -525,6 +526,7 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
     else if (firstIndex == DIGITS_SWITCH_KEY_INDEX) { //switch to digits
       keyboard->mode = MODE_DIGITS;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
+      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
     }
   }
   else if (keyboard->mode == MODE_DIGITS) {
@@ -539,6 +541,7 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
     else if (firstIndex == DIGITS_SWITCH_KEY_INDEX) { // switch to letters
       keyboard->mode = MODE_LETTERS;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
+      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
     }
   }
   else if (keyboard->mode == MODE_SPECIAL) {
@@ -553,6 +556,7 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
     else if (firstIndex == DIGITS_SWITCH_KEY_INDEX) { // switch to letters
       keyboard->mode = MODE_LETTERS;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
+      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
     }
   }
   if (firstIndex == BACKSPACE_KEY_INDEX) { // backspace
@@ -573,5 +577,8 @@ void nbgl_objDrawKeyboard(nbgl_keyboard_t *kbd) {
   kbd->needsRefresh = false;
 
   keyboardDraw(kbd);
+
+  // If a keyboard in the screen, exclude only top border from touch, to avoid missing touch on left keys
+  touch_exclude_borders(TOP_BORDER);
 }
 #endif // NBGL_KEYBOARD

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -9,6 +9,7 @@
 #include "nbgl_screen.h"
 #include "nbgl_debug.h"
 #include "os_pic.h"
+#include "os_io.h"
 
 /*********************
  *      DEFINES
@@ -64,6 +65,12 @@ void nbgl_screenRedraw(void) {
     return;
   }
   LOG_DEBUG(SCREEN_LOGGER,"nbgl_screenRedraw(): nbScreensOnStack = %d\n",nbScreensOnStack);
+#ifdef HAVE_SE_TOUCH
+  // by default, exclude left & top borders from touch
+  // if any sub-object is a keyboard, this will be modified when drawing it
+  touch_exclude_borders(TOP_BORDER | LEFT_BORDER);
+#endif // HAVE_SE_TOUCH
+
   nbgl_screen_reinit();
   nbgl_redrawObject((nbgl_obj_t *)topOfStack, NULL, true);
 }

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1808,6 +1808,11 @@ void touch_set_state(bool enable) {
   SVC_Call(SYSCALL_touch_set_state_ID, parameters);
 }
 
+uint8_t touch_exclude_borders(uint8_t excluded_borders) {
+  unsigned int parameters[1] = {(unsigned int) excluded_borders};
+  return (uint8_t)SVC_Call(SYSCALL_touch_exclude_borders_ID, parameters);
+}
+
 #ifdef HAVE_TOUCH_DEBUG
 void touch_read_sensitivity(uint8_t *sensi_data) {
   unsigned int parameters[1] = {(unsigned int) sensi_data};


### PR DESCRIPTION
## Description

Add syscall to configure excluded borders for touch (to fix https://ledgerhq.atlassian.net/browse/FWEO-842)
This syscall is supposed to be called when entering pages containing keyboard to disable left border exclusion and to call it afterward to reenable it

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
