### PR TITLE
Makefile: Fix build of app that doesn't use default target

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -79,7 +79,11 @@ default: prebuild
 	$(MAKE) glyphs_gen
 	$(MAKE) targets_gen
 
-$(OBJ_DIR)/%.o: %.c
+# Some apps use `bin/app.elf` as default makefile target instead of `default`.
+# Therefore we should keep for now the `prepare` dependency on next target
+# in order not to break these apps build...
+# At some point, this should be changed in the apps and removed from the SDK.
+$(OBJ_DIR)/%.o: %.c prepare
 	@echo "[CC]   $@"
 	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 


### PR DESCRIPTION
## Description

This fix a regression from 01d5cd4f9eb69ca6071736af7ebc3d832da1d8bd

> Some app use `bin/app.elf` as default makefile target instead of `default`.
> Therefore we should keep for now the `prepare` dependency on next target
> in order not to break these apps build...
> At some point, this should be changed in the apps and removed from the SDK.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
