### PR TITLE
Stax - Fix QR Code position when not centered (add vertical offset)

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1278,6 +1278,7 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
   }
   else {
     container->alignment = BOTTOM_MIDDLE;
+    container->alignmentMarginY = BORDER_MARGIN;
     container->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
   }
 


### PR DESCRIPTION
## Description

Fix QR Code position when not centered (add vertical offset)

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
