### PR TITLE
Fat: Use 4BPP for spinner text

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1939,7 +1939,7 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, const char *text, bool fixed) {
   textArea->textColor = BLACK;
   textArea->text = PIC(text);
   textArea->textAlignment = CENTER;
-  textArea->fontId = BAGL_FONT_INTER_REGULAR_24px_1bpp;
+  textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
   textArea->alignmentMarginY = 36;
   textArea->alignTo = (nbgl_obj_t*)spinner;
   textArea->alignment = BOTTOM_MIDDLE;


### PR DESCRIPTION
## Description

Use 4BPP font for spinner text.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

