### PR TITLE
NFC support 

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -28,6 +28,17 @@ endif
 endif
 
 #####################################################################
+#                               NFC                                 #
+#####################################################################
+ifeq ($(ENABLE_NFC), 1)
+ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME), TARGET_STAX))
+    STANDARD_APP_FLAGS = 0x200  # APPLICATION_FLAG_BOLOS_SETTINGS
+    DEFINES += HAVE_NFC
+    SDK_SOURCE_PATH += lib_nfc
+endif
+endif
+
+#####################################################################
 #                               DEBUG                               #
 #####################################################################
 ifneq ($(DEBUG), 0)

--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -30,6 +30,10 @@
 #include "os_print.h"
 #include "os_types.h"
 
+#ifdef HAVE_NFC
+#include "nfc.h"
+#endif
+
 #ifdef HAVE_SERIALIZED_NBGL
 #include "nbgl_serialize.h"
 #endif


### PR DESCRIPTION
## Description

Add NFC support in Makefile.standard_app
To enable NFC on a STAX app, please add the following enabler in your app Makefile
```
ENABLE_NFC = 1
```

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

