### PR TITLE
Makefile.standard_app: Format APP_FLAGS in hex

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -150,7 +150,7 @@ ifeq ($(HAVE_APPLICATION_FLAG_LIBRARY), 1)
 STANDARD_APP_FLAGS := $(shell echo $$(($(STANDARD_APP_FLAGS) + 0x800)))
 endif
 
-APP_FLAGS = $(shell echo $$(( $(STANDARD_APP_FLAGS) + $(CUSTOM_APP_FLAGS) )) )
+APP_FLAGS = $(shell printf '0x%x' $$(( $(STANDARD_APP_FLAGS) + $(CUSTOM_APP_FLAGS) )) )
 
 APP_LOAD_PARAMS += --appFlags $(APP_FLAGS)
 


### PR DESCRIPTION
## Description

Makefile.standard_app: Format APP_FLAGS in hex.
This is the format that is often used in makefiles and in the app database, so stick with it.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)