### PR TITLE
Fat: Receive status resp before sending piezo cmd

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -454,9 +454,9 @@ void io_seproxyhal_play_tune(tune_index_e tune_index) {
     return;
   }
 
-  io_seproxyhal_general_status();
-  // wait for next event before continuing (likely a ticker event)
-  io_seproxyhal_spi_recv(G_io_seproxyhal_spi_buffer, sizeof(G_io_seproxyhal_spi_buffer), 0);
+  if (io_seproxyhal_spi_is_status_sent()) {
+      io_seproxyhal_spi_recv(G_io_seproxyhal_spi_buffer, sizeof(G_io_seproxyhal_spi_buffer), 0);
+  }
 
   buffer[0] = SEPROXYHAL_TAG_PLAY_TUNE;
   buffer[1] = 0;


### PR DESCRIPTION
## Description

Receive status reponse before sending piezo command.
The previous implementation systematically received spi response when sending piezo command - making some seph messages being discarded (such as touch or timer)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

