### PR TITLE
Restrict touch debug related calls

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -83,7 +83,7 @@ typedef struct io_touch_info_s {
 SYSCALL void touch_get_last_info(io_touch_info_t *info);
 SYSCALL void touch_set_state(bool enable);
 SYSCALL uint8_t touch_exclude_borders(uint8_t excluded_borders);
-#ifdef HAVE_TOUCH_DEBUG
+#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
 SYSCALL void touch_read_sensitivity(uint8_t *sensi_data);
 #endif
 #endif

--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -126,7 +126,7 @@ void io_seproxyhal_nfc_init(ndef_struct_t *ndef_message, bool async, bool forceI
 #endif
 
 #ifdef HAVE_SE_TOUCH
-#ifdef HAVE_TOUCH_DEBUG
+#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
 void io_seproxyhal_touch_read_sensi(uint8_t * sensi_data);
 #endif
 #endif

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -311,7 +311,7 @@
 #define SYSCALL_touch_get_last_info_ID                                   0x01fa000b
 #define SYSCALL_touch_exclude_borders_ID                                 0x01fa000d
 #define SYSCALL_touch_set_state_ID                                       0x01fa000e
-#ifdef HAVE_TOUCH_DEBUG
+#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
 #define SYSCALL_touch_read_sensi_ID                                      0x01fa000f
 #endif
 

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -534,7 +534,7 @@ void io_seproxyhal_nfc_init(ndef_struct_t *ndef_message, bool async, bool forceI
 #endif
 
 #ifdef HAVE_SE_TOUCH
-#ifdef HAVE_TOUCH_DEBUG
+#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
 void io_seproxyhal_touch_read_sensi(uint8_t * sensi_data) {
   touch_read_sensitivity(sensi_data);
 }

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1813,7 +1813,7 @@ uint8_t touch_exclude_borders(uint8_t excluded_borders) {
   return (uint8_t)SVC_Call(SYSCALL_touch_exclude_borders_ID, parameters);
 }
 
-#ifdef HAVE_TOUCH_DEBUG
+#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
 void touch_read_sensitivity(uint8_t *sensi_data) {
   unsigned int parameters[1] = {(unsigned int) sensi_data};
   SVC_Call(SYSCALL_touch_read_sensi_ID, parameters);


### PR DESCRIPTION

## Description

Place touch read sensi syscall usage under HAVE_TOUCH_READ_SENSI_SYSCALL ifdef

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Read sensi syscall was defined under HAVE_TOUCH_DEBUG ifdef, applications that were using this syscall must update their makefile with replacing HAVE_TOUCH_DEBUG with HAVE_TOUCH_READ_SENSI_SYSCALL
