### PR TITLE
Makefile: Rename WERROR param to ENABLE_SDK_WERROR

### DIFF
--- a/.github/workflows/check_clang_static_analyzer.yml
+++ b/.github/workflows/check_clang_static_analyzer.yml
@@ -37,7 +37,7 @@ jobs:
           BOLOS_SDK=sdk \
           scan-build --use-cc=clang -analyze-headers -enable-checker security \
             -enable-checker unix -enable-checker valist -o scan-build --status-bugs \
-            make -j WERROR=1 DEBUG=${{ matrix.debug }}
+            make -j ENABLE_SDK_WERROR=1 DEBUG=${{ matrix.debug }}
 
       - name: Upload scan result
         uses: actions/upload-artifact@v3

--- a/Makefile.defines
+++ b/Makefile.defines
@@ -120,8 +120,8 @@ CFLAGS   += -Werror=int-to-pointer-cast
 CFLAGS   += -Wno-error=int-conversion -Wimplicit-fallthrough
 CFLAGS   += -Wvla -Wundef -Wshadow -Wformat=2 -Wformat-security -Wwrite-strings
 
-WERROR ?= 0
-ifneq ($(WERROR),0)
+ENABLE_SDK_WERROR ?= 0
+ifneq ($(ENABLE_SDK_WERROR),0)
     CFLAGS   += -Werror
 endif
 


### PR DESCRIPTION
## Description

Some apps uses `WERROR` in their makefiles (caradano, fio, ...) So previous parameter name was causing issue.
Makefile: Rename WERROR param to ENABLE_SDK_WERROR


## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
