### PR TITLE
Fat: Post refresh power optimization

### DIFF
--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -299,7 +299,7 @@
 #define SYSCALL_nbgl_side_refresh_area_ID                                0x02fa0008
 #define SYSCALL_nbgl_get_font_ID                                         0x01fa000c
 #define SYSCALL_nbgl_screen_reinit_ID                                    0x00fa000d
-#define SYSCALL_nbgl_front_draw_img_rle_ID                               0x00fa000e
+#define SYSCALL_nbgl_front_draw_img_rle_ID                               0x04fa0010
 #endif
 
 #ifdef HAVE_BACKGROUND_IMG

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -291,12 +291,12 @@
 #define SYSCALL_nbgl_front_draw_rect_ID                                  0x01fa0000
 #define SYSCALL_nbgl_front_draw_horizontal_line_ID                       0x03fa0001
 #define SYSCALL_nbgl_front_draw_img_ID                                   0x04fa0002
-#define SYSCALL_nbgl_front_refresh_area_ID                               0x02fa0003
+#define SYSCALL_nbgl_front_refresh_area_ID                               0x03fa0003
 #define SYSCALL_nbgl_front_draw_img_file_ID                              0x05fa0004
 #define SYSCALL_nbgl_side_draw_rect_ID                                   0x01fa0005
 #define SYSCALL_nbgl_side_draw_horizontal_line_ID                        0x03fa0006
 #define SYSCALL_nbgl_side_draw_img_ID                                    0x04fa0007
-#define SYSCALL_nbgl_side_refresh_area_ID                                0x01fa0008
+#define SYSCALL_nbgl_side_refresh_area_ID                                0x02fa0008
 #define SYSCALL_nbgl_get_font_ID                                         0x01fa000c
 #define SYSCALL_nbgl_screen_reinit_ID                                    0x00fa000d
 #define SYSCALL_nbgl_front_draw_img_rle_ID                               0x00fa000e

--- a/lib_nbgl/include/nbgl_front.h
+++ b/lib_nbgl/include/nbgl_front.h
@@ -32,8 +32,7 @@ void nbgl_frontDrawHorizontalLine(const nbgl_area_t *area, uint8_t mask, color_t
 void nbgl_frontDrawImage(const nbgl_area_t *area, const uint8_t* buffer, nbgl_transformation_t transformation, nbgl_color_map_t colorMap);
 void nbgl_frontDrawImageFile(const nbgl_area_t *area, const uint8_t* buffer, nbgl_color_map_t colorMap, const uint8_t *uzlib_chunk_buffer);
 void nbgl_frontDrawImageRle(const nbgl_area_t *area, const uint8_t *buffer, uint32_t buffer_len, color_t fore_color);
-
-void nbgl_frontRefreshArea(const nbgl_area_t * area, nbgl_refresh_mode_t mode);
+void nbgl_frontRefreshArea(const nbgl_area_t * area, nbgl_refresh_mode_t mode, nbgl_post_refresh_t post_refresh);
 
 /**********************
  *      MACROS

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -442,6 +442,7 @@ void nbgl_redrawObject(nbgl_obj_t* obj, nbgl_obj_t *prevObj, bool computePositio
 
 void nbgl_refresh(void);
 void nbgl_refreshSpecial(nbgl_refresh_mode_t mode);
+void nbgl_refreshSpecialWithPostRefresh(nbgl_refresh_mode_t mode, nbgl_post_refresh_t post_refresh);
 bool nbgl_refreshIsNeeded(void);
 void nbgl_refreshReset(void);
 

--- a/lib_nbgl/include/nbgl_side.h
+++ b/lib_nbgl/include/nbgl_side.h
@@ -36,7 +36,7 @@ extern "C" {
 void nbgl_sideDrawRect(nbgl_area_t *area);
 void nbgl_sideDrawHorizontalLine(nbgl_area_t *area, uint8_t mask, color_t lineColor);
 void nbgl_sideDrawImage(nbgl_area_t *area, uint8_t* buffer, nbgl_transformation_t transformation, nbgl_color_map_t colorMap);
-void nbgl_sideRefreshArea(nbgl_area_t * area);
+void nbgl_sideRefreshArea(nbgl_area_t * area, nbgl_post_refresh_t post_refresh);
 
 /**********************
  *      VARIABLES

--- a/lib_nbgl/include/nbgl_types.h
+++ b/lib_nbgl/include/nbgl_types.h
@@ -156,6 +156,20 @@ typedef enum {
    NB_REFRESH_MODES
 } nbgl_refresh_mode_t;
 
+
+/**
+ * @brief Available post-refresh power modes
+ *
+ * - Power off after a refresh allows to save power
+ * - Keep the screen powered on after a refresh allows to
+ *   achieve a faster following refresh.
+ */
+typedef enum nbgl_post_refresh_t {
+    POST_REFRESH_FORCE_POWER_OFF,  ///< Force screen power off after refresh
+    POST_REFRESH_FORCE_POWER_ON,   ///< Force screen power on after refresh
+    POST_REFRESH_KEEP_POWER_STATE, ///< Keep screen power state after refresh
+} nbgl_post_refresh_t;
+
 /**
  * @brief possible radius for objects
  *

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -121,11 +121,11 @@ static char numText[5];
  **********************/
 
 // Unit step in % of touchable progress bar
-#define HOLD_TO_APPROVE_STEP_PERCENT (17)
+#define HOLD_TO_APPROVE_STEP_PERCENT (10)
 // Duration in ms the user must hold the progress bar
 // to make it progress HOLD_TO_APPROVE_STEP_PERCENT %.
 // This duration must be higher than the screen refresh duration.
-#define HOLD_TO_APPROVE_STEP_DURATION_MS (400)
+#define HOLD_TO_APPROVE_STEP_DURATION_MS (150)
 
 static inline uint8_t get_hold_to_approve_percent(uint32_t touch_duration) {
         uint8_t current_step_nb = (touch_duration / HOLD_TO_APPROVE_STEP_DURATION_MS) + 1;
@@ -260,7 +260,7 @@ static void longTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType, nbgl_
         nbgl_redrawObject((nbgl_obj_t *)progressBar,false,false);
         // Ensure progress bar is fully drawn
         // before calling the callback.
-        nbgl_refreshSpecial(BLACK_AND_WHITE_FAST_REFRESH);
+        nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_FAST_REFRESH, POST_REFRESH_FORCE_POWER_ON);
       }
 
       if (trigger_callback) {
@@ -274,7 +274,7 @@ static void longTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType, nbgl_
   else if ((eventType == TOUCH_RELEASED) || (eventType == OUT_OF_TOUCH)) {
     progressBar->state = 0;
     nbgl_redrawObject((nbgl_obj_t *)progressBar,false,false);
-    nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
+    nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_OFF);
   }
 }
 

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -1126,8 +1126,20 @@ void nbgl_refreshSpecial(nbgl_refresh_mode_t mode) {
   #ifdef HAVE_SERIALIZED_NBGL
   io_seproxyhal_send_nbgl_serialized(NBGL_REFRESH_AREA, (nbgl_obj_t *) &refreshArea);
   #endif
-  nbgl_frontRefreshArea(&refreshArea, mode);
+  nbgl_frontRefreshArea(&refreshArea, mode, POST_REFRESH_FORCE_POWER_OFF);
   LOG_DEBUG(OBJ_LOGGER,"nbgl_refreshSpecial(), x0,y0 = [%d, %d], w,h = [%d, %d]\n", refreshArea.x0, refreshArea.y0, refreshArea.width, refreshArea.height);
+  nbgl_refreshReset();
+}
+
+void nbgl_refreshSpecialWithPostRefresh(nbgl_refresh_mode_t mode, nbgl_post_refresh_t post_refresh) {
+  if ((refreshArea.width == 0) || (refreshArea.height == 0))
+    return;
+
+  #ifdef HAVE_SERIALIZED_NBGL
+  io_seproxyhal_send_nbgl_serialized(NBGL_REFRESH_AREA, (nbgl_obj_t *) &refreshArea);
+  #endif
+  nbgl_frontRefreshArea(&refreshArea, mode, post_refresh);
+  LOG_DEBUG(OBJ_LOGGER,"nbgl_refreshSpecialNoPoff(), x0,y0 = [%d, %d], w,h = [%d, %d]\n", refreshArea.x0, refreshArea.y0, refreshArea.width, refreshArea.height);
   nbgl_refreshReset();
 }
 

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -105,11 +105,12 @@ void nbgl_frontDrawImageFile(nbgl_area_t *area, uint8_t *buffer,
   return;
 }
 
-void nbgl_frontRefreshArea(nbgl_area_t *area, nbgl_refresh_mode_t mode)
+void nbgl_frontRefreshArea(nbgl_area_t *area, nbgl_refresh_mode_t mode, nbgl_post_refresh_t post_refresh)
 {
-  unsigned int parameters[2];
+  unsigned int parameters[3];
   parameters[0] = (unsigned int)area;
   parameters[1] = (unsigned int)mode;
+  parameters[2] = (unsigned int)post_refresh;
   SVC_Call(SYSCALL_nbgl_front_refresh_area_ID, parameters);
   return;
 }
@@ -143,10 +144,11 @@ void nbgl_sideDrawImage(nbgl_area_t *area, uint8_t *buffer, nbgl_transformation_
   return;
 }
 
-void nbgl_sideRefreshArea(nbgl_area_t *area)
+void nbgl_sideRefreshArea(nbgl_area_t *area, nbgl_post_refresh_t post_refresh)
 {
-  unsigned int parameters[1];
+  unsigned int parameters[2];
   parameters[0] = (unsigned int)area;
+  parameters[1] = (unsigned int)post_refresh;
   SVC_Call(SYSCALL_nbgl_side_refresh_area_ID, parameters);
   return;
 }


### PR DESCRIPTION
## Description
 
Add a `post_refresh` parameter to display refresh syscalls.
This parameter allows to customize power off & power on behavior after refresh.
Keeping the display powered on makes following refresh more reactive.

This PR also implement the usage of this new parameter in the nbgl objects when necessary.

```
typedef enum nbgl_post_refresh_t {
    POST_REFRESH_FORCE_POWER_OFF,  ///< Force screen power off after refresh
    POST_REFRESH_FORCE_POWER_ON,   ///< Force screen power on after refresh
    POST_REFRESH_KEEP_POWER_STATE, ///< Keep screen power state after refresh
} nbgl_post_refresh_t;
```

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

`nbgl_frontRefreshArea` and `nbgl_sideRefreshArea` have a new argument.
