### PR TITLE
Fat: Restore string buffer size

### DIFF
--- a/lib_ux_stax/ux.h
+++ b/lib_ux_stax/ux.h
@@ -40,7 +40,7 @@ struct ux_state_s {
 
   asynchmodal_end_callback_t asynchmodal_end_callback;
 
-  char string_buffer[520];
+  char string_buffer[128];
 };
 
 


### PR DESCRIPTION
The OS does not need this buffer to be 520 anymore.

## Description

`string_buffer` had been made bigger, in order to implement 4BPP app icons.
Optimizations on OS side allow to restore this buffer to its original size.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

