### PR TITLE
checks.c: Remove unused variable slot

### DIFF
--- a/src/checks.c
+++ b/src/checks.c
@@ -151,7 +151,6 @@ void ui_audited_deinit(void) {}
 void check_audited_app(void) {
   unsigned char     data = BOLOS_FALSE;
   unsigned char*    buffer = &data;
-  unsigned int      slot;
   unsigned int      length = os_parse_bertlv((unsigned char*)(&_install_parameters),
                                              CHECK_NOT_AUDITED_MAX_LEN,
                                              NULL,


### PR DESCRIPTION
## Description

checks.c: Remove unused variable slot which generates a warning at build time when `HAVE_PENDING_REVIEW_SCREEN`

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
