### PR TITLE
Add a FORCE_RESET_BSS_SEGMENT API to reset the BSS segment to 0

### DIFF
--- a/include/os_utils.h
+++ b/include/os_utils.h
@@ -83,3 +83,6 @@ void *os_memmove(void *dest, const void *src, size_t n) __attribute__((deprecate
 void *os_memcpy(void *dest, const void *src, size_t n) __attribute__((deprecated));
 int os_memcmp(const void *s1, const void *s2, size_t n) __attribute__((deprecated));
 void *os_memset(void *s, int c, size_t n) __attribute__((deprecated));
+
+// This call will reset the value of the entire BSS segment
+void os_explicit_zero_BSS_segment(void);

--- a/src/os.c
+++ b/src/os.c
@@ -280,3 +280,12 @@ int bytes_to_lowercase_hex(char *out, size_t outl, const void *value, size_t len
   *out = 0;
   return 0;
 }
+
+// BSS start and end defines addresses
+extern void *_bss;
+extern void *_ebss;
+
+// This call will reset the value of the entire BSS segment
+void os_explicit_zero_BSS_segment(void) {
+  explicit_bzero(&_bss, ((uintptr_t)&_ebss) - ((uintptr_t)&_bss));
+}


### PR DESCRIPTION
## Description

Backport of https://github.com/LedgerHQ/ledger-secure-sdk/pull/283

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
