### PR TITLE
Fat: Adapt icon2glyph and buffers for 4BPP app icons

### DIFF
--- a/lib_nbgl/include/nbgl_types.h
+++ b/lib_nbgl/include/nbgl_types.h
@@ -120,6 +120,7 @@ typedef enum {
 typedef enum {
     NBGL_NO_COMPRESSION = 0, ///< no compression, raw data
     NBGL_GZLIB_COMPRESSION,  ///< gzlib compression
+    NBGL_RLE_COMPRESSION,    ///< RLE compression
     NB_NBGL_COMPRESSION      ///< Number of NBGL_COMPRESSION enums
 } nbgl_compression_t;
 

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -408,7 +408,7 @@ static void draw_image(nbgl_image_t* obj, nbgl_obj_t *prevObj, bool computePosit
     colorMap = ((WHITE<<6)|(LIGHT_GRAY<<4)|(DARK_GRAY<<2)|BLACK);
   }
   else {
-    colorMap = INVALID_COLOR_MAP;
+    colorMap = obj->foregroundColor;
   }
   if (!iconDetails->isFile) {
     nbgl_frontDrawImage((nbgl_area_t*)obj, (uint8_t*)iconDetails->bitmap, NO_TRANSFORMATION, colorMap);

--- a/lib_nbgl/tools/icon2glyph.py
+++ b/lib_nbgl/tools/icon2glyph.py
@@ -5,335 +5,334 @@ Converts the given icons, in bmp or gif format, to Stax compatible glyphs, as C 
 """
 
 import argparse
-import collections
-import colorsys
 import math
 import os
-import struct
 import binascii
 import sys
 import traceback
 import gzip
 
 from enum import IntEnum
-from PIL import Image
+from PIL import Image as img, ImageOps
+from PIL.Image import Image
+from typing import Tuple, Optional
+
+from nbgl_rle import Rle1bpp, Rle4bpp
+
 
 class NbglFileCompression(IntEnum):
     NoCompression = 0
     Gzlib = 1,
     Rle = 2
 
-MAX_COLORS = 16
-
 
 def is_power2(n):
     return n != 0 and ((n & (n - 1)) == 0)
 
-# returns true if the given image size should be compressed
-def toCompress(width, height):
-    return (width >= 64) and (height >= 64)
 
-def get4BPPval(color_index):
-    pixel_val = color_index[0]<<16+color_index[1]<<8+color_index[0]
-    if (pixel_val > 0xF0F0F0):
-        return 0xF
-    elif (pixel_val > 0xE0E0E0):
-        return 0xE
-    elif (pixel_val > 0xD0D0D0):
-        return 0xD
-    elif (pixel_val > 0xC0C0C0):
-        return 0xC
-    elif (pixel_val > 0xB0B0B0):
-        return 0xB
-    elif (pixel_val > 0xA0A0A0):
-        return 0xA
-    elif (pixel_val > 0x909090):
-        return 0x9
-    elif (pixel_val > 0x808080):
-        return 0x8
-    elif (pixel_val > 0x707070):
-        return 0x7
-    elif (pixel_val > 0x606060):
-        return 0x6
-    elif (pixel_val > 0x505050):
-        return 0x5
-    elif (pixel_val > 0x404040):
-        return 0x4
-    elif (pixel_val > 0x303030):
-        return 0x3
-    elif (pixel_val > 0x202020):
-        return 0x2
-    elif (pixel_val > 0x101010):
-        return 0x1
-    else:
-        return 0
+def open_image(file_path) -> Optional[Tuple[Image, int]]:
+    """
+    Open and prepare image for processing.
+    Returns None if image has too many colors or does not exist.
+    else returns tuple: Image, bpp
+    """
+    # Check existente
+    if not os.path.exists(file_path):
+        sys.stderr.write("Error: {} does not exist!".format(file_path) + "\n")
 
-def get2BPPval(color_index):
-    pixel_val = color_index[0]<<16+color_index[1]<<8+color_index[0]
-    if (pixel_val == 0xFFFFFF):
-        return 3
-    elif (pixel_val > 0x808080):
-        return 2
-    elif (pixel_val > 0x404080):
-        return 1
-    else:
-        return 0
+    # Load Image in mode L
+    im = img.open(file_path)
+    im.load()
+    im = im.convert('L')
 
-def get1BPPval(color_index):
-    pixel_val = color_index[0]<<16+color_index[1]<<8+color_index[0]
-    if (pixel_val > 0xF0F0F0):
-        return 0
-    else:
-        return 1
+    # Do not open image with more than 16 colors
+    num_colors = len(im.getcolors())
+    if num_colors > 16:
+        sys.stderr.write(
+            "Error: input file {} has too many colors".format(file_path) + "\n")
+        return None
 
-def image_to_packed_buffer(im, palette, bits_per_pixel):
-    width, height = im.size
+    # Compute bits_per_pixel
+    # Round number of colors to a power of 2
+    if not is_power2(num_colors):
+        num_colors = int(pow(2, math.ceil(math.log(num_colors, 2))))
+
+    bits_per_pixel = int(math.log(num_colors, 2))
+    if bits_per_pixel == 3:
+        bits_per_pixel = 4
+
+    # Invert if bpp is 1
+    if bits_per_pixel == 1:
+        im = ImageOps.invert(im)
+
+    return im, bits_per_pixel
+
+
+def image_to_packed_buffer(img, bpp: int):
+    """
+    Rotate and pack bitmap data of the character.
+    """
+    width, height = img.size
 
     current_byte = 0
     current_bit = 0
     image_data = []
-    if palette == None:
-        palette_func = {
-            1: get1BPPval, # palette for 1BPP
-            2: get2BPPval, # palette for 2BPP
-            4: get4BPPval, # palette for 4BPP
-        }
+    nb_colors = pow(2, bpp)
+    base_threshold = int(256 / nb_colors)
+    half_threshold = int(base_threshold / 2)
 
     # col first
     for col in reversed(range(width)):
         for row in range(height):
-            # Return an index in the indexed colors list for indexed address spaces
-            # left to right
-            # Perform implicit rotation here (0,0) is left top in BAGL, and generally left bottom for various canvas
-            color_index = im.getpixel((col, row))
+            # Return an index in the indexed colors list
+            # top to bottom
+            # Perform implicit rotation here (0,0) is left top in NBGL,
+            # and generally left bottom for various canvas
+            color_index = img.getpixel((col, row))
+            color_index = int((color_index + half_threshold) / base_threshold)
 
-            # Remap index by luminance
-            if palette == None:
-                color_index = palette_func[bits_per_pixel](color_index)
-            else:
-                if bits_per_pixel == 1:
-                    # be sure to saturate index to 1
-                    if (color_index > 1):
-                        color_index = 1
-                    # in Stax we want 1BPP to be 1 for Black and 0 for White, in GIF it's the opposite
-                    if palette[color_index] == 0:
-                        color_index = 1
-                    else:
-                        color_index = 0
-                else:
-                    color_index = palette[color_index]
+            if color_index >= nb_colors:
+                color_index = nb_colors - 1
 
             # le encoded
-            current_byte += color_index << ((8-bits_per_pixel)-current_bit)
-            current_bit += bits_per_pixel
+            current_byte += color_index << ((8-bpp)-current_bit)
+            current_bit += bpp
 
             if current_bit >= 8:
                 image_data.append(current_byte & 0xFF)
                 current_bit = 0
                 current_byte = 0
 
-        # Handle last byte if any
+    # Handle last byte if any
     if current_bit > 0:
         image_data.append(current_byte & 0xFF)
 
-    if toCompress(width,height):
-        output_buffer = apply_compression(image_data)
-        return format_image(output_buffer, width, height, bits_per_pixel, NbglFileCompression.Gzlib)
-    else:
-        return bytes(image_data)
+    return bytes(image_data)
 
-# returns a compressed version of the given pixels_buffer
-def apply_compression(pixels_buffer) -> bytes:
+
+# Compressions functions
+
+
+def rle_compress(im: Image, bpp) -> bytes:
+    """
+    Run RLE compression on input image
+    """
+    if bpp == 1:
+        return Rle1bpp.rle_1bpp(im)[1]
+    elif bpp == 2:
+        return None
+    elif bpp == 4:
+        return Rle4bpp.rle_4bpp(im)[1]
+
+
+def gzlib_compress(im: Image, bpp: int) -> bytes:
+    """
+    Run gzlib compression on input image
+    """
+    pixels_buffer = image_to_packed_buffer(im, bpp)
     output_buffer = []
     # cut into chunks of 2048 bytes max of uncompressed data (because decompression needs the full buffer)
     full_uncompressed_size = len(pixels_buffer)
     i = 0
-    while full_uncompressed_size>0:
-        chunk_size = min(2048,full_uncompressed_size)
+    while full_uncompressed_size > 0:
+        chunk_size = min(2048, full_uncompressed_size)
         tmp = bytes(pixels_buffer[i:i+chunk_size])
-        #print("len = %d"%len(tmp))
-        #print("0x%X"%tmp[chunk_size-1])
         compressed_buffer = gzip.compress(tmp, mtime=0)
-        output_buffer += [len(compressed_buffer)&0xFF, (len(compressed_buffer)>>8)&0xFF]
+        output_buffer += [len(compressed_buffer) & 0xFF,
+                          (len(compressed_buffer) >> 8) & 0xFF]
         output_buffer += compressed_buffer
         full_uncompressed_size -= chunk_size
-        i+=chunk_size
+        i += chunk_size
 
     return bytearray(output_buffer)
 
-# returns a "image file" version of the given compressed buffer
-def format_image(output_buffer: bytearray, width: int, height: int,
-                 bpp: int, compression: NbglFileCompression) -> bytes:
+
+NBGL_IMAGE_FILE_HEADER_SIZE = 8
+
+
+def compress(im: Image, bpp) -> Tuple[NbglFileCompression, bytes]:
+    """
+    Compute multiple compression methods on the input image,
+    and return a tuple containing:
+        - The best compression method achieved
+        - The associated compressed bytes
+    """
+    compressed_bufs = {
+        NbglFileCompression.NoCompression: image_to_packed_buffer(im, bpp),
+        NbglFileCompression.Gzlib: gzlib_compress(im, bpp),
+        NbglFileCompression.Rle: rle_compress(im, bpp)
+    }
+
+    min_len = len(compressed_bufs[NbglFileCompression.NoCompression])
+    min_comp = NbglFileCompression.NoCompression
+
+    for compression, buffer in compressed_bufs.items():
+        final_length = len(buffer)
+        if compression != NbglFileCompression.NoCompression:
+            final_length += NBGL_IMAGE_FILE_HEADER_SIZE
+
+        if min_len > final_length:
+            min_len = final_length
+            min_comp = compression
+
+    return min_comp, compressed_bufs[min_comp]
+
+
+def convert_to_image_file(image_data: bytes, width: int, height: int,
+                          bpp: int, compression: NbglFileCompression) -> bytes:
+    """
+    Returns an image file version of the input image data and parameters
+    """
     BPP_FORMATS = {
         1: 0,
         2: 1,
         4: 2
     }
 
-    result = [width&0xFF, width>>8,
-              height&0xFF, height>>8,
-              (BPP_FORMATS[bpp]<<4) | compression,
-              len(output_buffer)&0xFF, (len(output_buffer)>>8)&0xFF, (len(output_buffer)>>16)&0xFF]
-    result.extend(output_buffer)
-    return bytearray(result)
+    result = [width & 0xFF, width >> 8,
+              height & 0xFF, height >> 8,
+              (BPP_FORMATS[bpp] << 4) | compression,
+              len(image_data) & 0xFF, (len(image_data) >> 8) & 0xFF, (len(image_data) >> 16) & 0xFF]
+    result.extend(image_data)
+    return bytes(bytearray(result))
 
 
-def main():
-    parser = argparse.ArgumentParser(description='Generate source code for NBGL icons.')
-    parser.add_argument('image_file', help="Icons to process", nargs='+')
-    parser.add_argument('--max_width', type=int, default=4096, help="Max width")
-    parser.add_argument('--max_height', type=int, default=4096, help="Max height")
-    parser.add_argument('--hexbitmaponly', action='store_true')
-    parser.add_argument('--glyphcheader', action='store_true')
-    parser.add_argument('--glyphcfile', action='store_true')
-    parser.add_argument('--errors', action='store_true')
-    args = parser.parse_args()
+def compute_app_icon_data(im: Image, bpp) -> Tuple[bool, bytes]:
+    """
+    Process image as app icon:
+    - App icon are always image file
+    - Compression is not limited to 64x64
+    """
+    compression, image_data = compress(im, bpp)
+    is_file = True
+    width, height = im.size
+    image_data = convert_to_image_file(
+        image_data, width, height, bpp, compression)
+    return is_file, image_data
 
-    exitcode = 0
-    for file in args.image_file:
-        if not os.path.exists(file):
-            sys.stderr.write("Error: {} does not exist!".format(file) + "\n")
-            if args.errors:
-                exitcode = -1
-            continue
 
-    if args.glyphcfile:
+def compute_regular_icon_data(im: Image, bpp) -> Tuple[bool, bytes]:
+    """
+    Process image as regular icon:
+    - Regular icon are image file only if compressed
+    - Compression is limited to images bigger than 64x64
+    """
+    width, height = im.size
+    # We do not compress regular icon smaller than 64x64 because
+    # these smaller images are the one being transformed through
+    # symmetry. And the symmetry is not implemented for compressed
+    # icons (yet).
+    if (width >= 64) and (height >= 64):
+        compression, image_data = compress(im, bpp)
+        if compression != NbglFileCompression.NoCompression:
+            is_file = True
+            image_data = convert_to_image_file(
+                image_data, width, height, bpp, compression)
+    else:
+        is_file = False
+        image_data = image_to_packed_buffer(im, bpp)
+    return is_file, image_data
+
+# glyphs.c/.h chunk files generators
+
+
+def print_glyphfile_top(add_include: bool):
+    if add_include:
         print("#include \"glyphs.h\"")
-    if args.glyphcfile or args.glyphcheader:
-        print("""#ifdef HAVE_NBGL
+    print(
+        """\
+#ifdef HAVE_NBGL
 #include \"nbgl_types.h\"
 #endif // HAVE_NBGL
 """)
 
-    colors_array = {}
+
+def print_glyphcfile_data(image_name, bpp, image_data):
+    print("uint8_t const C_{0}_bitmap[] = {{".format(image_name))
+    for i in range(0, len(image_data), 16):
+        print("  " + ", ".join("0x{0:02x}".format(c)
+                               for c in image_data[i:i+16]) + ",")
+    print("};")
+    print("""#ifdef HAVE_NBGL
+const nbgl_icon_details_t C_{0} = {{ GLYPH_{0}_WIDTH, GLYPH_{0}_HEIGHT, NBGL_BPP_{1}, GLYPH_{0}_ISFILE, C_{0}_bitmap }};
+#endif // HAVE_NBGL
+""".format(image_name, bpp))
+
+
+def print_glyphcheader_data(image_name, bpp, width, height, is_file, image_data):
+    if is_file:
+        is_file = 'true'
+    else:
+        is_file = 'false'
+
+    print("""#ifndef GLYPH_{0}_BPP
+    #define GLYPH_{0}_WIDTH {1}
+    #define GLYPH_{0}_HEIGHT {2}
+    #define GLYPH_{0}_ISFILE {3}
+    #define GLYPH_{0}_BPP {4}""".format(image_name, width, height, is_file, bpp))
+    print("  extern uint8_t const C_{0}_bitmap[{1:d}];".format(
+        image_name, len(image_data)))
+    print("""  #ifdef HAVE_NBGL
+    extern const nbgl_icon_details_t C_{0};
+  #endif // HAVE_NBGL
+#endif // GLYPH_{0}_BPP
+""".format(image_name))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate source code for NBGL icons.')
+    parser.add_argument('image_file', help="Icons to process", nargs='+')
+    parser.add_argument('--hexbitmaponly', action='store_true')
+    parser.add_argument('--glyphcheader', action='store_true')
+    parser.add_argument('--glyphcfile', action='store_true')
+    args = parser.parse_args()
+
+    # Print C header
+    if args.glyphcfile or args.glyphcheader:
+        print_glyphfile_top(args.glyphcfile)
+
     processed_image_names = []
     for file in args.image_file:
         try:
-            im = Image.open(file)
-
-            im.load()
-
-            width, height = im.size
-            width = min(width, args.max_width)
-            height = min(height, args.max_height)
-
+            # Get image name
             image_name = os.path.splitext(os.path.basename(file))[0]
+
             # if image name has already been done, then don't do it twice
             if image_name in processed_image_names:
                 continue
             processed_image_names.append(image_name)
 
-            num_colors = len(im.getcolors())
-            if num_colors > MAX_COLORS:
-                sys.stderr.write("Error: input file {} has too many colors".format(file) + "\n")
-                if args.errors:
-                    exitcode = -1
+            # Open image in luminance format
+            opened = open_image(file)
+            if opened is not None:
+                im, bpp = opened
+            else:
                 continue
-
-            # Round number of colors to a power of 2
-            if not is_power2(num_colors):
-                num_colors = int(pow(2, math.ceil(math.log(num_colors, 2))))
-
-            bits_per_pixel = int(math.log(num_colors, 2))
-            if bits_per_pixel == 3:
-                bits_per_pixel = 4
-
-            # if palettized, create palette
-            if im.mode == 'P':
-                # Reorder color map by luminance
-                palette = im.getpalette()
-                opalette = {}
-                for i in range(num_colors):
-                    red, green, blue = palette[3 * i: 3 * i + 3]
-                    hue, saturation, value = colorsys.rgb_to_hsv(red / 255., green / 255., blue / 255.)
-
-                    # Several colors could have the same luminance
-                    if value * 255. not in opalette:
-                        opalette[value * 255.] = []
-                    opalette[value * 255.].append([i, (red << 16) + (green << 8) + blue])
-                opalette = collections.OrderedDict(sorted(opalette.items()))
-
-                # Compute the remapping index
-                i = 0
-                new_indices = {}
-                new_palette = []
-                color_array_serialized = ""
-                for lum, values in opalette.items():
-                    # Old index to new index
-                    for v in values:
-                        new_indices[v[0]] = i
-                        new_palette.append(v[1])
-                        color_array_serialized += hex(v[1])
-                        i += 1
 
             if args.hexbitmaponly:
-                # if not palettized
-                if im.mode != 'P':
-                    image_data = image_to_packed_buffer(im, None, bits_per_pixel)
-                else:
-                    image_data = image_to_packed_buffer(im, new_indices, bits_per_pixel)
-
-                image_file = \
-                    format_image(image_data, width, height, bits_per_pixel, NbglFileCompression.NoCompression)
-                print(binascii.hexlify(image_file).decode('utf-8'))
-                continue
-
+                # Prepare and print app icon data
+                _, image_data = compute_app_icon_data(im, bpp)
+                print(binascii.hexlify(image_data).decode('utf-8'))
             else:
-                # General definitions
-                if not args.glyphcfile:
-                    if toCompress(width,height):
-                        isFile='true'
-                    else:
-                        isFile='false'
-                    print("""#ifndef GLYPH_{0}_BPP
-  #define GLYPH_{0}_WIDTH {1}
-  #define GLYPH_{0}_HEIGHT {2}
-  #define GLYPH_{0}_ISFILE {3}
-  #define GLYPH_{0}_BPP {4}""".format(image_name, width, height, isFile, bits_per_pixel))
+                # Prepare and print regular icon data
+                width, height = im.size
+                is_file, image_data = compute_regular_icon_data(im, bpp)
 
-                # Print image data
+                if args.glyphcfile:
+                    print_glyphcfile_data(image_name, bpp, image_data)
+
                 if args.glyphcheader:
-                    # if not palettized
-                    if im.mode != 'P':
-                        image_data = image_to_packed_buffer(im, None, bits_per_pixel)
-                    else:
-                        image_data = image_to_packed_buffer(im, new_indices, bits_per_pixel)
-                    print("  extern uint8_t const C_{0}_bitmap[{1:d}];".format(image_name, len(image_data)))
-                else:
-                    print("uint8_t const C_{0}_bitmap[] = {{".format(image_name))
+                    print_glyphcheader_data(
+                        image_name, bpp, width, height, is_file, image_data)
 
-                    # Packed, row preferred
-                    if not args.glyphcheader:
-                        # if not palettized
-                        if im.mode != 'P':
-                            image_data = image_to_packed_buffer(im, None, bits_per_pixel)
-                        else:
-                            image_data = image_to_packed_buffer(im, new_indices, bits_per_pixel)
-                        for i in range(0, len(image_data), 16):
-                            print("  " + ", ".join("0x{0:02x}".format(c) for c in image_data[i:i+16]) + ",")
-                        print("};")
-
-            if args.glyphcheader:
-                print("""  #ifdef HAVE_NBGL
-    extern const nbgl_icon_details_t C_{0};
-  #endif // HAVE_NBGL
-#endif // GLYPH_{0}_BPP
-""".format(image_name))
-            elif args.glyphcfile:
-                print("""#ifdef HAVE_NBGL
-const nbgl_icon_details_t C_{0} = {{ GLYPH_{0}_WIDTH, GLYPH_{0}_HEIGHT, NBGL_BPP_{1}, GLYPH_{0}_ISFILE, C_{0}_bitmap }};
-#endif // HAVE_NBGL
-""".format(image_name, bits_per_pixel))
-        except:
-            sys.stderr.write("Exception while processing {}\n".format(file))
+        except Exception as e:
+            sys.stderr.write(
+                "Exception while processing {} {}\n".format(file), e)
             try:
                 traceback.print_tb()
             except:
                 pass
-            if args.errors:
-                exitcode = -1
-    if exitcode != 0:
-        sys.exit(exitcode)
 
 
 if __name__ == "__main__":

--- a/lib_nbgl/tools/nbgl_rle.py
+++ b/lib_nbgl/tools/nbgl_rle.py
@@ -1,0 +1,333 @@
+from typing import List, Tuple
+
+NB_MIN_PACKED_PIXELS = 3
+NB_MAX_PACKED_PIXELS = 6
+class Rle4bpp():
+
+    @staticmethod
+    def image_to_pixels(img, bpp: int) -> List[Tuple]:
+        """
+        Rotate and pack bitmap data of the character.
+        """
+        width, height = img.size
+
+        color_indexes = []
+        nb_colors = pow(2, bpp)
+        base_threshold = int(256 / nb_colors)
+        half_threshold = int(base_threshold / 2)
+
+        # col first
+        for col in reversed(range(width)):
+            for row in range(height):
+                # Return an index in the indexed colors list
+                # top to bottom
+                # Perform implicit rotation here (0,0) is left top in NBGL,
+                # and generally left bottom for various canvas
+                color_index = img.getpixel((col, row))
+                color_index = int((color_index + half_threshold) / base_threshold)
+
+                if color_index >= nb_colors:
+                    color_index = nb_colors - 1
+
+                color_indexes.append(color_index)
+
+        return color_indexes
+
+
+    @staticmethod
+    def pixels_to_occurrences(pixels: List[int]) -> List[Tuple]:
+        occurrences = []
+        for pixel in pixels:
+            if len(occurrences) == 0:
+                occurrences.append((pixel, 1))
+            else:
+                color, cnt = occurrences[-1]
+                if pixel == color:
+                    occurrences[-1] = (pixel, cnt+1)
+                else:
+                    occurrences.append((pixel, 1))
+        return occurrences
+
+    # Fetch next single pixels that can be packed
+    @classmethod
+    def fetch_next_single_pixels(cls, occurrences: List[Tuple[int, int]]) -> List[int]:
+        result = []
+        for occurrence in occurrences:
+            color, cnt = occurrence
+            if cnt >= 2:
+                break
+            else:
+                result.append(color)
+
+        # Ensure pixels can be packed by groups
+        nb_pixels = len(result)
+        if (nb_pixels % NB_MAX_PACKED_PIXELS < NB_MIN_PACKED_PIXELS):
+            return result[0:(nb_pixels - nb_pixels%NB_MIN_PACKED_PIXELS)]
+        return result
+
+    # Generate bytes from a list of single pixels
+    def generate_packed_single_pixels_bytes(packed_occurences: List[int]) -> bytes:
+        assert len(packed_occurences) >= 3
+        assert len(packed_occurences) <= 6
+        header = (0b10 << 2) | (len(packed_occurences) - 3)
+        nibbles = [header]
+        for occurrence in packed_occurences:
+            nibbles.append(occurrence)
+
+        result = []
+        for i, nibble in enumerate(nibbles):
+            if (i % 2) == 0:
+                result.append(nibble << 4)
+            else:
+                result[-1] += nibble
+        return bytes(result)
+
+    @classmethod
+    def handle_packed_pixels(cls, packed_occurences: List[int]) -> bytes:
+        assert len(packed_occurences) >= 3
+        result = bytes()
+        for i in range(0, len(packed_occurences), NB_MAX_PACKED_PIXELS):
+            result += cls.generate_packed_single_pixels_bytes(packed_occurences[i:i+NB_MAX_PACKED_PIXELS])
+        return result
+
+    @staticmethod
+    def handle_white_occurrence(occurrence: Tuple[int, int]) -> bytes:
+        _, cnt = occurrence
+        unit_cnt_max = 64
+        result = []
+
+        for i in range(0, cnt, unit_cnt_max):
+            diff_cnt = cnt - i
+            if diff_cnt > unit_cnt_max:
+                i_cnt = unit_cnt_max
+            else:
+                i_cnt = diff_cnt
+
+            result.append((0b11 << 6) | (i_cnt-1))
+        return bytes(result)
+
+    @staticmethod
+    def handle_non_white_occurrence(occurrence: Tuple[int, int]) -> bytes:
+        color, cnt = occurrence
+        unit_cnt_max = 8
+        result = []
+
+        for i in range(0, cnt, unit_cnt_max):
+            diff_cnt = cnt - i
+            if diff_cnt > unit_cnt_max:
+                i_cnt = unit_cnt_max
+            else:
+                i_cnt = diff_cnt
+
+            result.append((0 << 7) | (i_cnt-1) << 4 | color)
+
+        return bytes(result)
+
+    @classmethod
+    def occurrences_to_rle(cls, occurrences: Tuple[int, int], bpp: int) -> bytes:
+        result = bytes()
+        WHITE_COLOR = pow(2, bpp) - 1
+        i = 0
+        while i < len(occurrences):
+            # Check if next occurrences are packable in single occurrences
+            single_pixels = cls.fetch_next_single_pixels(occurrences[i:])
+            if len(single_pixels) > 0:
+                # Pack single occurrences
+                result += cls.handle_packed_pixels(single_pixels)
+                i += len(single_pixels)
+            else:
+                # Encode next occurrence
+                occurrence = occurrences[i]
+                color, _ = occurrence
+                if color == WHITE_COLOR:
+                    result += cls.handle_white_occurrence(occurrence)
+                else:
+                    result += cls.handle_non_white_occurrence(occurrence)
+                i += 1
+        return result
+
+    @classmethod
+    def rle_4bpp(cls, img) -> bytes:
+        bpp = 4
+        pixels = cls.image_to_pixels(img, bpp)
+        occurrences = cls.pixels_to_occurrences(pixels)
+        return 1, cls.occurrences_to_rle(occurrences, bpp)
+
+# -----------------------------------------------------------------------------
+class Rle1bpp():
+    """
+    Class handling custom RLE encoding, optimized for 1PP.
+    The generated bytes will contain alternances counts ZZZZOOOO with
+    - ZZZZ: number of consecutives 0, from 0 to 15
+    - OOOO: number of consecutives 1, from 0 to 15
+    """
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def image_to_pixels(img):
+        """
+        Rotate and pack bitmap data of the character.
+        return an array of pixels values.
+        """
+        width, height = img.size
+
+        pixels = []
+        # Intensity level value to be considered a white pixel
+        white_threshold = 128
+        white_pixel = 1
+        black_pixel = 0
+
+        # col first
+        for col in reversed(range(width)):
+            for row in range(height):
+                # Return an index in the indexed colors list (0 or 1, here)
+                # top to bottom
+                # Perform implicit rotation here (0,0) is left top in NBGL,
+                # and generally left bottom for various canvas
+                if img.getpixel((col, row)) >= white_threshold:
+                    pixels.append(white_pixel)
+                else:
+                    pixels.append(black_pixel)
+
+        return pixels
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def encode_pass1(data):
+        """
+        Encode array of values using 'normal' RLE.
+        Return an array of tuples containing (repeat, val)
+        """
+        output = []
+        previous_value = -1
+        count = 0
+        for value in data:
+            # Same value than before?
+            if value == previous_value:
+                count += 1
+            else:
+                # Store previous result
+                if count:
+                    pair = (count, previous_value)
+                    output.append(pair)
+                # Start a new count
+                previous_value = value
+                count = 1
+
+        # Store previous result
+        if count:
+            pair = (count, previous_value)
+            output.append(pair)
+
+        return output
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def encode_pass2(pairs):
+        """
+        Encode alternance counts between pixels (nb of 0, then nb of 1, etc)
+        The generated packed values will contain ZZZZOOOO ZZZZOOOO with
+        - ZZZZ: number of consecutives 0, from 0 to 15
+        - OOOO: number of consecutives 1, from 0 to 15
+        """
+        max_count = 15
+        # First step: store alternances, and split if count > 15
+        next_pixel = 0
+        alternances = []
+        for repeat, value in pairs:
+            # Store a count of 0 pixel if next pixel is not the one expected
+            if value != next_pixel:
+                alternances.append(0)
+                next_pixel ^= 1
+
+            while repeat > max_count:
+                # Store 15 pixels of value next_pixel
+                alternances.append(max_count)
+                repeat -= max_count
+                # Store 0 pixel of alternate value
+                alternances.append(0)
+
+            if repeat:
+                alternances.append(repeat)
+                next_pixel ^= 1
+
+        # Now read all those values and store them into quartets
+        output = bytes()
+        index = 0
+
+        while index < len(alternances):
+            zeros = alternances[index]
+            index += 1
+            if index < len(alternances):
+                ones = alternances[index]
+                index += 1
+            else:
+                ones = 0
+
+            byte = (zeros << 4) | ones
+            output += bytes([byte])
+
+        return output
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def remove_duplicates(pairs):
+        """
+        Check if there are some duplicated pairs (same values) and merge them.
+        """
+        index = len(pairs) - 1
+        while index >= 1:
+            repeat1, value1 = pairs[index-1]
+            repeat2, value2 = pairs[index]
+            # Do we have identical consecutives values?
+            if value1 == value2:
+                repeat1 += repeat2
+                # Merge them and remove last entry
+                pairs[index-1] = (repeat1, value1)
+                pairs.pop(index)
+            index -= 1
+
+        return pairs
+
+    # -------------------------------------------------------------------------
+    @classmethod
+    def decode_pass2(cls, data):
+        """
+        Decode packed bytes into array of tuples containing (repeat, value).
+        The provided packed values will contain ZZZZOOOO ZZZZOOOO with
+        - ZZZZ: number of consecutives 0, from 0 to 15
+        - OOOO: number of consecutives 1, from 0 to 15
+        """
+        pairs = []
+        for byte in data:
+            ones = byte & 0x0F
+            byte >>= 4
+            zeros = byte & 0x0F
+            if zeros:
+                pairs.append((zeros, 0))
+            if ones:
+                pairs.append((ones, 1))
+
+        # There was a limitation on repeat count => remove duplicates
+        pairs = cls.remove_duplicates(pairs)
+
+        return pairs
+
+    # -------------------------------------------------------------------------
+    @classmethod
+    def rle_1bpp(cls, img) -> bytes:
+        """
+        Input: image to compress
+        - convert the picture to an array of pixels
+        - convert the array of pixels to tuples of (repeat, value)
+        - encode using custom RLE
+        Output: array of compressed bytes
+        """
+        pixels = cls.image_to_pixels(img)
+        pairs = cls.encode_pass1(pixels)
+        encoded_data = cls.encode_pass2(pairs)
+
+        # Check if encoding/decoding is fine
+        pairs2 = cls.decode_pass2(encoded_data)
+        assert pairs == pairs2
+
+        return 1, encoded_data

--- a/lib_ux_stax/ux.h
+++ b/lib_ux_stax/ux.h
@@ -40,7 +40,7 @@ struct ux_state_s {
 
   asynchmodal_end_callback_t asynchmodal_end_callback;
 
-  char string_buffer[128];
+  char string_buffer[520];
 };
 
 


### PR DESCRIPTION
## Description

- App icons are now image files that can be up to 4BPP.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

App icons (generated with `icon2glyph --hexbitmaponly`) are now NBGL image files, and the OS will not accept app icons that are not compliant with the image file format and dimensions. 
