### PR TITLE
Makefile: allow app to specify prebuild target in APP_CUSTOM_PREBUILD_TARGETS

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -69,9 +69,17 @@ prepare:
 BIN_TARGETS := bin/app.elf bin/app.apdu bin/app.sha256 bin/app.hex
 DBG_TARGETS := debug/app.map debug/app.asm
 
-default: $(BIN_TARGETS) $(DBG_TARGETS)
+prebuild: prepare $(APP_CUSTOM_PREBUILD_TARGETS) Makefile
 
-$(OBJ_DIR)/%.o: %.c $(GLYPH_DESTC) prepare Makefile
+glyphs_gen: $(GLYPH_DESTC)
+
+targets_gen: $(BIN_TARGETS) $(DBG_TARGETS)
+
+default: prebuild
+	$(MAKE) glyphs_gen
+	$(MAKE) targets_gen
+
+$(OBJ_DIR)/%.o: %.c
 	@echo "[CC]   $@"
 	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 


### PR DESCRIPTION
## Description

Allow apps to specify prebuild target in APP_CUSTOM_TARGETS.
Previously this was done like https://github.com/LedgerHQ/app-dock/pull/17/files

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
