### PR TITLE
lib_standard_app: main.c: Improvements

### DIFF
--- a/lib_standard_app/main.c
+++ b/lib_standard_app/main.c
@@ -26,15 +26,8 @@ bolos_ux_params_t G_ux_params;
 /**
  * Exit the application and go back to the dashboard.
  */
-WEAK void app_exit() {
-    BEGIN_TRY_L(exit) {
-        TRY_L(exit) {
-            os_sched_exit(-1);
-        }
-        FINALLY_L(exit) {
-        }
-    }
-    END_TRY_L(exit);
+WEAK void __attribute__((noreturn)) app_exit(void) {
+    os_sched_exit(-1);
 }
 
 /**

--- a/lib_standard_app/main.c
+++ b/lib_standard_app/main.c
@@ -38,40 +38,34 @@ WEAK __attribute__((section(".boot"))) int main() {
 
     os_boot();
 
-    for (;;) {
-        // Initialize the UX system
-        UX_INIT();
+    BEGIN_TRY {
+        TRY {
+            UX_INIT();
 
-        BEGIN_TRY {
-            TRY {
-                io_seproxyhal_init();
+            io_seproxyhal_init();
 
 #ifdef HAVE_BLE
-                G_io_app.plane_mode = os_setting_get(OS_SETTING_PLANEMODE, NULL, 0);
+            G_io_app.plane_mode = os_setting_get(OS_SETTING_PLANEMODE, NULL, 0);
 #endif // HAVE_BLE
-                USB_power(0);
-                USB_power(1);
+            USB_power(0);
+            USB_power(1);
 
 #ifdef HAVE_BLE
-                BLE_power(0, NULL);
-                BLE_power(1, NULL);
+            BLE_power(0, NULL);
+            BLE_power(1, NULL);
 #endif // HAVE_BLE
-                app_main();
-            }
-            CATCH(EXCEPTION_IO_RESET) {
-                CLOSE_TRY;
-                continue;
-            }
-            CATCH_ALL {
-                CLOSE_TRY;
-                break;
-            }
-            FINALLY {
-            }
+
+            app_main();
         }
-        END_TRY;
+        CATCH_OTHER(e) {
+            PRINTF("Exiting following exception: %d\n", e);
+        }
+        FINALLY {
+        }
     }
+    END_TRY;
 
+    // Exit the application and go back to the dashboard.
     app_exit();
 
     return 0;

--- a/lib_standard_app/main.c
+++ b/lib_standard_app/main.c
@@ -44,9 +44,6 @@ WEAK __attribute__((section(".boot"))) int main() {
 
             io_seproxyhal_init();
 
-#ifdef HAVE_BLE
-            G_io_app.plane_mode = os_setting_get(OS_SETTING_PLANEMODE, NULL, 0);
-#endif // HAVE_BLE
             USB_power(0);
             USB_power(1);
 


### PR DESCRIPTION
## Description

Previous behavior was to catch the Exception and somehow restart the app. This was somehow hiding the error as the user would not see the app crash. As Exception should not be raised in nominal situation or should be caught before, we changed the behavior to directly exit the app.

This also have the benefit of avoiding issue where the whole app BSS should be reset to have a sane behavior when the app was restarted.

Linked to https://github.com/LedgerHQ/app-boilerplate/pull/85

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
