### PR TITLE
Read Stax touch diff data (debug feature)

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -89,8 +89,9 @@ typedef struct io_touch_info_s {
 SYSCALL void touch_get_last_info(io_touch_info_t *info);
 SYSCALL void touch_set_state(bool enable);
 SYSCALL uint8_t touch_exclude_borders(uint8_t excluded_borders);
-#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
+#ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
 SYSCALL void touch_read_sensitivity(uint8_t *sensi_data);
+SYSCALL void touch_read_diff_data(uint8_t *diff_data);
 #endif
 #endif
 #endif // HAVE_SE_TOUCH

--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -130,8 +130,9 @@ void io_seproxyhal_nfc_init(ndef_struct_t *ndef_message, bool async, bool forceI
 #endif
 
 #ifdef HAVE_SE_TOUCH
-#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
+#ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
 void io_seproxyhal_touch_read_sensi(uint8_t * sensi_data);
+void io_seproxyhal_touch_read_diff_data(uint8_t * sensi_data);
 #endif
 #endif
 

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -311,8 +311,9 @@
 #define SYSCALL_touch_get_last_info_ID                                   0x01fa000b
 #define SYSCALL_touch_exclude_borders_ID                                 0x01fa000d
 #define SYSCALL_touch_set_state_ID                                       0x01fa000e
-#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
+#ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
 #define SYSCALL_touch_read_sensi_ID                                      0x01fa000f
+#define SYSCALL_touch_read_diff_data_ID                                  0x01fa0010
 #endif
 
 #endif // HAVE_SE_TOUCH

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -500,9 +500,13 @@ void io_seproxyhal_nfc_init(ndef_struct_t *ndef_message, bool async, bool forceI
 #endif
 
 #ifdef HAVE_SE_TOUCH
-#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
+#ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
 void io_seproxyhal_touch_read_sensi(uint8_t * sensi_data) {
   touch_read_sensitivity(sensi_data);
+}
+
+void io_seproxyhal_touch_read_diff_data(uint8_t *diff_data) {
+  touch_read_diff_data(diff_data);
 }
 #endif
 #endif

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1821,10 +1821,15 @@ uint8_t touch_exclude_borders(uint8_t excluded_borders) {
   return (uint8_t)SVC_Call(SYSCALL_touch_exclude_borders_ID, parameters);
 }
 
-#ifdef HAVE_TOUCH_READ_SENSI_SYSCALL
+#ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
 void touch_read_sensitivity(uint8_t *sensi_data) {
   unsigned int parameters[1] = {(unsigned int) sensi_data};
   SVC_Call(SYSCALL_touch_read_sensi_ID, parameters);
+}
+
+void touch_read_diff_data(uint8_t *diff_data) {
+  unsigned int parameters[1] = {(unsigned int) diff_data};
+  SVC_Call(SYSCALL_touch_read_diff_data_ID, parameters);
 }
 #endif
 


### PR DESCRIPTION
## Description

Implement read touch diff data
New syscall touch_read_diff_data() syscall_id (0x01fa0010) New SDK function io_seproxyhal_touch_read_diff_data() to wrap the syscall

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

