### PR TITLE
Sanitise some crypto functions

### DIFF
--- a/include/decorators.h
+++ b/include/decorators.h
@@ -58,3 +58,7 @@
     #define FALL_THROUGH ((void)0)
   #endif
 #endif
+
+#ifndef WARN_UNUSED_RESULT
+  #define WARN_UNUSED_RESULT __attribute__ ((warn_unused_result))
+#endif

--- a/include/os_seed.h
+++ b/include/os_seed.h
@@ -109,14 +109,15 @@ SYSCALL                                       void           os_perso_derive_nod
  *                             - CX_OK on success
  *                             - CX_INTERNAL_ERROR
  */
-static inline cx_err_t os_derive_bip32_with_seed_no_throw(unsigned int derivation_mode,
-                                                          cx_curve_t curve,
-                                                          const unsigned int *path,
-                                                          unsigned int path_len,
-                                                          unsigned char raw_privkey[static 64],
-                                                          unsigned char *chain_code,
-                                                          unsigned char *seed,
-                                                          unsigned int seed_len) {
+WARN_UNUSED_RESULT static inline cx_err_t os_derive_bip32_with_seed_no_throw(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const unsigned int *path,
+        unsigned int path_len,
+        unsigned char raw_privkey[static 64],
+        unsigned char *chain_code,
+        unsigned char *seed,
+        unsigned int seed_len) {
     cx_err_t error = CX_OK;
 
     BEGIN_TRY {
@@ -159,11 +160,12 @@ static inline cx_err_t os_derive_bip32_with_seed_no_throw(unsigned int derivatio
  *                             - CX_OK on success
  *                             - CX_INTERNAL_ERROR
  */
-static inline cx_err_t os_derive_bip32_no_throw(cx_curve_t curve,
-                                                const unsigned int *path,
-                                                unsigned int path_len,
-                                                unsigned char raw_privkey[static 64],
-                                                unsigned char *chain_code) {
+WARN_UNUSED_RESULT static inline cx_err_t os_derive_bip32_no_throw(
+        cx_curve_t curve,
+        const unsigned int *path,
+        unsigned int path_len,
+        unsigned char raw_privkey[static 64],
+        unsigned char *chain_code) {
     return os_derive_bip32_with_seed_no_throw(HDW_NORMAL,
                                               curve,
                                               path,
@@ -191,10 +193,11 @@ SYSCALL                                       void           os_perso_derive_eip
  *                             - CX_OK on success
  *                             - CX_INTERNAL_ERROR
  */
-static inline cx_err_t os_derive_eip2333_no_throw(cx_curve_t curve,
-                                                  const unsigned int *path,
-                                                  unsigned int path_len,
-                                                  unsigned char raw_privkey[static 64]) {
+WARN_UNUSED_RESULT static inline cx_err_t os_derive_eip2333_no_throw(
+        cx_curve_t curve,
+        const unsigned int *path,
+        unsigned int path_len,
+        unsigned char raw_privkey[static 64]) {
     cx_err_t error = CX_OK;
 
     BEGIN_TRY {

--- a/include/os_seed.h
+++ b/include/os_seed.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include "appflags.h"
 #include "decorators.h"
 #include "lcx_ecfp.h"
@@ -134,6 +136,10 @@ WARN_UNUSED_RESULT static inline cx_err_t os_derive_bip32_with_seed_no_throw(
         }
         CATCH_OTHER(e) {
             error = e;
+
+            // Make sure the caller doesn't use uninitialized data in case
+            // the return code is not checked.
+            explicit_bzero(&raw_privkey, 64);
         }
         FINALLY {
         }
@@ -207,6 +213,10 @@ WARN_UNUSED_RESULT static inline cx_err_t os_derive_eip2333_no_throw(
         }
         CATCH_OTHER(e) {
             error = e;
+
+            // Make sure the caller doesn't use uninitialized data in case
+            // the return code is not checked.
+            explicit_bzero(&raw_privkey, 64);
         }
         FINALLY {
         }

--- a/lib_standard_app/crypto_helpers.c
+++ b/lib_standard_app/crypto_helpers.c
@@ -58,6 +58,8 @@ end:
     explicit_bzero(&raw_privkey, sizeof(raw_privkey));
 
     if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
         explicit_bzero(&privkey, sizeof(privkey));
     }
     return error;
@@ -100,6 +102,12 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_get_pubkey_256(
 
 end:
     explicit_bzero(&privkey, sizeof(privkey));
+
+    if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
+        explicit_bzero(raw_pubkey, 65);
+    }
     return error;
 }
 
@@ -119,6 +127,7 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(
         size_t seed_len) {
     cx_err_t error = CX_OK;
     cx_ecfp_256_private_key_t privkey;
+    size_t buf_len = *sig_len;
 
     // Derive private key according to BIP32 path
     CX_CHECK(bip32_derive_with_seed_init_privkey_256(derivation_mode,
@@ -134,6 +143,12 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(
 
 end:
     explicit_bzero(&privkey, sizeof(privkey));
+
+    if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
+        explicit_bzero(sig, buf_len);
+    }
     return error;
 }
 
@@ -152,6 +167,7 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(
     cx_err_t error = CX_OK;
     cx_ecfp_256_private_key_t privkey;
     size_t size;
+    size_t buf_len = *sig_len;
 
     if (sig_len == NULL) {
         error = CX_INVALID_PARAMETER_VALUE;
@@ -175,5 +191,11 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(
 
 end:
     explicit_bzero(&privkey, sizeof(privkey));
+
+    if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
+        explicit_bzero(sig, buf_len);
+    }
     return error;
 }

--- a/lib_standard_app/crypto_helpers.c
+++ b/lib_standard_app/crypto_helpers.c
@@ -21,14 +21,15 @@
 #include "cx.h"
 #include "os.h"
 
-cx_err_t bip32_derive_with_seed_init_privkey_256(unsigned int derivation_mode,
-                                                 cx_curve_t curve,
-                                                 const uint32_t *path,
-                                                 size_t path_len,
-                                                 cx_ecfp_256_private_key_t *privkey,
-                                                 uint8_t *chain_code,
-                                                 unsigned char *seed,
-                                                 size_t seed_len) {
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_init_privkey_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_ecfp_256_private_key_t *privkey,
+        uint8_t *chain_code,
+        unsigned char *seed,
+        size_t seed_len) {
     cx_err_t error = CX_OK;
     uint8_t raw_privkey[64]; // Allocate 64 bytes to respect Syscall API but only 32 will be used
     size_t length;
@@ -62,15 +63,16 @@ end:
     return error;
 }
 
-cx_err_t bip32_derive_with_seed_get_pubkey_256(unsigned int derivation_mode,
-                                               cx_curve_t curve,
-                                               const uint32_t *path,
-                                               size_t path_len,
-                                               uint8_t raw_pubkey[static 65],
-                                               uint8_t *chain_code,
-                                               cx_md_t hashID,
-                                               unsigned char *seed,
-                                               size_t seed_len) {
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_get_pubkey_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint8_t raw_pubkey[static 65],
+        uint8_t *chain_code,
+        cx_md_t hashID,
+        unsigned char *seed,
+        size_t seed_len) {
     cx_err_t error = CX_OK;
 
     cx_ecfp_256_private_key_t privkey;
@@ -101,19 +103,20 @@ end:
     return error;
 }
 
-cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(unsigned int derivation_mode,
-                                                    cx_curve_t curve,
-                                                    const uint32_t *path,
-                                                    size_t path_len,
-                                                    uint32_t sign_mode,
-                                                    cx_md_t hashID,
-                                                    const uint8_t *hash,
-                                                    size_t hash_len,
-                                                    uint8_t *sig,
-                                                    size_t *sig_len,
-                                                    uint32_t *info,
-                                                    unsigned char *seed,
-                                                    size_t seed_len) {
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint32_t sign_mode,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len,
+        uint32_t *info,
+        unsigned char *seed,
+        size_t seed_len) {
     cx_err_t error = CX_OK;
     cx_ecfp_256_private_key_t privkey;
 
@@ -134,17 +137,18 @@ end:
     return error;
 }
 
-cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(unsigned int derivation_mode,
-                                                    cx_curve_t curve,
-                                                    const uint32_t *path,
-                                                    size_t path_len,
-                                                    cx_md_t hashID,
-                                                    const uint8_t *hash,
-                                                    size_t hash_len,
-                                                    uint8_t *sig,
-                                                    size_t *sig_len,
-                                                    unsigned char *seed,
-                                                    size_t seed_len) {
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len,
+        unsigned char *seed,
+        size_t seed_len) {
     cx_err_t error = CX_OK;
     cx_ecfp_256_private_key_t privkey;
     size_t size;

--- a/lib_standard_app/crypto_helpers.h
+++ b/lib_standard_app/crypto_helpers.h
@@ -29,14 +29,15 @@
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-cx_err_t bip32_derive_with_seed_init_privkey_256(unsigned int derivation_mode,
-                                                 cx_curve_t curve,
-                                                 const uint32_t *path,
-                                                 size_t path_len,
-                                                 cx_ecfp_256_private_key_t *privkey,
-                                                 uint8_t *chain_code,
-                                                 unsigned char *seed,
-                                                 size_t seed_len);
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_init_privkey_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_ecfp_256_private_key_t *privkey,
+        uint8_t *chain_code,
+        unsigned char *seed,
+        size_t seed_len);
 
 /**
  * @brief   Gets the private key from the device seed using the specified bip32 path.
@@ -56,11 +57,12 @@ cx_err_t bip32_derive_with_seed_init_privkey_256(unsigned int derivation_mode,
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-static inline cx_err_t bip32_derive_init_privkey_256(cx_curve_t curve,
-                                                     const uint32_t *path,
-                                                     size_t path_len,
-                                                     cx_ecfp_256_private_key_t *privkey,
-                                                     uint8_t *chain_code) {
+WARN_UNUSED_RESULT static inline cx_err_t bip32_derive_init_privkey_256(
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_ecfp_256_private_key_t *privkey,
+        uint8_t *chain_code) {
     return bip32_derive_with_seed_init_privkey_256(HDW_NORMAL,
                                                    curve,
                                                    path,
@@ -97,15 +99,16 @@ static inline cx_err_t bip32_derive_init_privkey_256(cx_curve_t curve,
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-cx_err_t bip32_derive_with_seed_get_pubkey_256(unsigned int derivation_mode,
-                                               cx_curve_t curve,
-                                               const uint32_t *path,
-                                               size_t path_len,
-                                               uint8_t raw_pubkey[static 65],
-                                               uint8_t *chain_code,
-                                               cx_md_t hashID,
-                                               unsigned char *seed,
-                                               size_t seed_len);
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_get_pubkey_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint8_t raw_pubkey[static 65],
+        uint8_t *chain_code,
+        cx_md_t hashID,
+        unsigned char *seed,
+        size_t seed_len);
 
 /**
  * @brief   Gets the public key from the device seed using the specified bip32 path.
@@ -127,12 +130,13 @@ cx_err_t bip32_derive_with_seed_get_pubkey_256(unsigned int derivation_mode,
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-static inline cx_err_t bip32_derive_get_pubkey_256(cx_curve_t curve,
-                                                   const uint32_t *path,
-                                                   size_t path_len,
-                                                   uint8_t raw_pubkey[static 65],
-                                                   uint8_t *chain_code,
-                                                   cx_md_t hashID) {
+WARN_UNUSED_RESULT static inline cx_err_t bip32_derive_get_pubkey_256(
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint8_t raw_pubkey[static 65],
+        uint8_t *chain_code,
+        cx_md_t hashID) {
     return bip32_derive_with_seed_get_pubkey_256(HDW_NORMAL,
                                                  curve,
                                                  path,
@@ -179,19 +183,20 @@ static inline cx_err_t bip32_derive_get_pubkey_256(cx_curve_t curve,
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(unsigned int derivation_mode,
-                                                    cx_curve_t curve,
-                                                    const uint32_t *path,
-                                                    size_t path_len,
-                                                    uint32_t sign_mode,
-                                                    cx_md_t hashID,
-                                                    const uint8_t *hash,
-                                                    size_t hash_len,
-                                                    uint8_t *sig,
-                                                    size_t *sig_len,
-                                                    uint32_t *info,
-                                                    unsigned char *seed,
-                                                    size_t seed_len);
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint32_t sign_mode,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len,
+        uint32_t *info,
+        unsigned char *seed,
+        size_t seed_len);
 
 /**
  * @brief   Sign a hash with ecdsa using the device seed derived from the specified bip32 path.
@@ -224,16 +229,17 @@ cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(unsigned int derivation_mode
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-static inline cx_err_t bip32_derive_ecdsa_sign_hash_256(cx_curve_t curve,
-                                                        const uint32_t *path,
-                                                        size_t path_len,
-                                                        uint32_t sign_mode,
-                                                        cx_md_t hashID,
-                                                        const uint8_t *hash,
-                                                        size_t hash_len,
-                                                        uint8_t *sig,
-                                                        size_t *sig_len,
-                                                        uint32_t *info) {
+WARN_UNUSED_RESULT static inline cx_err_t bip32_derive_ecdsa_sign_hash_256(
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint32_t sign_mode,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len,
+        uint32_t *info) {
     return bip32_derive_with_seed_ecdsa_sign_hash_256(HDW_NORMAL,
                                                       curve,
                                                       path,
@@ -281,17 +287,18 @@ static inline cx_err_t bip32_derive_ecdsa_sign_hash_256(cx_curve_t curve,
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(unsigned int derivation_mode,
-                                                    cx_curve_t curve,
-                                                    const uint32_t *path,
-                                                    size_t path_len,
-                                                    cx_md_t hashID,
-                                                    const uint8_t *hash,
-                                                    size_t hash_len,
-                                                    uint8_t *sig,
-                                                    size_t *sig_len,
-                                                    unsigned char *seed,
-                                                    size_t seed_len);
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len,
+        unsigned char *seed,
+        size_t seed_len);
 
 /**
  * @brief   Sign a hash with eddsa using the device seed derived from the specified bip32 path.
@@ -319,14 +326,15 @@ cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(unsigned int derivation_mode
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-static inline cx_err_t bip32_derive_eddsa_sign_hash_256(cx_curve_t curve,
-                                                        const uint32_t *path,
-                                                        size_t path_len,
-                                                        cx_md_t hashID,
-                                                        const uint8_t *hash,
-                                                        size_t hash_len,
-                                                        uint8_t *sig,
-                                                        size_t *sig_len) {
+WARN_UNUSED_RESULT static inline cx_err_t bip32_derive_eddsa_sign_hash_256(
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len) {
     return bip32_derive_with_seed_eddsa_sign_hash_256(HDW_NORMAL,
                                                       curve,
                                                       path,


### PR DESCRIPTION
## Description

include: decorators.h: Add WARN_UNUSED_RESULT attribute decorator
os_seed.h / crypto_helpers: Use WARN_UNUSED_RESULT decorator
os_seed.h / crypto_helpers: Ensure output buffers are memset in case of error

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
