### PR TITLE
Makefile: Add possibility to add BUILD and LINK dependencies

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -69,17 +69,9 @@ prepare:
 BIN_TARGETS := bin/app.elf bin/app.apdu bin/app.sha256 bin/app.hex
 DBG_TARGETS := debug/app.map debug/app.asm
 
-prebuild: prepare $(APP_CUSTOM_PREBUILD_TARGETS) Makefile
+default: $(BIN_TARGETS) $(DBG_TARGETS)
 
-glyphs_gen: $(GLYPH_DESTC)
-
-targets_gen: $(BIN_TARGETS) $(DBG_TARGETS)
-
-default: prebuild
-	$(MAKE) glyphs_gen
-	$(MAKE) targets_gen
-
-$(OBJ_DIR)/%.o: %.c
+$(OBJ_DIR)/%.o: %.c $(GLYPH_DESTC) prepare Makefile
 	@echo "[CC]   $@"
 	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -62,24 +62,29 @@ clean:
 clean_target:
 	rm -fr $(TARGET_BUILD_DIR)
 
+BUILD_DEPENDENCIES  = $(GLYPH_DESTH) $(GLYPH_DESTC) Makefile
+BUILD_DEPENDENCIES += $(APP_CUSTOM_BUILD_DEPENDENCIES)
+
 prepare:
 	$(L)echo Prepare directories
 	@mkdir -p $(BIN_DIR) $(OBJ_DIR) $(DBG_DIR) $(DEP_DIR) $(GEN_SRC_DIR) bin debug
+
+$(BUILD_DEPENDENCIES): prepare
 
 BIN_TARGETS := bin/app.elf bin/app.apdu bin/app.sha256 bin/app.hex
 DBG_TARGETS := debug/app.map debug/app.asm
 
 default: $(BIN_TARGETS) $(DBG_TARGETS)
 
-$(OBJ_DIR)/%.o: %.c $(GLYPH_DESTC) prepare Makefile
+$(OBJ_DIR)/%.o: %.c $(BUILD_DEPENDENCIES) prepare
 	@echo "[CC]   $@"
 	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 
-$(OBJ_DIR)/%.o: %.s
+$(OBJ_DIR)/%.o: %.s $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
 	$(L)$(call as_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 
-$(OBJ_DIR)/%.o: %.S
+$(OBJ_DIR)/%.o: %.S $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
 	$(L)$(call as_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 
@@ -90,7 +95,12 @@ $(info Using custom link script: $(SCRIPT_LD))
 endif
 LDFLAGS  += -T$(SCRIPT_LD)
 
-$(BIN_DIR)/app.elf: $(OBJECT_FILES) $(SCRIPT_LD)
+$(LINK_DEPENDENCIES): prepare
+
+LINK_DEPENDENCIES  = $(OBJECT_FILES) $(SCRIPT_LD) Makefile
+LINK_DEPENDENCIES += $(APP_CUSTOM_LINK_DEPENDENCIES)
+
+$(BIN_DIR)/app.elf: $(LINK_DEPENDENCIES)
 	@echo "[LINK] $(BIN_DIR)/app.elf"
 	$(L)$(call link_cmdline,$(OBJECT_FILES) $(LDLIBS),$(BIN_DIR)/app.elf)
 	$(L)$(GCCPATH)arm-none-eabi-objcopy -O ihex -S $(BIN_DIR)/app.elf $(BIN_DIR)/app.hex

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -79,11 +79,7 @@ default: prebuild
 	$(MAKE) glyphs_gen
 	$(MAKE) targets_gen
 
-# Some apps use `bin/app.elf` as default makefile target instead of `default`.
-# Therefore we should keep for now the `prepare` dependency on next target
-# in order not to break these apps build...
-# At some point, this should be changed in the apps and removed from the SDK.
-$(OBJ_DIR)/%.o: %.c prepare
+$(OBJ_DIR)/%.o: %.c
 	@echo "[CC]   $@"
 	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
 


### PR DESCRIPTION
## Description

First revert previous try that wasn't great:
- https://github.com/LedgerHQ/ledger-secure-sdk/commit/43e346283229b9fb52725c302e5208ef0ef97431 from https://github.com/LedgerHQ/ledger-secure-sdk/pull/223
- https://github.com/LedgerHQ/ledger-secure-sdk/commit/80e3c76c01159270d58e568fad7238058a0df773 from https://github.com/LedgerHQ/ledger-secure-sdk/pull/239

Then add a better one that doesn't break the compatibility while:
- Allowing apps to add dependencies to the build step using APP_CUSTOM_BUILD_DEPENDENCIES
- Allowing apps to add dependencies to the link step using APP_CUSTOM_LINK_DEPENDENCIES
- Cleanup Makefile.rules_generic dependencies on `prepare` target and on `Makefile` 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Additional comments

Tested with building an app with `make -j` with having firstly added in the Makefile:
```
.PHONY: toto
toto:
	@echo toto start
	@sleep 2
	@echo toto stop

APP_CUSTOM_BUILD_DEPENDENCIES = toto

.PHONY: tata
tata:
	@echo tata start
	@sleep 5
	@echo tata stop

APP_CUSTOM_LINK_DEPENDENCIES = tata
```

Which gives an output of:
```
$make -j                                                                                                                                                        
Prepare directories                                                                                                                                                                                                
tata start                                                                                                                                                                                                         
toto start                                                                                                                                                                                                         
[GLYPH] Compiling...                                                                                                                                                                                               
toto stop                                                                                                                                                                                                          
[CC]   build/stax/obj/address.o                                                                                                                                                                                    
[...]
tata stop
[LINK] build/stax/bin/app.elf
[CP] build/stax/bin/app.hex => bin/app.hex
[CP] build/stax/bin/app.elf => bin/app.elf
[CP] build/stax/dbg/app.map => debug/app.map
[CP] build/stax/dbg/app.asm => debug/app.asm
[CP] build/stax/bin/app.apdu => bin/app.apdu
[CP] build/stax/bin/app.sha256 => bin/app.sha256
```
