### PR TITLE
Revert "Makefile: allow app to specify prebuild target in APP_CUSTOM_TARGETS"

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -69,17 +69,9 @@ prepare:
 BIN_TARGETS := bin/app.elf bin/app.apdu bin/app.sha256 bin/app.hex
 DBG_TARGETS := debug/app.map debug/app.asm
 
-prebuild: prepare $(APP_CUSTOM_PREBUILD_TARGETS) Makefile
+default: $(BIN_TARGETS) $(DBG_TARGETS)
 
-glyphs_gen: $(GLYPH_DESTC)
-
-targets_gen: $(BIN_TARGETS) $(DBG_TARGETS)
-
-default: prebuild
-	$(MAKE) glyphs_gen
-	$(MAKE) targets_gen
-
-$(OBJ_DIR)/%.o: %.c
+$(OBJ_DIR)/%.o: %.c $(GLYPH_DESTC) prepare Makefile
 	@echo "[CC]   $@"
 	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 


### PR DESCRIPTION
This reverts commit 43e346283229b9fb52725c302e5208ef0ef97431.

## Description
this is causing issue for the OS side.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
