### PR TITLE
Add __attribute__((noreturn)) for os_lib_end SYSCALL

### DIFF
--- a/include/os_lib.h
+++ b/include/os_lib.h
@@ -12,4 +12,8 @@
  * call_parameters[2+] = called function parameters
  */
 SYSCALL void os_lib_call(unsigned int *call_parameters PLENGTH(3*sizeof(unsigned int)));
+#ifdef HAVE_BOLOS
 SYSCALL void os_lib_end(void);
+#else
+SYSCALL void __attribute__((noreturn)) os_lib_end(void);
+#endif


### PR DESCRIPTION
## Description

An attribute was missing, it triggered false positive warnings at compilation
## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
