### PR TITLE
Fat: Fix nbgl_drawText for data larger than 255

### DIFF
--- a/lib_nbgl/src/nbgl_draw.c
+++ b/lib_nbgl/src/nbgl_draw.c
@@ -417,7 +417,7 @@ void nbgl_drawText(const nbgl_area_t *area, const char* text, uint16_t textLen, 
     uint8_t char_y_min = 0;
     uint8_t char_x_max = 0;
     uint8_t char_y_max = 0;
-    uint8_t char_byte_cnt = 0;
+    uint16_t char_byte_cnt = 0;
     uint8_t encoding = 0;
 
     unicode = nbgl_popUnicodeChar((const uint8_t **)&text, &textLen, &is_unicode);


### PR DESCRIPTION

## Description

'@' character compressed length was bigger than 255. The stored byte count on `nbgl_drawText` was on 8 bits only, making a badly rendered '@'. This variable is now an `uint16_t`.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

