### PR TITLE
workflow: Enable -j and WERROR=1 for boilerplate clang check

### DIFF
--- a/.github/workflows/check_clang_static_analyzer.yml
+++ b/.github/workflows/check_clang_static_analyzer.yml
@@ -37,7 +37,7 @@ jobs:
           BOLOS_SDK=sdk \
           scan-build --use-cc=clang -analyze-headers -enable-checker security \
             -enable-checker unix -enable-checker valist -o scan-build --status-bugs \
-            make default DEBUG=${{ matrix.debug }}
+            make -j WERROR=1 DEBUG=${{ matrix.debug }}
 
       - name: Upload scan result
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

Modify workflow so that build uses `-j` and `WERROR=1`.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
