### PR TITLE
Fat: string_buffer array is BOLOS only

### DIFF
--- a/lib_ux_stax/ux.h
+++ b/lib_ux_stax/ux.h
@@ -40,7 +40,9 @@ struct ux_state_s {
 
   asynchmodal_end_callback_t asynchmodal_end_callback;
 
+#ifdef HAVE_BOLOS
   char string_buffer[520];
+#endif
 };
 
 


### PR DESCRIPTION
string_buffer is not used by SDK on Stax.
Ifdef it in order to save app RAM.

## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
