### PR TITLE
nbgl: handle long APPNAME for useCaseHome

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -780,6 +780,11 @@ void nbgl_useCaseHomeExt(const char *appName, const nbgl_icon_details_t *appIcon
   }
   if (tagline == NULL) {
     snprintf(appDescription, APP_DESCRIPTION_MAX_LEN, "This app enables signing\ntransactions on the %s\nnetwork.", appName);
+
+    // If there is more than 3 lines, it means the appName was split, so we put it on the next line
+    if (nbgl_getTextNbLinesInWidth(BAGL_FONT_INTER_REGULAR_24px, appDescription, SCREEN_WIDTH-2*BORDER_MARGIN, false) > 3) {
+        snprintf(appDescription, APP_DESCRIPTION_MAX_LEN, "This app enables signing\ntransactions on the\n%s network.", appName);
+    }
     info.centeredInfo.text2 = appDescription;
   }
   else {


### PR DESCRIPTION
## Description
Long appname were broken often split in the middle of the word.

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
