### PR TITLE
os_printf.c: Improve snprintf() handling of buffer of size 1

### DIFF
--- a/src/os_printf.c
+++ b/src/os_printf.c
@@ -570,7 +570,7 @@ int snprintf(char * str, size_t str_size, const char * format, ...)
     //
     // Check the arguments.
     //
-    if(str == NULL ||str_size < 2) {
+    if(str == NULL ||str_size < 1) {
       return 0;
     }
 
@@ -578,6 +578,12 @@ int snprintf(char * str, size_t str_size, const char * format, ...)
     memset(str, 0, str_size);
     str_size--;
 
+    //
+    // Check if there is still space left for data in the buffer.
+    //
+    if(str_size < 1) {
+      return 0;
+    }
 
     //
     // Start the varargs processing.


### PR DESCRIPTION
## Description


Fixes https://github.com/LedgerHQ/nanos-secure-sdk/issues/39

> Apparently, for a buffer of size 1, snprintf does nothing, especially it does not include the terminating '\0' in case an empty string is to be printed. That might not conform to callers' expectations and poses a security risk.


## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)