### PR TITLE
STAX Touch debug data syscalls factorization

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -79,6 +79,12 @@ typedef struct io_touch_info_s {
     uint8_t h;
 } io_touch_info_t;
 
+typedef enum io_touch_debug_mode_e {
+    TOUCH_DEBUG_END = 0,
+    TOUCH_DEBUG_READ_RAW_DATA = 1,
+    TOUCH_DEBUG_READ_DIFF_DATA = 2,
+} io_touch_debug_mode_t;
+
 // bitfield for exclusion borders, for touch_exclude_borders() (if a bit is set, means that pixels on this border are not taken into account)
 #define LEFT_BORDER   1
 #define RIGHT_BORDER  2
@@ -90,8 +96,7 @@ SYSCALL void touch_get_last_info(io_touch_info_t *info);
 SYSCALL void touch_set_state(bool enable);
 SYSCALL uint8_t touch_exclude_borders(uint8_t excluded_borders);
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-SYSCALL void touch_read_sensitivity(uint8_t *sensi_data);
-SYSCALL void touch_read_diff_data(uint8_t *diff_data);
+SYSCALL uint8_t touch_switch_debug_mode_and_read(io_touch_debug_mode_t mode, uint8_t *read_buffer);
 #endif
 #endif
 #endif // HAVE_SE_TOUCH

--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -131,8 +131,9 @@ void io_seproxyhal_nfc_init(ndef_struct_t *ndef_message, bool async, bool forceI
 
 #ifdef HAVE_SE_TOUCH
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-void io_seproxyhal_touch_read_sensi(uint8_t * sensi_data);
-void io_seproxyhal_touch_read_diff_data(uint8_t * sensi_data);
+bolos_bool_t io_seproxyhal_touch_debug_read_sensi(uint8_t * sensi_data);
+bolos_bool_t io_seproxyhal_touch_debug_read_diff_data(uint8_t * sensi_data);
+bolos_bool_t io_seproxyhal_touch_debug_end(void);
 #endif
 #endif
 

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -312,8 +312,7 @@
 #define SYSCALL_touch_exclude_borders_ID                                 0x01fa000d
 #define SYSCALL_touch_set_state_ID                                       0x01fa000e
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-#define SYSCALL_touch_read_sensi_ID                                      0x01fa000f
-#define SYSCALL_touch_read_diff_data_ID                                  0x01fa0010
+#define SYSCALL_touch_debug_ID                                           0x02fa000f
 #endif
 
 #endif // HAVE_SE_TOUCH

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -501,12 +501,34 @@ void io_seproxyhal_nfc_init(ndef_struct_t *ndef_message, bool async, bool forceI
 
 #ifdef HAVE_SE_TOUCH
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-void io_seproxyhal_touch_read_sensi(uint8_t * sensi_data) {
-  touch_read_sensitivity(sensi_data);
+/**
+ * @brief Set touch in read raw data mode and read raw data
+ *
+ * @param sensi_data Pointer to the buffer to store sensi data
+ * @return BOLOS_TRUE/BOLOS_FALSE
+ */
+bolos_bool_t io_seproxyhal_touch_debug_read_sensi(uint8_t * sensi_data) {
+  return touch_switch_debug_mode_and_read(TOUCH_DEBUG_READ_RAW_DATA, sensi_data);
 }
 
-void io_seproxyhal_touch_read_diff_data(uint8_t *diff_data) {
-  touch_read_diff_data(diff_data);
+/**
+ * @brief Set touch in read diff data mode and read diff data
+ *
+ * @param diff_data Pointer to the buffer to store diff data
+ * @return BOLOS_TRUE/BOLOS_FALSE
+ */
+bolos_bool_t io_seproxyhal_touch_debug_read_diff_data(uint8_t *diff_data) {
+  return touch_switch_debug_mode_and_read(TOUCH_DEBUG_READ_DIFF_DATA, diff_data);
+}
+
+/**
+ * @brief Set touch in read coordinates mode
+ *
+ * @param None
+ * @return BOLOS_TRUE/BOLOS_FALSE
+ */
+bolos_bool_t io_seproxyhal_touch_debug_end(void) {
+  return touch_switch_debug_mode_and_read(TOUCH_DEBUG_END, NULL);
 }
 #endif
 #endif

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1822,14 +1822,11 @@ uint8_t touch_exclude_borders(uint8_t excluded_borders) {
 }
 
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-void touch_read_sensitivity(uint8_t *sensi_data) {
-  unsigned int parameters[1] = {(unsigned int) sensi_data};
-  SVC_Call(SYSCALL_touch_read_sensi_ID, parameters);
-}
-
-void touch_read_diff_data(uint8_t *diff_data) {
-  unsigned int parameters[1] = {(unsigned int) diff_data};
-  SVC_Call(SYSCALL_touch_read_diff_data_ID, parameters);
+uint8_t touch_switch_debug_mode_and_read(io_touch_debug_mode_t mode, uint8_t *read_buffer) {
+    unsigned int parameters[2];
+    parameters[0] = (unsigned int) mode;
+    parameters[1] = (unsigned int) read_buffer;
+    return (uint8_t)SVC_Call(SYSCALL_touch_debug_ID, parameters);
 }
 #endif
 


### PR DESCRIPTION
## Description

Syscalls with ID SYSCALL_touch_read_sensi_ID and SYSCALL_touch_read_diff_data_ID are merged into one syscall with ID SYSCALL_touch_debug_ID
A second parameter has been added to the merged syscall to allow "dispatching" the two previous syscalls
So depending on this parameter value, this new syscall can:
- fetch touch raw data
- fetch touch diff data
- set touch panel in "read coordinates mode" (used by a caller script, to setup STAX in "standard mode" (ie read coordinates) after test

Breaking API change with SDK functions renaming (touch debug functions only used by STAX touch test apps)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
