### PR TITLE
Indicate if poweroff was triggered by critical battery level

### DIFF
--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -263,7 +263,7 @@ void io_start(void);
 #endif // HAVE_IO_TASK
 
 void io_seproxyhal_setup_ticker(unsigned int interval_ms);
-void io_seproxyhal_power_off(void);
+void io_seproxyhal_power_off(bool criticalBattery);
 void io_seproxyhal_se_reset(void);
 void io_seproxyhal_disable_io(void);
 

--- a/lib_ux/include/ux.h
+++ b/lib_ux/include/ux.h
@@ -600,7 +600,7 @@ void io_seproxyhal_request_mcu_status(void);
  */
 void io_seproxyhal_display_bitmap(int x, int y, unsigned int w, unsigned int h, unsigned int* color_index, unsigned int bit_per_pixel, unsigned char* bitmap);
 
-void io_seproxyhal_power_off(void);
+void io_seproxyhal_power_off(bool criticalBattery);
 
 void io_seproxyhal_se_reset(void);
 

--- a/lib_ux_stax/ux.h
+++ b/lib_ux_stax/ux.h
@@ -122,7 +122,7 @@ SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX) bolos_err_t delete_background_img(
 extern ux_seph_os_and_app_t G_ux_os;
 
 void io_seproxyhal_request_mcu_status(void);
-void io_seproxyhal_power_off(void);
+void io_seproxyhal_power_off(bool criticalBattery);
 
 #if defined(HAVE_LANGUAGE_PACK)
 const char *get_ux_loc_string(UX_LOC_STRINGS_INDEX index);

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -889,12 +889,13 @@ void io_seproxyhal_setup_ticker(unsigned int interval_ms) {
   io_seproxyhal_spi_send(buffer, 5);
 }
 
-static const unsigned char seph_io_device_off[] = {
-  SEPROXYHAL_TAG_DEVICE_OFF,
-  0,
-  0,
-};
-void io_seproxyhal_power_off(void) {
+void io_seproxyhal_power_off(bool criticalBattery) {
+  unsigned char seph_io_device_off[4] = {
+    SEPROXYHAL_TAG_DEVICE_OFF,
+    0,
+    1,
+    (char) criticalBattery,
+  };
   io_seproxyhal_spi_send(seph_io_device_off, sizeof(seph_io_device_off));
   for(;;);
 }


### PR DESCRIPTION
## Description

Add new boolean parameter "criticalBattery" to io_seproxyhal_power_off() to indicate if power off is due to critical battery condition

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

