### PR TITLE
Add API_LEVEL_5 JSON files for Nano fonts

### DIFF
--- a/lib_bagl/src/bagl_font_open_sans_extrabold_11px.json
+++ b/lib_bagl/src/bagl_font_open_sans_extrabold_11px.json
@@ -1,0 +1,784 @@
+[
+  {
+    "bitmap": "//M7JSSSn/KXSCSItywOh6YfAk5Ywwr24zesYQ05PGzY4ODtnj3fF2Q2M2NG2Wx7C0z7ex4M8zMM1v8PGDFmjBie2Ww2m808zD3GGGPOhmGMY3wPhjkYhj0YDkej+WEwb4zHGHscg+Azm808H4ZhDMMYntnMM5vNPJ7ZbOaDYRwPDzZgDZiZYRgGP/ADwzDMzA+GOQZgGPgwZvfWS6+9nwH4ARg8PH5mfufD37Y927Z93jAMwzB4n9lsNpvNPm+MN8Z4f4w3xhi+wWA3m818s9nsN5vNZtu2bYwxxhhjjB3z2ebx2czmY4wxxvjHHffee++ttttuZ2dvb3t7c3M+Y2NjY2NjPt+2bd8wDD5jY2NjY2M+MGCPzWbz2GxmfozjOH8/wzAMwzCz2Ww2m8088zzPnucxc7ab3axmNe5wBxvDZjw8PDxmw2ObjYPBYDB/GA7DcBj+PzMzM/NDGMMYwo8xxhhj7AEMhkcyAz/DHphvNvMBw/Bt+759vHEcBg8wGM92u9l4PPP/YOABnPEZhmEYfpvNY/CNxz7D8G3btm3Dtm0MMMYYY4wdw7B9z7Pt27Zt7bZt27ZtG922bdsGHNv9buPftu/bNwwDPtvtZvPBYDD9MzNvPI8f5htjDAfbtm3bBWObzcbhM9vmn3/MMAN3G4djuwNjm43G4TAYBj/GMMYPnDF2DmOMAzMzMzMzA8cYw7kx5m8PL6WUUno=",
+    "bagl_font_character": [
+      {
+        "char": 32,
+        "char_width": 4,
+        "x_offset": 0,
+        "y_offset": 6,
+        "bitmap_byte_count": 0,
+        "bitmap_offset": 0
+      },
+      {
+        "char": 33,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 0
+      },
+      {
+        "char": 34,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 2
+      },
+      {
+        "char": 35,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 4
+      },
+      {
+        "char": 36,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 0,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 11
+      },
+      {
+        "char": 37,
+        "char_width": 12,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 19
+      },
+      {
+        "char": 38,
+        "char_width": 10,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 30
+      },
+      {
+        "char": 39,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 39
+      },
+      {
+        "char": 40,
+        "char_width": 5,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 40
+      },
+      {
+        "char": 41,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 45
+      },
+      {
+        "char": 42,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 49
+      },
+      {
+        "char": 43,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 2,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 53
+      },
+      {
+        "char": 44,
+        "char_width": 4,
+        "x_offset": 1,
+        "y_offset": 7,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 57
+      },
+      {
+        "char": 45,
+        "char_width": 5,
+        "x_offset": 1,
+        "y_offset": 5,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 58
+      },
+      {
+        "char": 46,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 7,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 59
+      },
+      {
+        "char": 47,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 60
+      },
+      {
+        "char": 48,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 65
+      },
+      {
+        "char": 49,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 72
+      },
+      {
+        "char": 50,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 77
+      },
+      {
+        "char": 51,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 83
+      },
+      {
+        "char": 52,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 89
+      },
+      {
+        "char": 53,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 96
+      },
+      {
+        "char": 54,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 101
+      },
+      {
+        "char": 55,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 108
+      },
+      {
+        "char": 56,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 114
+      },
+      {
+        "char": 57,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 121
+      },
+      {
+        "char": 58,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 128
+      },
+      {
+        "char": 59,
+        "char_width": 4,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 130
+      },
+      {
+        "char": 60,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 2,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 133
+      },
+      {
+        "char": 61,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 4,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 138
+      },
+      {
+        "char": 62,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 2,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 141
+      },
+      {
+        "char": 63,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 145
+      },
+      {
+        "char": 64,
+        "char_width": 11,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 151
+      },
+      {
+        "char": 65,
+        "char_width": 9,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 163
+      },
+      {
+        "char": 66,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 171
+      },
+      {
+        "char": 67,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 177
+      },
+      {
+        "char": 68,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 183
+      },
+      {
+        "char": 69,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 190
+      },
+      {
+        "char": 70,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 195
+      },
+      {
+        "char": 71,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 200
+      },
+      {
+        "char": 72,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 207
+      },
+      {
+        "char": 73,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 214
+      },
+      {
+        "char": 74,
+        "char_width": 5,
+        "x_offset": 0,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 217
+      },
+      {
+        "char": 75,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 224
+      },
+      {
+        "char": 76,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 231
+      },
+      {
+        "char": 77,
+        "char_width": 12,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 236
+      },
+      {
+        "char": 78,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 246
+      },
+      {
+        "char": 79,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 254
+      },
+      {
+        "char": 80,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 262
+      },
+      {
+        "char": 81,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 268
+      },
+      {
+        "char": 82,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 278
+      },
+      {
+        "char": 83,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 285
+      },
+      {
+        "char": 84,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 290
+      },
+      {
+        "char": 85,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 296
+      },
+      {
+        "char": 86,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 303
+      },
+      {
+        "char": 87,
+        "char_width": 12,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 309
+      },
+      {
+        "char": 88,
+        "char_width": 9,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 320
+      },
+      {
+        "char": 89,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 328
+      },
+      {
+        "char": 90,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 335
+      },
+      {
+        "char": 91,
+        "char_width": 6,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 342
+      },
+      {
+        "char": 92,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 347
+      },
+      {
+        "char": 93,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 352
+      },
+      {
+        "char": 94,
+        "char_width": 7,
+        "x_offset": 0,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 359
+      },
+      {
+        "char": 95,
+        "char_width": 7,
+        "x_offset": 0,
+        "y_offset": 10,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 364
+      },
+      {
+        "char": 96,
+        "char_width": 8,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 365
+      },
+      {
+        "char": 97,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 366
+      },
+      {
+        "char": 98,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 372
+      },
+      {
+        "char": 99,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 378
+      },
+      {
+        "char": 100,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 383
+      },
+      {
+        "char": 101,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 390
+      },
+      {
+        "char": 102,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 396
+      },
+      {
+        "char": 103,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 402
+      },
+      {
+        "char": 104,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 410
+      },
+      {
+        "char": 105,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 416
+      },
+      {
+        "char": 106,
+        "char_width": 5,
+        "x_offset": 0,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 419
+      },
+      {
+        "char": 107,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 426
+      },
+      {
+        "char": 108,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 432
+      },
+      {
+        "char": 109,
+        "char_width": 11,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 435
+      },
+      {
+        "char": 110,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 442
+      },
+      {
+        "char": 111,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 447
+      },
+      {
+        "char": 112,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 452
+      },
+      {
+        "char": 113,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 459
+      },
+      {
+        "char": 114,
+        "char_width": 6,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 467
+      },
+      {
+        "char": 115,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 470
+      },
+      {
+        "char": 116,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 2,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 474
+      },
+      {
+        "char": 117,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 479
+      },
+      {
+        "char": 118,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 484
+      },
+      {
+        "char": 119,
+        "char_width": 11,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 489
+      },
+      {
+        "char": 120,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 497
+      },
+      {
+        "char": 121,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 503
+      },
+      {
+        "char": 122,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 511
+      },
+      {
+        "char": 123,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 516
+      },
+      {
+        "char": 124,
+        "char_width": 7,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 523
+      },
+      {
+        "char": 125,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 529
+      },
+      {
+        "char": 126,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 4,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 535
+      },
+      {
+        "char": 127,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 537
+      }
+    ],
+    "bagl_font": {
+      "font_id": 8,
+      "bpp": 1,
+      "char_height": 12,
+      "baseline_height": 9,
+      "char_leftmost_x": -1,
+      "first_char": 32,
+      "last_char": 127
+    }
+  }
+]

--- a/lib_bagl/src/bagl_font_open_sans_light_16px.json
+++ b/lib_bagl/src/bagl_font_open_sans_light_16px.json
@@ -1,0 +1,784 @@
+[
+  {
+    "bitmap": "VVVQKaUEkECCCCL+I4HEf0QQQQIJCDwKCQkKHDhISCkeCAaRCImQBEmQMqYESZCESIhEMByIIIIIFDAgUUhBBTKMT1VSkiRJEgmJJEmSpAQICAh/FBQiCAgIfwgICJICBxsQgiAEQRCCIAQcIkFBQUFBQUFBIhwEQ4FAIBAIBAKBHiEgICAgEAgEAgF/HiFAIDAeIEBAQCAfQMBAQYKEiBAh/4EAAQI+AgICAR9gQEBAIR44BgIBAT1DQUFBQjx/QCAgIBAQCAgIBAQcIkFBIhwiQUFBQT4eIUFBQWFeQEAgMA4bAGADGwAgCUAwDAMMMEB/AAB/AQYYYBgGAQ8EQRBCCAIgCPCBQQgQ8RSRElJCSkiJKe4EAAFAAPABMMAAAxJIIEEIPwIJJFCAHyFBQSEfIUFBQSEf+AgICBAgQIAAAQQQwAcfQgQJFChQoECBgoT4v0AgEPgFAoFA4Ad/EARB8AdBEAT4IYAAAhCAAIQvQAESEIHwA4EEEkgggfwTSCCBBBJIIFVVVQRBEARBEARBEAQxwVAkURgUEpFIKAhBEARBEARBEPwBEjADMzCFUiiFkiRJEiMxEiCBDDJIIYUkEkkkoQQTTCB4IIRAAhSgAAUoQAESCCHwn1AoFAp9AoFAIHgghEACFKAABShAARIIIfAABEAABh8hQUFBIR8RESFBQT5BAQEBDjBAQEBAP38EAoFAIBAIBAIBgQQSSCCBBBJIIIEEIgQPAQUkiCCCEEEEESigAAEEwaAwJAyJRCIRSUKSUCgUCoaBYSAQggQRQYICAgoURIgICgiBhAghQQIDBggQIECAf0AgIBAICAQCAgF/HxEREREREQ+BIAgEQRAIgkAPIYQQQgghhNADCBQUIiJBQX+BQB4QCOQLhWIuAQIECNBjSKBAgQIFGtIDPEEgEAgEBDyAAAECxEtYoECBAgUSxgscIkFBfwEBQjw4QRAfQRAEQRAE/CJCQiI8BAJ8QoFDPgEBAQEdI0FBQUFBQUEBkiRJBABCCCGEEELIAYFAIBCKJAqFRSQUBEmSJEkSnWOMBKEgFISCUBAKQkEIHSNBQUFBQUFBHCJBQUFBQSIcPYYEChQoUKAhPQIECBC8hAUKFChQIGG8AAECBAh9hBBCCAFeEAwMBEEP4gkhhBCCA0FBQUFBQUFiXkFBIiIiFBQUCGEoRmIkSZJEKQyDEAgBoZCEwWBIQiFBQSIiIhQUFAgIBAQDH4QghCAEHxhBEARBDARBEASBASGEEEIIIYQQQggBQxBCCMGEEELEB3g/ISEhISEhISEhPw==",
+    "bagl_font_character": [
+      {
+        "char": 32,
+        "char_width": 6,
+        "x_offset": 0,
+        "y_offset": 8,
+        "bitmap_byte_count": 0,
+        "bitmap_offset": 0
+      },
+      {
+        "char": 33,
+        "char_width": 5,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 0
+      },
+      {
+        "char": 34,
+        "char_width": 8,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 3
+      },
+      {
+        "char": 35,
+        "char_width": 12,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 6
+      },
+      {
+        "char": 36,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 13,
+        "bitmap_offset": 21
+      },
+      {
+        "char": 37,
+        "char_width": 15,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 18,
+        "bitmap_offset": 34
+      },
+      {
+        "char": 38,
+        "char_width": 13,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 52
+      },
+      {
+        "char": 39,
+        "char_width": 5,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 67
+      },
+      {
+        "char": 40,
+        "char_width": 6,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 68
+      },
+      {
+        "char": 41,
+        "char_width": 6,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 74
+      },
+      {
+        "char": 42,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 80
+      },
+      {
+        "char": 43,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 2,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 87
+      },
+      {
+        "char": 44,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 11,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 94
+      },
+      {
+        "char": 45,
+        "char_width": 7,
+        "x_offset": 3,
+        "y_offset": 8,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 96
+      },
+      {
+        "char": 46,
+        "char_width": 6,
+        "x_offset": 3,
+        "y_offset": 11,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 97
+      },
+      {
+        "char": 47,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 98
+      },
+      {
+        "char": 48,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 107
+      },
+      {
+        "char": 49,
+        "char_width": 11,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 119
+      },
+      {
+        "char": 50,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 129
+      },
+      {
+        "char": 51,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 141
+      },
+      {
+        "char": 52,
+        "char_width": 11,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 14,
+        "bitmap_offset": 153
+      },
+      {
+        "char": 53,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 167
+      },
+      {
+        "char": 54,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 179
+      },
+      {
+        "char": 55,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 191
+      },
+      {
+        "char": 56,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 203
+      },
+      {
+        "char": 57,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 215
+      },
+      {
+        "char": 58,
+        "char_width": 6,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 227
+      },
+      {
+        "char": 59,
+        "char_width": 6,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 231
+      },
+      {
+        "char": 60,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 235
+      },
+      {
+        "char": 61,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 5,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 242
+      },
+      {
+        "char": 62,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 246
+      },
+      {
+        "char": 63,
+        "char_width": 9,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 253
+      },
+      {
+        "char": 64,
+        "char_width": 13,
+        "x_offset": 0,
+        "y_offset": 1,
+        "bitmap_byte_count": 23,
+        "bitmap_offset": 262
+      },
+      {
+        "char": 65,
+        "char_width": 12,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 285
+      },
+      {
+        "char": 66,
+        "char_width": 12,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 300
+      },
+      {
+        "char": 67,
+        "char_width": 12,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 14,
+        "bitmap_offset": 312
+      },
+      {
+        "char": 68,
+        "char_width": 13,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 13,
+        "bitmap_offset": 326
+      },
+      {
+        "char": 69,
+        "char_width": 11,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 339
+      },
+      {
+        "char": 70,
+        "char_width": 10,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 350
+      },
+      {
+        "char": 71,
+        "char_width": 14,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 17,
+        "bitmap_offset": 359
+      },
+      {
+        "char": 72,
+        "char_width": 14,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 376
+      },
+      {
+        "char": 73,
+        "char_width": 6,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 391
+      },
+      {
+        "char": 74,
+        "char_width": 6,
+        "x_offset": 0,
+        "y_offset": 1,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 394
+      },
+      {
+        "char": 75,
+        "char_width": 11,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 405
+      },
+      {
+        "char": 76,
+        "char_width": 10,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 416
+      },
+      {
+        "char": 77,
+        "char_width": 14,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 18,
+        "bitmap_offset": 425
+      },
+      {
+        "char": 78,
+        "char_width": 14,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 443
+      },
+      {
+        "char": 79,
+        "char_width": 14,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 16,
+        "bitmap_offset": 458
+      },
+      {
+        "char": 80,
+        "char_width": 11,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 474
+      },
+      {
+        "char": 81,
+        "char_width": 14,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 21,
+        "bitmap_offset": 484
+      },
+      {
+        "char": 82,
+        "char_width": 12,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 505
+      },
+      {
+        "char": 83,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 517
+      },
+      {
+        "char": 84,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 529
+      },
+      {
+        "char": 85,
+        "char_width": 14,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 540
+      },
+      {
+        "char": 86,
+        "char_width": 12,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 555
+      },
+      {
+        "char": 87,
+        "char_width": 15,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 21,
+        "bitmap_offset": 570
+      },
+      {
+        "char": 88,
+        "char_width": 11,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 14,
+        "bitmap_offset": 591
+      },
+      {
+        "char": 89,
+        "char_width": 11,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 13,
+        "bitmap_offset": 605
+      },
+      {
+        "char": 90,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 618
+      },
+      {
+        "char": 91,
+        "char_width": 7,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 630
+      },
+      {
+        "char": 92,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 638
+      },
+      {
+        "char": 93,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 647
+      },
+      {
+        "char": 94,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 657
+      },
+      {
+        "char": 95,
+        "char_width": 9,
+        "x_offset": 1,
+        "y_offset": 14,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 664
+      },
+      {
+        "char": 96,
+        "char_width": 11,
+        "x_offset": 5,
+        "y_offset": 0,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 665
+      },
+      {
+        "char": 97,
+        "char_width": 10,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 667
+      },
+      {
+        "char": 98,
+        "char_width": 12,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 675
+      },
+      {
+        "char": 99,
+        "char_width": 10,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 690
+      },
+      {
+        "char": 100,
+        "char_width": 12,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 698
+      },
+      {
+        "char": 101,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 713
+      },
+      {
+        "char": 102,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 0,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 722
+      },
+      {
+        "char": 103,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 4,
+        "bitmap_byte_count": 13,
+        "bitmap_offset": 732
+      },
+      {
+        "char": 104,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 13,
+        "bitmap_offset": 745
+      },
+      {
+        "char": 105,
+        "char_width": 6,
+        "x_offset": 3,
+        "y_offset": 2,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 758
+      },
+      {
+        "char": 106,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 2,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 762
+      },
+      {
+        "char": 107,
+        "char_width": 10,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 772
+      },
+      {
+        "char": 108,
+        "char_width": 6,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 784
+      },
+      {
+        "char": 109,
+        "char_width": 14,
+        "x_offset": 1,
+        "y_offset": 4,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 789
+      },
+      {
+        "char": 110,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 804
+      },
+      {
+        "char": 111,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 813
+      },
+      {
+        "char": 112,
+        "char_width": 12,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 14,
+        "bitmap_offset": 822
+      },
+      {
+        "char": 113,
+        "char_width": 12,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 15,
+        "bitmap_offset": 836
+      },
+      {
+        "char": 114,
+        "char_width": 8,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 851
+      },
+      {
+        "char": 115,
+        "char_width": 9,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 857
+      },
+      {
+        "char": 116,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 864
+      },
+      {
+        "char": 117,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 871
+      },
+      {
+        "char": 118,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 4,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 880
+      },
+      {
+        "char": 119,
+        "char_width": 14,
+        "x_offset": 2,
+        "y_offset": 4,
+        "bitmap_byte_count": 14,
+        "bitmap_offset": 889
+      },
+      {
+        "char": 120,
+        "char_width": 10,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 903
+      },
+      {
+        "char": 121,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 4,
+        "bitmap_byte_count": 13,
+        "bitmap_offset": 911
+      },
+      {
+        "char": 122,
+        "char_width": 9,
+        "x_offset": 3,
+        "y_offset": 4,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 924
+      },
+      {
+        "char": 123,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 12,
+        "bitmap_offset": 931
+      },
+      {
+        "char": 124,
+        "char_width": 8,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 943
+      },
+      {
+        "char": 125,
+        "char_width": 8,
+        "x_offset": 3,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 954
+      },
+      {
+        "char": 126,
+        "char_width": 11,
+        "x_offset": 3,
+        "y_offset": 6,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 963
+      },
+      {
+        "char": 127,
+        "char_width": 12,
+        "x_offset": 4,
+        "y_offset": 2,
+        "bitmap_byte_count": 11,
+        "bitmap_offset": 965
+      }
+    ],
+    "bagl_font": {
+      "font_id": 9,
+      "bpp": 1,
+      "char_height": 17,
+      "baseline_height": 13,
+      "char_leftmost_x": -2,
+      "first_char": 32,
+      "last_char": 127
+    }
+  }
+]

--- a/lib_bagl/src/bagl_font_open_sans_regular_11px.json
+++ b/lib_bagl/src/bagl_font_open_sans_regular_11px.json
@@ -1,0 +1,784 @@
+[
+  {
+    "bitmap": "VUUbIJKfQvlJBK8Uw9gDIxUVbVtUVGIOCQkGJSkRLwOSkkQSlWoFBPEzEsiPUgMBSEQiEiallFIyphBCCCEHIUREeAchgxA6EAxFIvlBIC+EhxA6LoSXUjIPIUKEECYlk1IyJqX0EDoBBAIAKYiMQRAPPEEwJgKHSCIgfATlKlWqVL8APggKhSLyiYJfFD1RFH3eEARBMHifUCgUCoU+L4QXQng/hPBDCL5AIBALhXyhUOgXCoVCVVVERERENFFSDEUShSGEEEL4w4YNK1UqU6ZMoVGplErFQj5BQUFBQUE+TxRFTxAEPkFBQUFBQT4QIE8URU8SRS6EwRA6H0EQBEEQoVAoFAqFPEGRSEShUBAxyiSTUkopRQghIQmDwZBIQqEkMQiCIA8RIkJ4T5IkOSEiRIRHREREdAwjSSEfIQ+9lB5B8ERRFD0eEeEQ5EVRFHkuvRAcTDwhhBC+JDmCF4YeQfBEURRFUVUERERERAchpDJKSlVV7yJFihQpEk8URVEEThRFkQNPFEXREwQBXhRFkQdBEE+SF0N48iIiDlEURdEHoSRJDAMRValSRYQIKRmTEqEkSQxDEAMfESI+lpRIMkmSJEkjIkQiMoMBXxRFURR9",
+    "bagl_font_character": [
+      {
+        "char": 32,
+        "char_width": 4,
+        "x_offset": 0,
+        "y_offset": 6,
+        "bitmap_byte_count": 0,
+        "bitmap_offset": 0
+      },
+      {
+        "char": 33,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 0
+      },
+      {
+        "char": 34,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 2
+      },
+      {
+        "char": 35,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 3
+      },
+      {
+        "char": 36,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 2,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 10
+      },
+      {
+        "char": 37,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 15
+      },
+      {
+        "char": 38,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 23
+      },
+      {
+        "char": 39,
+        "char_width": 3,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 31
+      },
+      {
+        "char": 40,
+        "char_width": 4,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 32
+      },
+      {
+        "char": 41,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 36
+      },
+      {
+        "char": 42,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 39
+      },
+      {
+        "char": 43,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 4,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 43
+      },
+      {
+        "char": 44,
+        "char_width": 4,
+        "x_offset": 1,
+        "y_offset": 8,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 45
+      },
+      {
+        "char": 45,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 6,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 46
+      },
+      {
+        "char": 46,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 8,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 47
+      },
+      {
+        "char": 47,
+        "char_width": 5,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 48
+      },
+      {
+        "char": 48,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 52
+      },
+      {
+        "char": 49,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 57
+      },
+      {
+        "char": 50,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 62
+      },
+      {
+        "char": 51,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 67
+      },
+      {
+        "char": 52,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 72
+      },
+      {
+        "char": 53,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 79
+      },
+      {
+        "char": 54,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 84
+      },
+      {
+        "char": 55,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 89
+      },
+      {
+        "char": 56,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 94
+      },
+      {
+        "char": 57,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 99
+      },
+      {
+        "char": 58,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 104
+      },
+      {
+        "char": 59,
+        "char_width": 4,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 106
+      },
+      {
+        "char": 60,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 2,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 109
+      },
+      {
+        "char": 61,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 4,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 113
+      },
+      {
+        "char": 62,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 2,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 115
+      },
+      {
+        "char": 63,
+        "char_width": 6,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 119
+      },
+      {
+        "char": 64,
+        "char_width": 11,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 123
+      },
+      {
+        "char": 65,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 133
+      },
+      {
+        "char": 66,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 140
+      },
+      {
+        "char": 67,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 146
+      },
+      {
+        "char": 68,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 152
+      },
+      {
+        "char": 69,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 159
+      },
+      {
+        "char": 70,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 164
+      },
+      {
+        "char": 71,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 169
+      },
+      {
+        "char": 72,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 176
+      },
+      {
+        "char": 73,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 183
+      },
+      {
+        "char": 74,
+        "char_width": 4,
+        "x_offset": 0,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 185
+      },
+      {
+        "char": 75,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 190
+      },
+      {
+        "char": 76,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 196
+      },
+      {
+        "char": 77,
+        "char_width": 11,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 9,
+        "bitmap_offset": 201
+      },
+      {
+        "char": 78,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 210
+      },
+      {
+        "char": 79,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 8,
+        "bitmap_offset": 217
+      },
+      {
+        "char": 80,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 225
+      },
+      {
+        "char": 81,
+        "char_width": 10,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 231
+      },
+      {
+        "char": 82,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 241
+      },
+      {
+        "char": 83,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 247
+      },
+      {
+        "char": 84,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 252
+      },
+      {
+        "char": 85,
+        "char_width": 9,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 258
+      },
+      {
+        "char": 86,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 265
+      },
+      {
+        "char": 87,
+        "char_width": 11,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 10,
+        "bitmap_offset": 272
+      },
+      {
+        "char": 88,
+        "char_width": 8,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 282
+      },
+      {
+        "char": 89,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 289
+      },
+      {
+        "char": 90,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 295
+      },
+      {
+        "char": 91,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 300
+      },
+      {
+        "char": 92,
+        "char_width": 5,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 304
+      },
+      {
+        "char": 93,
+        "char_width": 5,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 308
+      },
+      {
+        "char": 94,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 313
+      },
+      {
+        "char": 95,
+        "char_width": 6,
+        "x_offset": 0,
+        "y_offset": 10,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 317
+      },
+      {
+        "char": 96,
+        "char_width": 7,
+        "x_offset": 3,
+        "y_offset": 0,
+        "bitmap_byte_count": 1,
+        "bitmap_offset": 318
+      },
+      {
+        "char": 97,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 319
+      },
+      {
+        "char": 98,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 323
+      },
+      {
+        "char": 99,
+        "char_width": 6,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 329
+      },
+      {
+        "char": 100,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 332
+      },
+      {
+        "char": 101,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 338
+      },
+      {
+        "char": 102,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 342
+      },
+      {
+        "char": 103,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 347
+      },
+      {
+        "char": 104,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 354
+      },
+      {
+        "char": 105,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 360
+      },
+      {
+        "char": 106,
+        "char_width": 4,
+        "x_offset": 0,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 362
+      },
+      {
+        "char": 107,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 368
+      },
+      {
+        "char": 108,
+        "char_width": 4,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 373
+      },
+      {
+        "char": 109,
+        "char_width": 11,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 375
+      },
+      {
+        "char": 110,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 382
+      },
+      {
+        "char": 111,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 387
+      },
+      {
+        "char": 112,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 392
+      },
+      {
+        "char": 113,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 399
+      },
+      {
+        "char": 114,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 406
+      },
+      {
+        "char": 115,
+        "char_width": 6,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 3,
+        "bitmap_offset": 408
+      },
+      {
+        "char": 116,
+        "char_width": 5,
+        "x_offset": 1,
+        "y_offset": 2,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 411
+      },
+      {
+        "char": 117,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 415
+      },
+      {
+        "char": 118,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 420
+      },
+      {
+        "char": 119,
+        "char_width": 10,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 425
+      },
+      {
+        "char": 120,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 3,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 432
+      },
+      {
+        "char": 121,
+        "char_width": 7,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 7,
+        "bitmap_offset": 436
+      },
+      {
+        "char": 122,
+        "char_width": 6,
+        "x_offset": 1,
+        "y_offset": 3,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 443
+      },
+      {
+        "char": 123,
+        "char_width": 5,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 447
+      },
+      {
+        "char": 124,
+        "char_width": 7,
+        "x_offset": 4,
+        "y_offset": 1,
+        "bitmap_byte_count": 4,
+        "bitmap_offset": 451
+      },
+      {
+        "char": 125,
+        "char_width": 5,
+        "x_offset": 1,
+        "y_offset": 1,
+        "bitmap_byte_count": 5,
+        "bitmap_offset": 455
+      },
+      {
+        "char": 126,
+        "char_width": 7,
+        "x_offset": 2,
+        "y_offset": 4,
+        "bitmap_byte_count": 2,
+        "bitmap_offset": 460
+      },
+      {
+        "char": 127,
+        "char_width": 8,
+        "x_offset": 2,
+        "y_offset": 1,
+        "bitmap_byte_count": 6,
+        "bitmap_offset": 462
+      }
+    ],
+    "bagl_font": {
+      "font_id": 10,
+      "bpp": 1,
+      "char_height": 12,
+      "baseline_height": 9,
+      "char_leftmost_x": -1,
+      "first_char": 32,
+      "last_char": 127
+    }
+  }
+]


### PR DESCRIPTION
## Description
Contains the .json files with font data for Nano X & Nano S+
(those files are JSON versions of the .inc files, to be able to use them with Python to fix speculos OCR troubles)