### PR TITLE
Makefile.defines: Enable more build warnings and add option to enable  -Werror

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -110,7 +110,21 @@ CFLAGS   += $(OPTI_LVL) $(DBG_LVL)
 CFLAGS   += -fomit-frame-pointer -momit-leaf-frame-pointer
 
 CFLAGS   += -fno-common -mlittle-endian
-CFLAGS   += -std=gnu99 -Werror=int-to-pointer-cast -Wall -Wextra -Wno-main
+CFLAGS   += -std=gnu99
+
+CFLAGS   += -Wall -Wextra
+CFLAGS   += -Wno-main
+CFLAGS   += -Werror=int-to-pointer-cast
+
+# Additional Clang warnings
+CFLAGS   += -Wno-error=int-conversion -Wimplicit-fallthrough
+CFLAGS   += -Wvla -Wundef -Wshadow -Wformat=2 -Wformat-security -Wwrite-strings
+
+WERROR ?= 0
+ifneq ($(WERROR),0)
+    CFLAGS   += -Werror
+endif
+
 CFLAGS   += -fdata-sections -ffunction-sections -funsigned-char -fshort-enums
 CFLAGS   += -mno-unaligned-access
 CFLAGS   += -fropi

--- a/src/os_printf.c
+++ b/src/os_printf.c
@@ -974,9 +974,7 @@ s_pad:
                 //
                 case 'X':
                     ulCap = 1;
-#if !defined(__clang__)
                     FALL_THROUGH;
-#endif // !defined(__clang__)
                 case 'x':
                 case 'p':
                 {


### PR DESCRIPTION
## Description

Enable more build warnings and add option to enable ` -Werror`.
List inspired from app usage, discussion with other devs and https://embeddedartistry.com/blog/2017/06/07/warnings-weverything-and-the-kitchen-sink/ and https://clang.llvm.org/docs/DiagnosticsReference.html#id413


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)
