### PR TITLE
stax: dont poweroff display when using keyboard

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -521,12 +521,12 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
           break;
       }
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
-      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
+      nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_ON);
     }
     else if (firstIndex == DIGITS_SWITCH_KEY_INDEX) { //switch to digits
       keyboard->mode = MODE_DIGITS;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
-      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
+      nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_ON);
     }
   }
   else if (keyboard->mode == MODE_DIGITS) {
@@ -536,12 +536,12 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
     else if (firstIndex==SPECIAL_KEYS_INDEX) {
       keyboard->mode = MODE_SPECIAL;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
-      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
+      nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_ON);
     }
     else if (firstIndex == DIGITS_SWITCH_KEY_INDEX) { // switch to letters
       keyboard->mode = MODE_LETTERS;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
-      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
+      nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_ON);
     }
   }
   else if (keyboard->mode == MODE_SPECIAL) {
@@ -551,12 +551,12 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
     else if (firstIndex==SPECIAL_KEYS_INDEX) {
       keyboard->mode = MODE_DIGITS;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
-      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
+      nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_ON);
     }
     else if (firstIndex == DIGITS_SWITCH_KEY_INDEX) { // switch to letters
       keyboard->mode = MODE_LETTERS;
       nbgl_redrawObject((nbgl_obj_t *)keyboard,NULL,false);
-      nbgl_refreshSpecial(BLACK_AND_WHITE_REFRESH);
+      nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_ON);
     }
   }
   if (firstIndex == BACKSPACE_KEY_INDEX) { // backspace


### PR DESCRIPTION
## Description

Do not poweroff screen for better reactivity when using the keyboard in an app

## Changes include

- [ X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
