### PR TITLE
Add crypto helpers

### DIFF
--- a/lib_standard_app/crypto_helpers.c
+++ b/lib_standard_app/crypto_helpers.c
@@ -1,0 +1,175 @@
+/*****************************************************************************
+ *   Ledger SDK.
+ *   (c) 2023 Ledger SAS.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *****************************************************************************/
+#include <stdint.h>   // uint*_t
+#include <string.h>   // memset, explicit_bzero
+#include <stdbool.h>  // bool
+
+#include "cx.h"
+#include "os.h"
+
+cx_err_t bip32_derive_with_seed_init_privkey_256(unsigned int derivation_mode,
+                                                 cx_curve_t curve,
+                                                 const uint32_t *path,
+                                                 size_t path_len,
+                                                 cx_ecfp_256_private_key_t *privkey,
+                                                 uint8_t *chain_code,
+                                                 unsigned char *seed,
+                                                 size_t seed_len) {
+    cx_err_t error = CX_OK;
+    uint8_t raw_privkey[64]; // Allocate 64 bytes to respect Syscall API but only 32 will be used
+    size_t length;
+
+    // Check curve key length
+    CX_CHECK(cx_ecdomain_parameters_length(curve, &length));
+    if (length != 32) {
+        error = CX_EC_INVALID_CURVE;
+        goto end;
+    }
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(os_derive_bip32_with_seed_no_throw(derivation_mode,
+                                                curve,
+                                                path,
+                                                path_len,
+                                                raw_privkey,
+                                                chain_code,
+                                                seed,
+                                                seed_len));
+
+    // Init privkey from raw
+    CX_CHECK(cx_ecfp_init_private_key_no_throw(curve, raw_privkey, length, privkey));
+
+end:
+    explicit_bzero(&raw_privkey, sizeof(raw_privkey));
+
+    if (error != CX_OK) {
+        explicit_bzero(&privkey, sizeof(privkey));
+    }
+    return error;
+}
+
+cx_err_t bip32_derive_with_seed_get_pubkey_256(unsigned int derivation_mode,
+                                               cx_curve_t curve,
+                                               const uint32_t *path,
+                                               size_t path_len,
+                                               uint8_t raw_pubkey[static 65],
+                                               uint8_t *chain_code,
+                                               cx_md_t hashID,
+                                               unsigned char *seed,
+                                               size_t seed_len) {
+    cx_err_t error = CX_OK;
+
+    cx_ecfp_256_private_key_t privkey;
+    cx_ecfp_256_public_key_t pubkey;
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(bip32_derive_with_seed_init_privkey_256(derivation_mode,
+                                                     curve,
+                                                     path,
+                                                     path_len,
+                                                     &privkey,
+                                                     chain_code,
+                                                     seed,
+                                                     seed_len));
+
+    // Generate associated pubkey
+    CX_CHECK(cx_ecfp_generate_pair2_no_throw(curve, &pubkey, &privkey, true, hashID));
+
+    // Check pubkey length then copy it to raw_pubkey
+    if (pubkey.W_len != 65) {
+        error = CX_EC_INVALID_CURVE;
+        goto end;
+    }
+    memmove(raw_pubkey, pubkey.W, pubkey.W_len);
+
+end:
+    explicit_bzero(&privkey, sizeof(privkey));
+    return error;
+}
+
+cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(unsigned int derivation_mode,
+                                                    cx_curve_t curve,
+                                                    const uint32_t *path,
+                                                    size_t path_len,
+                                                    uint32_t sign_mode,
+                                                    cx_md_t hashID,
+                                                    const uint8_t *hash,
+                                                    size_t hash_len,
+                                                    uint8_t *sig,
+                                                    size_t *sig_len,
+                                                    uint32_t *info,
+                                                    unsigned char *seed,
+                                                    size_t seed_len) {
+    cx_err_t error = CX_OK;
+    cx_ecfp_256_private_key_t privkey;
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(bip32_derive_with_seed_init_privkey_256(derivation_mode,
+                                                     curve,
+                                                     path,
+                                                     path_len,
+                                                     &privkey,
+                                                     NULL,
+                                                     seed,
+                                                     seed_len));
+
+    CX_CHECK(cx_ecdsa_sign_no_throw(&privkey, sign_mode, hashID, hash, hash_len, sig, sig_len, info));
+
+end:
+    explicit_bzero(&privkey, sizeof(privkey));
+    return error;
+}
+
+cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(unsigned int derivation_mode,
+                                                    cx_curve_t curve,
+                                                    const uint32_t *path,
+                                                    size_t path_len,
+                                                    cx_md_t hashID,
+                                                    const uint8_t *hash,
+                                                    size_t hash_len,
+                                                    uint8_t *sig,
+                                                    size_t *sig_len,
+                                                    unsigned char *seed,
+                                                    size_t seed_len) {
+    cx_err_t error = CX_OK;
+    cx_ecfp_256_private_key_t privkey;
+    size_t size;
+
+    if (sig_len == NULL) {
+        error = CX_INVALID_PARAMETER_VALUE;
+        goto end;
+    }
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(bip32_derive_with_seed_init_privkey_256(derivation_mode,
+                                                     curve,
+                                                     path,
+                                                     path_len,
+                                                     &privkey,
+                                                     NULL,
+                                                     seed,
+                                                     seed_len));
+
+    CX_CHECK(cx_eddsa_sign_no_throw(&privkey, hashID, hash, hash_len, sig, *sig_len));
+
+    CX_CHECK(cx_ecdomain_parameters_length(curve, &size));
+    *sig_len = size * 2;
+
+end:
+    explicit_bzero(&privkey, sizeof(privkey));
+    return error;
+}

--- a/lib_standard_app/crypto_helpers.h
+++ b/lib_standard_app/crypto_helpers.h
@@ -1,0 +1,341 @@
+#pragma once
+
+#include <stdint.h>  // uint*_t
+
+#include "os.h"
+#include "cx.h"
+
+/**
+ * @brief   Gets the private key from the device seed using the specified bip32 path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL / HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] privkey         Generated private key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be NULL.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+cx_err_t bip32_derive_with_seed_init_privkey_256(unsigned int derivation_mode,
+                                                 cx_curve_t curve,
+                                                 const uint32_t *path,
+                                                 size_t path_len,
+                                                 cx_ecfp_256_private_key_t *privkey,
+                                                 uint8_t *chain_code,
+                                                 unsigned char *seed,
+                                                 size_t seed_len);
+
+/**
+ * @brief   Gets the private key from the device seed using the specified bip32 path.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] privkey         Generated private key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be NULL.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+static inline cx_err_t bip32_derive_init_privkey_256(cx_curve_t curve,
+                                                     const uint32_t *path,
+                                                     size_t path_len,
+                                                     cx_ecfp_256_private_key_t *privkey,
+                                                     uint8_t *chain_code) {
+    return bip32_derive_with_seed_init_privkey_256(HDW_NORMAL,
+                                                   curve,
+                                                   path,
+                                                   path_len,
+                                                   privkey,
+                                                   chain_code,
+                                                   NULL,
+                                                   0);
+}
+
+/**
+ * @brief   Gets the public key from the device seed using the specified bip32 path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL / HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] raw_pubkey      Buffer where to store the public key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be NULL.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+cx_err_t bip32_derive_with_seed_get_pubkey_256(unsigned int derivation_mode,
+                                               cx_curve_t curve,
+                                               const uint32_t *path,
+                                               size_t path_len,
+                                               uint8_t raw_pubkey[static 65],
+                                               uint8_t *chain_code,
+                                               cx_md_t hashID,
+                                               unsigned char *seed,
+                                               size_t seed_len);
+
+/**
+ * @brief   Gets the public key from the device seed using the specified bip32 path.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] raw_pubkey      Buffer where to store the public key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be NULL.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+static inline cx_err_t bip32_derive_get_pubkey_256(cx_curve_t curve,
+                                                   const uint32_t *path,
+                                                   size_t path_len,
+                                                   uint8_t raw_pubkey[static 65],
+                                                   uint8_t *chain_code,
+                                                   cx_md_t hashID) {
+    return bip32_derive_with_seed_get_pubkey_256(HDW_NORMAL,
+                                                 curve,
+                                                 path,
+                                                 path_len,
+                                                 raw_pubkey,
+                                                 chain_code,
+                                                 hashID,
+                                                 NULL,
+                                                 0);
+}
+
+/**
+ * @brief   Sign a hash with ecdsa using the device seed derived from the specified bip32 path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL / HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the group order size.
+ *                             Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *                             The signature is encoded in TLV:  **30 || L || 02 || Lr || r || 02 || Ls || s**
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with signature length.
+ *
+ * @param[out] info            Set with CX_ECCINFO_PARITY_ODD if the y-coordinate is odd when computing **[k].G**.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(unsigned int derivation_mode,
+                                                    cx_curve_t curve,
+                                                    const uint32_t *path,
+                                                    size_t path_len,
+                                                    uint32_t sign_mode,
+                                                    cx_md_t hashID,
+                                                    const uint8_t *hash,
+                                                    size_t hash_len,
+                                                    uint8_t *sig,
+                                                    size_t *sig_len,
+                                                    uint32_t *info,
+                                                    unsigned char *seed,
+                                                    size_t seed_len);
+
+/**
+ * @brief   Sign a hash with ecdsa using the device seed derived from the specified bip32 path.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL / HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the group order size.
+ *                             Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *                             The signature is encoded in TLV:  **30 || L || 02 || Lr || r || 02 || Ls || s**
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with signature length.
+ *
+ * @param[out] info            Set with CX_ECCINFO_PARITY_ODD if the y-coordinate is odd when computing **[k].G**.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+static inline cx_err_t bip32_derive_ecdsa_sign_hash_256(cx_curve_t curve,
+                                                        const uint32_t *path,
+                                                        size_t path_len,
+                                                        uint32_t sign_mode,
+                                                        cx_md_t hashID,
+                                                        const uint8_t *hash,
+                                                        size_t hash_len,
+                                                        uint8_t *sig,
+                                                        size_t *sig_len,
+                                                        uint32_t *info) {
+    return bip32_derive_with_seed_ecdsa_sign_hash_256(HDW_NORMAL,
+                                                      curve,
+                                                      path,
+                                                      path_len,
+                                                      sign_mode,
+                                                      hashID,
+                                                      hash,
+                                                      hash_len,
+                                                      sig,
+                                                      sig_len,
+                                                      info,
+                                                      NULL,
+                                                      0);
+}
+
+/**
+ * @brief   Sign a hash with eddsa using the device seed derived from the specified bip32 path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL / HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the group order size.
+ *                             Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with signature length.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(unsigned int derivation_mode,
+                                                    cx_curve_t curve,
+                                                    const uint32_t *path,
+                                                    size_t path_len,
+                                                    cx_md_t hashID,
+                                                    const uint8_t *hash,
+                                                    size_t hash_len,
+                                                    uint8_t *sig,
+                                                    size_t *sig_len,
+                                                    unsigned char *seed,
+                                                    size_t seed_len);
+
+/**
+ * @brief   Sign a hash with eddsa using the device seed derived from the specified bip32 path.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the group order size.
+ *                             Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with signature length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+static inline cx_err_t bip32_derive_eddsa_sign_hash_256(cx_curve_t curve,
+                                                        const uint32_t *path,
+                                                        size_t path_len,
+                                                        cx_md_t hashID,
+                                                        const uint8_t *hash,
+                                                        size_t hash_len,
+                                                        uint8_t *sig,
+                                                        size_t *sig_len) {
+    return bip32_derive_with_seed_eddsa_sign_hash_256(HDW_NORMAL,
+                                                      curve,
+                                                      path,
+                                                      path_len,
+                                                      hashID,
+                                                      hash,
+                                                      hash_len,
+                                                      sig,
+                                                      sig_len,
+                                                      NULL,
+                                                      0);
+}


### PR DESCRIPTION
## Description

- os_seed.h: Add no_throw wrappers on os_perso_derive syscalls
- lib_standard_app: Add bip32_crypto helpers

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
