### PR TITLE
Do not display spinner in App if not allowed by UX

### DIFF
--- a/lib_nbgl/include/nbgl_screen.h
+++ b/lib_nbgl/include/nbgl_screen.h
@@ -28,8 +28,9 @@ extern "C" {
 
 /**
  * @brief prototype of function to be called when a timer on screen is fired
+ * @param allowDisplay if true, the callback is allowed to draw/refresh
  */
-typedef void (*nbgl_tickerCallback_t)(void);
+typedef void (*nbgl_tickerCallback_t)(bool allowDisplay);
 
 /**
  * @brief struct to configure a screen layer
@@ -81,7 +82,7 @@ int nbgl_screenRelease(void);
 int nbgl_screenPush(nbgl_obj_t*** elements, uint8_t nbElements, const nbgl_screenTickerConfiguration_t *ticker, nbgl_touchCallback_t touchCallback);
 int nbgl_screenPop(uint8_t screenIndex);
 int nbgl_screenReset(void);
-void nbgl_screenHandler(uint32_t intervaleMs);
+void nbgl_screenHandler(uint32_t intervaleMs, bool allowDisplay);
 
 
 /**********************

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -335,7 +335,7 @@ static void radioTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType, nbgl
 }
 
 // callback for spinner ticker
-static void spinnerTickerCallback(void) {
+static void spinnerTickerCallback(bool allowDisplay) {
   nbgl_spinner_t *spinner;
   uint8_t i=0;
   nbgl_layoutInternal_t *layout;
@@ -354,8 +354,10 @@ static void spinnerTickerCallback(void) {
       spinner = (nbgl_spinner_t *)layout->container->children[i];
       spinner->position++;
       spinner->position &= 3; // modulo 4
-      nbgl_redrawObject((nbgl_obj_t*)spinner, NULL, false);
-      nbgl_refreshSpecial(BLACK_AND_WHITE_FAST_REFRESH);
+      if (allowDisplay) {
+        nbgl_redrawObject((nbgl_obj_t*)spinner, NULL, false);
+        nbgl_refreshSpecial(BLACK_AND_WHITE_FAST_REFRESH);
+      }
       return;
     }
     i++;

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -353,8 +353,9 @@ int nbgl_screenReset(void) {
  * @brief Function to be called periodically by system to enable using ticker
  *
  * @param intervaleMs intervale or time since the last call, in ms
+ * @param allowDisplay if true, the callback is allowed to draw/refresh
  */
-void nbgl_screenHandler(uint32_t intervaleMs) {
+void nbgl_screenHandler(uint32_t intervaleMs, bool allowDisplay) {
   // ensure a screen exists
   if (nbScreensOnStack == 0)
     return;
@@ -365,7 +366,7 @@ void nbgl_screenHandler(uint32_t intervaleMs) {
     if (topOfStack->tickerValue == 0) {
       // rearm if intervale is not null, and call the registered function
       topOfStack->tickerValue = topOfStack->tickerIntervale;
-      topOfStack->tickerCallback();
+      topOfStack->tickerCallback(allowDisplay);
     }
   }
 }

--- a/lib_ux_stax/ux.c
+++ b/lib_ux_stax/ux.c
@@ -85,9 +85,13 @@ void ux_process_finger_event(uint8_t seph_packet[]) {
 void ux_process_ticker_event(void) {
   nbTicks++;
   // forward to UX
-  ux_forward_event(false);
-  nbgl_screenHandler(100);
+  bool display_allowed = ux_forward_event(true);
+  nbgl_screenHandler(100, display_allowed);
 
+  // exit here if no display of APP is allowed by UX
+  if (!display_allowed) {
+    return;
+  }
   // handle touch only if detected as pressed in last touch message
   if (pos.state == PRESSED) {
     io_touch_info_t touch_info;


### PR DESCRIPTION
## Description

Fixes https://ledgerhq.atlassian.net/browse/FWEO-924 to forbid Apps to redraw/refresh screen when disallowed by UX

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
