### PR TITLE
nbgl: handle very long app names

### DIFF
--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -54,6 +54,22 @@ extern "C" {
  */
 #define TAG_VALUE_AREA_HEIGHT   400
 
+/**
+ *  @brief Default strings used in the Home tagline
+ */
+#define TAGLINE_PART1 "This app enables signing\ntransactions on the"
+#define TAGLINE_PART2 "network."
+
+/**
+ *  @brief Length of buffer used for the default Home tagline
+ */
+#define APP_DESCRIPTION_MAX_LEN 74
+
+/**
+ *  @brief Max supported length of appName used for the default Home tagline
+ */
+#define MAX_APP_NAME_FOR_SDK_TAGLINE (APP_DESCRIPTION_MAX_LEN - 1 - (sizeof(TAGLINE_PART1) + sizeof(TAGLINE_PART2)))
+
 /**********************
  *      MACROS
  **********************/

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -18,8 +18,6 @@
 /*********************
  *      DEFINES
  *********************/
-#define APP_DESCRIPTION_MAX_LEN 72
-
 /**********************
  *      TYPEDEFS
  **********************/
@@ -779,11 +777,16 @@ void nbgl_useCaseHomeExt(const char *appName, const nbgl_icon_details_t *appIcon
     onAction = actionCallback;
   }
   if (tagline == NULL) {
-    snprintf(appDescription, APP_DESCRIPTION_MAX_LEN, "This app enables signing\ntransactions on the %s\nnetwork.", appName);
+      if (strlen(appName) > MAX_APP_NAME_FOR_SDK_TAGLINE) {
+          snprintf(appDescription, APP_DESCRIPTION_MAX_LEN, "This app enables signing\ntransactions on its network.");
+      }
+      else {
+          snprintf(appDescription, APP_DESCRIPTION_MAX_LEN, "%s %s\n%s", TAGLINE_PART1, appName, TAGLINE_PART2);
+      }
 
     // If there is more than 3 lines, it means the appName was split, so we put it on the next line
     if (nbgl_getTextNbLinesInWidth(BAGL_FONT_INTER_REGULAR_24px, appDescription, SCREEN_WIDTH-2*BORDER_MARGIN, false) > 3) {
-        snprintf(appDescription, APP_DESCRIPTION_MAX_LEN, "This app enables signing\ntransactions on the\n%s network.", appName);
+        snprintf(appDescription, APP_DESCRIPTION_MAX_LEN, "%s\n%s %s", TAGLINE_PART1, appName, TAGLINE_PART2);
     }
     info.centeredInfo.text2 = appDescription;
   }


### PR DESCRIPTION
## Description

Very long appnames resulted in a truncated string in the home screen.
This solve the issue by defining a default string in case the app fails at providing a custom string.

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
