### PR TITLE
Fat: Toggle - callback after refresh

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -223,10 +223,10 @@ static void touchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
       io_seproxyhal_play_tune(layoutObj->tuneId);
     }
 #endif // HAVE_PIEZO_SOUND
-    layout->callback(layoutObj->token,layoutObj->index);
     if (needRefresh) {
       nbgl_refreshSpecial(FULL_COLOR_PARTIAL_REFRESH);
     }
+    layout->callback(layoutObj->token,layoutObj->index);
   }
 }
 


### PR DESCRIPTION
Call toggle callback after refresh.
If the callback is before the refresh, and another refresh occurs in the callback, the toggle redraw is cancelled by the display: making the display toggle state not being changed.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

