### PR TITLE
Fat: Fine tune alignments

### DIFF
--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -28,7 +28,7 @@ extern "C" {
 #define VALIDATE_KEY '\r'
 
 // for Keyboard
-#define KEYBOARD_KEY_HEIGHT         56
+#define KEYBOARD_KEY_HEIGHT         60
 
 // for Keypad
 #define KEYPAD_KEY_HEIGHT           104
@@ -37,7 +37,10 @@ extern "C" {
 #define EXIT_PAGE 0xFF
 
 // external margin in pixels
-#define BORDER_MARGIN 20
+#define BORDER_MARGIN 24
+
+// Back button header height
+#define BACK_BUTTON_HEADER_HEIGHT 88
 
 // common dimensions for buttons
 #define BUTTON_RADIUS RADIUS_40_PIXELS

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -967,7 +967,7 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
     // init button for this choice
     button->activeColor = BLACK;
     button->borderColor = LIGHT_GRAY;
-    button->alignmentMarginX = INNER_MARGIN;
+    button->alignmentMarginX = INNER_MARGIN-4;
     button->alignTo = (nbgl_obj_t*)container;
     button->alignment = MID_RIGHT;
     button->state = OFF_STATE;
@@ -1231,6 +1231,7 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
   qrcode->text = PIC(info->url);
   qrcode->bpp = NBGL_BPP_1;
   qrcode->alignment = TOP_MIDDLE;
+  qrcode->alignmentMarginY = 24;
 
   fullHeight += qrcode->height;
   container->children[container->nbChildren] = (nbgl_obj_t*)qrcode;
@@ -1940,7 +1941,7 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, const char *text, bool fixed) {
   textArea->text = PIC(text);
   textArea->textAlignment = CENTER;
   textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-  textArea->alignmentMarginY = 36;
+  textArea->alignmentMarginY = 20;
   textArea->alignTo = (nbgl_obj_t*)spinner;
   textArea->alignment = BOTTOM_MIDDLE;
   textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
@@ -1981,7 +1982,7 @@ int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInf
 
   // create keyboard
   keyboard = (nbgl_keyboard_t*)nbgl_objPoolGet(KEYBOARD, layoutInt->layer);
-  keyboard->alignmentMarginY = 60;
+  keyboard->alignmentMarginY = 64;
   keyboard->alignment = BOTTOM_MIDDLE;
   keyboard->borderColor = LIGHT_GRAY;
   keyboard->callback = PIC(kbdInfo->callback);
@@ -2327,7 +2328,7 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout, bool active, const c
   if (obj == NULL)
     return -1;
 
-  button->alignmentMarginY = BORDER_MARGIN+4;
+  button->alignmentMarginY = BORDER_MARGIN;
   button->alignment = TOP_MIDDLE;
   button->foregroundColor = WHITE;
   if (active) {
@@ -2485,8 +2486,8 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits) {
   // 12 pixels between each icon (knowing that the effective round are 18px large and the icon 24px)
   container->width = nbDigits*C_round_24px.width + (nbDigits+1)*12;
   container->height = 48;
-  // distance from digits to title is fixed to 24 px
-  container->alignmentMarginY = 24;
+  // distance from digits to title is fixed to 20 px
+  container->alignmentMarginY = 20;
   // item N-2 is the title
   container->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-2];
   container->alignment = BOTTOM_MIDDLE;

--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -325,7 +325,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
     rectArea.width = C_shift32px.width;
     rectArea.height = C_shift32px.height;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2;
+    rectArea.y0 = (keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
     rectArea.x0 = (SHIFT_KEY_WIDTH-rectArea.width)/2;
     rectArea.backgroundColor = (keyboard->casing != LOWER_CASE)?BLACK:WHITE;
     nbgl_frontDrawImage(&rectArea,
@@ -351,7 +351,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   rectArea.height = C_backspace32px.height;
   rectArea.bpp = NBGL_BPP_1;
   rectArea.x0 = offsetX + 7*NORMAL_KEY_WIDTH;
-  rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2;
+  rectArea.y0 = (keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
   if (!keyboard->lettersOnly) {
     rectArea.x0 += (BACKSPACE_KEY_WIDTH_FULL-rectArea.width)/2;
   }


### PR DESCRIPTION

## Description

Fine tune some alignements on Stax to match with figma screens.

Impacted alignments:

- Keyboards
- Radio buttons
- Spinner
- Pin bullets

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
