### PR TITLE
Makefile.defines: Drop SEED_COOKIES mechanism

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -174,6 +174,8 @@ endif
 
 ifeq ($(TARGET_NAME),TARGET_NANOS)
 DEFINES += HAVE_BAGL
+DEFINES += BAGL_WIDTH=128 BAGL_HEIGHT=32
+
 LDFLAGS  += -L$(BOLOS_SDK)/lib/
 endif
 
@@ -211,9 +213,6 @@ DEFINES       += HAVE_FONTS
 # already defined within apps
 # DEFINES       += HAVE_BLE
 DEFINES       += HAVE_BATTERY
-else
-DEFINES       += HAVE_SEED_COOKIE
-DEFINES       += BAGL_WIDTH=128 BAGL_HEIGHT=32
 endif
 
 # include builtin CX libs options


### PR DESCRIPTION
Relates to https://ledgerhq.atlassian.net/browse/EMBSDK-18

## Description

Makefile.defines: Drop SEED_COOKIES mechanism

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Remove the seed cookie mechanism on Nanos and Stax device.