### PR TITLE
lib_standard_app/parser.c: Allow parsing APDU without Lc field

### DIFF
--- a/unit-tests/lib_standard_app/test_apdu_parser.c
+++ b/unit-tests/lib_standard_app/test_apdu_parser.c
@@ -11,8 +11,10 @@
 
 static void test_apdu_parser(void **state) {
     (void) state;
-    uint8_t apdu_bad_min_len[] = {0xE0, 0x03, 0x00, 0x00};   // less than 5 bytes
+    uint8_t apdu_bad_min_len[] = {0xE0, 0x03, 0x00};   // less than 4 bytes
     uint8_t apdu_bad_lc[] = {0xE0, 0x03, 0x00, 0x00, 0x01};  // Lc = 1 but no data
+    uint8_t apdu_no_lc[] = {0xE0, 0x03, 0x01, 0x02};
+    uint8_t apdu_no_data[] = {0xE0, 0x03, 0x01, 0x02, 0x00};
     uint8_t apdu[] = {0xE0, 0x03, 0x01, 0x02, 0x05, 0x00, 0x01, 0x02, 0x03, 0x04};
 
     command_t cmd;
@@ -24,12 +26,31 @@ static void test_apdu_parser(void **state) {
     assert_false(apdu_parser(&cmd, apdu_bad_lc, sizeof(apdu_bad_min_len)));
 
     memset(&cmd, 0, sizeof(cmd));
+    assert_true(apdu_parser(&cmd, apdu_no_lc, sizeof(apdu_no_lc)));
+    assert_int_equal(cmd.cla, 0xE0);
+    assert_int_equal(cmd.ins, 0x03);
+    assert_int_equal(cmd.p1, 0x01);
+    assert_int_equal(cmd.p2, 0x02);
+    assert_int_equal(cmd.lc, 0);
+    assert_null(cmd.data);
+
+    memset(&cmd, 0, sizeof(cmd));
+    assert_true(apdu_parser(&cmd, apdu_no_data, sizeof(apdu_no_data)));
+    assert_int_equal(cmd.cla, 0xE0);
+    assert_int_equal(cmd.ins, 0x03);
+    assert_int_equal(cmd.p1, 0x01);
+    assert_int_equal(cmd.p2, 0x02);
+    assert_int_equal(cmd.lc, 0);
+    assert_null(cmd.data);
+
+    memset(&cmd, 0, sizeof(cmd));
     assert_true(apdu_parser(&cmd, apdu, sizeof(apdu)));
     assert_int_equal(cmd.cla, 0xE0);
     assert_int_equal(cmd.ins, 0x03);
     assert_int_equal(cmd.p1, 0x01);
     assert_int_equal(cmd.p2, 0x02);
     assert_int_equal(cmd.lc, 5);
+    assert_non_null(cmd.data);
     assert_memory_equal(cmd.data, ((uint8_t[]){0x00, 0x01, 0x02, 0x03, 0x04}), cmd.lc);
 }
 


### PR DESCRIPTION
## Description

lib_standard_app/parser.c: Allow parsing APDU without Lc field

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)