### PR TITLE
Makefile.defines: Expose API_LEVEL to the app

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -43,7 +43,8 @@ endif
 ifeq ($(SDK_HASH),)
 SDK_HASH := "None"
 endif
-# Expose SDK_VERSION and SDK_HASH to the app.
+# Expose API_LEVEL, SDK_VERSION and SDK_HASH to the app.
+DEFINES += API_LEVEL=$(API_LEVEL)
 DEFINES += SDK_VERSION=\"$(SDK_VERSION)\"
 DEFINES += SDK_HASH=\"$(SDK_HASH)\"
 


### PR DESCRIPTION
## Description

Makefile.defines: Expose API_LEVEL to the app
this might be needed when app need to handle rare features that are not completely back-ported on all API_LEVELs as https://github.com/LedgerHQ/ledger-secure-sdk/pull/188.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)