### PR TITLE
Makefile.rules: add ${BOLOS_SDK} to INCLUDES_PATH

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -27,6 +27,9 @@ endif
 # adding the correct target header to sources
 SDK_SOURCE_PATH += target/$(TARGET)/include
 
+# Expose all SDK header files with their full relative path to the SDK root folder
+INCLUDES_PATH  += ${BOLOS_SDK}
+
 #include the lib_cxng definition by default if not asked otherwise
 ifeq ($(NO_CXNG),)
 INCLUDES_PATH += $(BOLOS_SDK)/lib_cxng/include


### PR DESCRIPTION
## Description

Expose all headers with their full paths.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
