### PR TITLE
Fat: Rename delete_background_img argument

### DIFF
--- a/lib_ux_stax/ux.h
+++ b/lib_ux_stax/ux.h
@@ -116,7 +116,7 @@ typedef struct ux_seph_s {
 
 #ifdef HAVE_BACKGROUND_IMG
 SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX) uint8_t *fetch_background_img(bool allow_candidate);
-SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX) bolos_err_t delete_background_img(bool force_skip_consent);
+SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX) bolos_err_t delete_background_img(bool from_ux);
 #endif
 
 extern ux_seph_os_and_app_t G_ux_os;

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1793,8 +1793,8 @@ uint8_t *fetch_background_img(bool allow_candidate) {
   return (uint8_t *) SVC_Call(SYSCALL_fetch_background_img, parameters);
 }
 
-bolos_err_t delete_background_img(bool force_skip_consent) {
-  uint8_t parameters[1] = {force_skip_consent};
+bolos_err_t delete_background_img(bool from_ux) {
+  uint8_t parameters[1] = {from_ux};
   return SVC_Call(SYSCALL_delete_background_img, parameters);
 }
 #endif


### PR DESCRIPTION
## Description

Rename `delete_background_img` syscall argument.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

