### PR TITLE
Makefile.glyphs: Remove some unnecessary override possibilities

### DIFF
--- a/Makefile.glyphs
+++ b/Makefile.glyphs
@@ -14,10 +14,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #*******************************************************************************
-#allow for makefile override of the default placement for generated glyph header/c files
-ifeq ($(GLYPH_SRC_DIR),)
-GLYPH_SRC_DIR = $(GEN_SRC_DIR)
+# Don't allow anymore makefile override of the default placement for glyphs and
+# the generated glyph header/c files
+ifneq ($(GLYPH_SRC_DIR),)
+$(info GLYPH_SRC_DIR is not supported anymore as it is now automatically computed, please remove it from your Makefile)
 endif
+ifneq ($(GLYPH_PATH),)
+$(info Setting GLYPH_PATH is not supported anymore, please remove it from your Makefile)
+endif
+GLYPH_SRC_DIR = $(GEN_SRC_DIR)
+
 ifeq ($(BOLOS_SDK),)
 $(error BOLOS_SDK not set)
 endif
@@ -37,7 +43,6 @@ ICON_SCRIPT = $(BOLOS_SDK)/lib_nbgl/tools/icon2glyph.py
 GENERATE_GLYPHS_CMD = python3 $(ICON_SCRIPT) --glyphcfile $(GLYPH_FILES)
 else
 # Nano glyphs files and generation script
-GLYPH_FILES += $(foreach gp,$(GLYPH_PATH),$(addprefix $(gp)/,$(sort $(notdir $(shell find $(gp))))))
 GLYPH_FILES += $(addprefix glyphs/,$(sort $(notdir $(shell find glyphs/))))
 GLYPH_FILES += $(addprefix $(BOLOS_SDK)/lib_ux/glyphs/,$(sort $(notdir $(shell find $(BOLOS_SDK)/lib_ux/glyphs/))))
 ICON_SCRIPT = $(BOLOS_SDK)/icon3.py


### PR DESCRIPTION
## Description

Makefile.glyphs: Remove some unnecessary override possibilities
Some apps are setting `GLYPH_SRC_DIR` to `glyphs` which create a circular dependency and doesn't bring much now that generated file sare put in a dedicated folder by default instead of in the src folder.
`GLYPH_PATH` is no longer supported, apps need to put `glyphs` in `glyphs/` folder. This is not used in any apps, so safe to remove.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

See description above.
