### PR TITLE
Do not use anonymous struct anymore

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -20,8 +20,6 @@ ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME),TARGET_NANOS TARGET_NANOX TARGET_NA
 SDK_SOURCE_PATH += lib_bagl lib_ux
 else ifeq ($(TARGET_NAME),TARGET_STAX)
 SDK_SOURCE_PATH += lib_nbgl lib_ux_stax qrcode lib_nfc
-CFLAGS += -fms-extensions
-CFLAGS += -Wno-microsoft-anon-tag
 endif
 
 # adding the correct target header to sources

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -178,10 +178,6 @@ typedef struct {
  */
 typedef void (*nbgl_touchCallback_t)(void *obj, nbgl_touchType_t eventType) ;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmicrosoft-anon-tag"
-#endif // __clang__
 /**
  * @brief Common structure for all graphical objects
  *
@@ -207,7 +203,7 @@ typedef struct PACKED__ nbgl_obj_s {
  *
  */
 typedef struct PACKED__ nbgl_container_s {
-    struct nbgl_obj_s; ///< common part
+    nbgl_obj_t obj; ///< common part
     nbgl_direction_t layout; ///< layout of children inside this object
     uint8_t nbChildren;
     bool forceClean; ///< if set to true, a paint will be done with background color
@@ -219,7 +215,7 @@ typedef struct PACKED__ nbgl_container_s {
  *
  */
 typedef struct PACKED__ nbgl_line_s {
-    struct nbgl_obj_s; ///<  common part
+    nbgl_obj_t obj; ///<  common part
     nbgl_direction_t direction; ///< direction of the line, e.g @ref VERTICAL or @ref HORIZONTAL
     color_t lineColor; ///< color of the line
     uint8_t thickness; ///< thickness of the line in pixel, maybe different from height for horizontal line
@@ -238,7 +234,7 @@ typedef nbgl_icon_details_t* (*onImageDrawCallback_t)(uint8_t token);
  *
  */
 typedef struct PACKED__ nbgl_image_s {
-    struct nbgl_obj_s; // common part
+    nbgl_obj_t obj; // common part
     color_t foregroundColor; ///< color set to '1' bits, for 1PBB images. '0' are set to background color.
     const nbgl_icon_details_t *buffer; ///< buffer containing bitmap, with exact same size as object (width*height*bpp/8 bytes)
     onImageDrawCallback_t onDrawCallback; ///< function called if buffer is NULL, with above token as parameter. Can be NULL
@@ -251,7 +247,7 @@ typedef struct PACKED__ nbgl_image_s {
  *
  */
 typedef struct PACKED__ nbgl_image_file_s {
-    struct nbgl_obj_s; // common part
+    nbgl_obj_t obj; // common part
     const uint8_t *buffer; ///< buffer containing image file
 } nbgl_image_file_t;
 
@@ -260,7 +256,7 @@ typedef struct PACKED__ nbgl_image_file_s {
  *
  */
 typedef struct PACKED__ nbgl_qrcode_s {
-    struct nbgl_obj_s; // common part
+    nbgl_obj_t obj; // common part
     color_t foregroundColor; ///< color set to '1' bits, for 1PBB images. '0' are set to background color.
     nbgl_qrcode_version_t version; ///< requested version, if V10, size will be fixed to 228*228, if V4, size will be fixed to 132*132
     const char *text; ///< text single line (NULL terminated)
@@ -273,7 +269,7 @@ typedef struct PACKED__ nbgl_qrcode_s {
  *
  */
 typedef struct PACKED__ nbgl_radio_s {
-    struct nbgl_obj_s; // common part
+    nbgl_obj_t obj; // common part
     color_t activeColor; ///< color set to to inner circle, when active.
     color_t borderColor; ///< color set to border.
     nbgl_state_t state; ///< state of the radio button. Active is when state == @ref ON_STATE
@@ -284,7 +280,7 @@ typedef struct PACKED__ nbgl_radio_s {
  *
  */
 typedef struct PACKED__ nbgl_switch_s {
-    struct nbgl_obj_s; // common part
+    nbgl_obj_t obj; // common part
     color_t onColor; ///< color set to border and knob, when ON (knob on the right).
     color_t offColor; ///< color set to border and knob, when OFF (knob on the left).
     nbgl_state_t state; ///< state of the switch.
@@ -295,7 +291,7 @@ typedef struct PACKED__ nbgl_switch_s {
  * @note if withBorder, the stroke of the border is fixed (3 pixels)
  */
 typedef struct PACKED__ nbgl_progress_bar_s {
-    struct nbgl_obj_s; // common part
+    nbgl_obj_t obj; // common part
     bool withBorder; ///< if set to true, a border in black surround the whole object
     uint8_t state; ///< state of the progress, in % (from 0 to 100).
     color_t foregroundColor; ///< color of the inner progress bar and border (if applicable)
@@ -309,7 +305,7 @@ typedef struct PACKED__ nbgl_progress_bar_s {
  * @note height is fixed
  */
 typedef struct PACKED__ nbgl_navigation_bar_s {
-    struct nbgl_obj_s; ///< common part
+    nbgl_obj_t obj; ///< common part
     uint8_t nbPages; ///< number of pages.
     uint8_t activePage; ///< index of active page (from 0 to nbPages-1).
 } nbgl_page_indicator_t;
@@ -328,7 +324,7 @@ typedef char* (*onTextDrawCallback_t)(uint8_t token);
  *
  */
 typedef struct PACKED__ nbgl_button_s {
-    struct nbgl_obj_s; ///< common part
+    nbgl_obj_t obj; ///< common part
     color_t innerColor; ///< color set inside of the button
     color_t borderColor; ///< color set to button's border
     color_t foregroundColor; ///< color set to '1' bits in icon, and text. '0' are set to innerColor color.
@@ -349,7 +345,7 @@ typedef struct PACKED__ nbgl_button_s {
  *
  */
 typedef struct PACKED__ nbgl_text_area_s {
-    struct nbgl_obj_s; ///< common part
+    nbgl_obj_t obj; ///< common part
     color_t textColor; ///< color set to '1' bits in text. '0' are set to backgroundColor color.
     nbgl_aligment_t textAlignment; ///< alignment of text within the area
     nbgl_style_t style; ///< to define the style of border
@@ -371,7 +367,7 @@ typedef struct PACKED__ nbgl_text_area_s {
  *
  */
 typedef struct PACKED__ nbgl_spinner_s {
-    struct nbgl_obj_s; ///< common part
+    nbgl_obj_t obj; ///< common part
     uint8_t position; ///< position of the spinner (from 0 to 3). If set to 0xFF, the spinner is entirely black
 } nbgl_spinner_t;
 
@@ -407,7 +403,7 @@ typedef enum {
  *
  */
 typedef struct PACKED__ nbgl_keyboard_s {
-    struct nbgl_obj_s; ///< common part
+    nbgl_obj_t obj; ///< common part
     color_t textColor; ///< color set to letters.
     color_t borderColor; ///< color set to key borders
     bool lettersOnly; ///< if true, only display letter keys and Backspace
@@ -424,7 +420,7 @@ typedef struct PACKED__ nbgl_keyboard_s {
  *
  */
 typedef struct PACKED__ nbgl_keypad_s {
-    struct nbgl_obj_s; ///< common part
+    nbgl_obj_t obj; ///< common part
     color_t textColor; ///< color set to digits.
     color_t borderColor; ///< color set to key borders
     bool enableBackspace; ///< if true, Backspace key is enabled
@@ -434,9 +430,6 @@ typedef struct PACKED__ nbgl_keypad_s {
     uint8_t digitIndexes[5]; ///< array of digits indexes, 4 bits per digit
     keyboardCallback_t callback; ///< function called when an active key is pressed
 } nbgl_keypad_t;
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif // __clang__
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -188,7 +188,7 @@ typedef void (*nbgl_touchCallback_t)(void *obj, nbgl_touchType_t eventType) ;
  * @note this type must never be instantiated
  */
 typedef struct PACKED__ nbgl_obj_s {
-    struct nbgl_area_s ; ///< absolute position, backGround color and size of the object. DO NOT MOVE THIS FIELD
+    nbgl_area_t area; ///< absolute position, backGround color and size of the object. DO NOT MOVE THIS FIELD
     nbgl_obj_type_t type; ///< type of the graphical object, must be explicitly set
     int16_t rel_x0; ///< horizontal position of top-left corner relative to parent's top-left corner
     int16_t rel_y0; ///< vertical position of top-left corner relative to parent's top-left corner, must be multiple of 4

--- a/lib_nbgl/include/nbgl_screen.h
+++ b/lib_nbgl/include/nbgl_screen.h
@@ -36,7 +36,6 @@ typedef void (*nbgl_tickerCallback_t)(void);
  *
  */
 typedef struct PACKED__ nbgl_screenTickerConfiguration_s {
-  nbgl_touchCallback_t touchCallback; ///< function to be called on events defined in touchMask field in each sub-object
   nbgl_tickerCallback_t tickerCallback; ///< callback called when ticker timer is fired. Set to NULL for no ticker
   uint32_t tickerValue; ///< timer initial value, in ms (should be multiple of 100 ms). Set to 0 for no ticker
   uint32_t tickerIntervale; ///< for periodic timers, the intervale in ms to rearm the timer (should be multiple of 100 ms). Set to 0 for one-shot timers
@@ -48,20 +47,13 @@ typedef struct PACKED__ nbgl_screenTickerConfiguration_s {
  * @note inherits from container
  *
  */
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmicrosoft-anon-tag"
-#endif // __clang__
 typedef struct PACKED__ nbgl_screen_s {
-    struct nbgl_container_s; ///< common part
-    struct nbgl_screenTickerConfiguration_s; ///< ticker configuration
+    nbgl_container_t container; ///< common part
+    nbgl_screenTickerConfiguration_t ticker; ///< ticker configuration
+    nbgl_touchCallback_t touchCallback; ///< function to be called on events defined in touchMask field in each sub-object
     struct nbgl_screen_s *next; ///< pointer to screen on top of this one (or NULL is this screen is top of stack)
     struct nbgl_screen_s *previous; ///< pointer to screen on bottom of this one (or NULL is this screen is bottom of stack)
 } nbgl_screen_t;
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif // __clang__
-
 
 /**********************
  * GLOBAL PROTOTYPES

--- a/lib_nbgl/serialization/Makefile
+++ b/lib_nbgl/serialization/Makefile
@@ -3,7 +3,7 @@ INC := -I ../include/ -I ../../lib_ux_stax/
 DEFINES := -DLINUX_SIMU -DHAVE_LANGUAGE_PACK -DNBGL_GENERATE_DATA_TEST
 
 default: generate_data_test.c
-	gcc $(INC) -fms-extensions generate_data_test.c $(DEFINES) ../src/nbgl_serialize.c -o generate_data_test
+	gcc $(INC) generate_data_test.c $(DEFINES) ../src/nbgl_serialize.c -o generate_data_test
 
 run_test: default
 	./generate_data_test > data_test.txt

--- a/lib_nbgl/src/nbgl_bottom_button.c
+++ b/lib_nbgl/src/nbgl_bottom_button.c
@@ -56,8 +56,8 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, boo
   nbgl_container_t *container;
 
   container = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layer);
-  container->width = SCREEN_WIDTH;
-  container->height = BUTTON_DIAMETER+2*BORDER_MARGIN;
+  container->area.width = SCREEN_WIDTH;
+  container->area.height = BUTTON_DIAMETER+2*BORDER_MARGIN;
   container->layout = HORIZONTAL ;
   container->nbChildren = NB_MAX_CHILDREN;
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren, layer);
@@ -66,8 +66,8 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, boo
   button = (nbgl_button_t*)nbgl_objPoolGet(BUTTON,layer);
   button->innerColor = WHITE;
   button->borderColor = LIGHT_GRAY;
-  button->width = BUTTON_DIAMETER;
-  button->height = BUTTON_DIAMETER;
+  button->area.width = BUTTON_DIAMETER;
+  button->area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
   button->icon = icon;
   button->alignment = CENTER;
@@ -79,8 +79,8 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, boo
     // create horizontal line
     line = (nbgl_line_t*)nbgl_objPoolGet(LINE,0);
     line->lineColor = LIGHT_GRAY;
-    line->width = SCREEN_WIDTH;
-    line->height = 4;
+    line->area.width = SCREEN_WIDTH;
+    line->area.height = 4;
     line->direction = HORIZONTAL;
     line->thickness = 1;
     line->alignmentMarginY = BORDER_MARGIN-4;

--- a/lib_nbgl/src/nbgl_bottom_button.c
+++ b/lib_nbgl/src/nbgl_bottom_button.c
@@ -56,22 +56,22 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, boo
   nbgl_container_t *container;
 
   container = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layer);
-  container->area.width = SCREEN_WIDTH;
-  container->area.height = BUTTON_DIAMETER+2*BORDER_MARGIN;
+  container->obj.area.width = SCREEN_WIDTH;
+  container->obj.area.height = BUTTON_DIAMETER+2*BORDER_MARGIN;
   container->layout = HORIZONTAL ;
   container->nbChildren = NB_MAX_CHILDREN;
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren, layer);
-  container->alignment = NO_ALIGNMENT;
+  container->obj.alignment = NO_ALIGNMENT;
 
   button = (nbgl_button_t*)nbgl_objPoolGet(BUTTON,layer);
   button->innerColor = WHITE;
   button->borderColor = LIGHT_GRAY;
-  button->area.width = BUTTON_DIAMETER;
-  button->area.height = BUTTON_DIAMETER;
+  button->obj.area.width = BUTTON_DIAMETER;
+  button->obj.area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
   button->icon = icon;
-  button->alignment = CENTER;
-  button->touchMask = (1<<TOUCHED);
+  button->obj.alignment = CENTER;
+  button->obj.touchMask = (1<<TOUCHED);
   container->children[QUIT_BUTTON_INDEX] = (nbgl_obj_t*)button;
 
   if (separationLine) {
@@ -79,13 +79,13 @@ nbgl_container_t *nbgl_bottomButtonPopulate(const nbgl_icon_details_t *icon, boo
     // create horizontal line
     line = (nbgl_line_t*)nbgl_objPoolGet(LINE,0);
     line->lineColor = LIGHT_GRAY;
-    line->area.width = SCREEN_WIDTH;
-    line->area.height = 4;
+    line->obj.area.width = SCREEN_WIDTH;
+    line->obj.area.height = 4;
     line->direction = HORIZONTAL;
     line->thickness = 1;
-    line->alignmentMarginY = BORDER_MARGIN-4;
-    line->alignTo = (nbgl_obj_t*)button;
-    line->alignment = TOP_MIDDLE;
+    line->obj.alignmentMarginY = BORDER_MARGIN-4;
+    line->obj.alignTo = (nbgl_obj_t*)button;
+    line->obj.alignment = TOP_MIDDLE;
     container->children[LINE_INDEX] = (nbgl_obj_t*)line;
   }
 

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -367,8 +367,8 @@ static nbgl_line_t* createHorizontalLine(uint8_t layer) {
 
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE,layer);
   line->lineColor = LIGHT_GRAY;
-  line->width = SCREEN_WIDTH;
-  line->height = 4;
+  line->area.width = SCREEN_WIDTH;
+  line->area.height = 4;
   line->direction = HORIZONTAL;
   line->thickness = 1;
   return line;
@@ -379,8 +379,8 @@ static nbgl_line_t* createLeftVerticalLine(uint8_t layer) {
 
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE,layer);
   line->lineColor = LIGHT_GRAY;
-  line->width = 1;
-  line->height = SCREEN_HEIGHT;
+  line->area.width = 1;
+  line->area.height = SCREEN_HEIGHT;
   line->direction = VERTICAL;
   line->thickness = 1;
   line->alignment = MID_LEFT;
@@ -459,8 +459,8 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description) {
     layout->layer = 0;
   }
   layout->container = (nbgl_container_t*)nbgl_objPoolGet(CONTAINER,layout->layer);
-  layout->container->width = SCREEN_WIDTH;
-  layout->container->height = SCREEN_HEIGHT;
+  layout->container->area.width = SCREEN_WIDTH;
+  layout->container->area.height = SCREEN_HEIGHT;
   layout->container->layout = VERTICAL ;
   layout->container->children = nbgl_containerPoolGet(NB_MAX_CONTAINER_CHILDREN,layout->layer);
   layout->children[layout->nbChildren] = (nbgl_obj_t*)layout->container;
@@ -483,8 +483,8 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description) {
     layout->tapText->text = PIC(description->tapActionText);
     layout->tapText->textColor = DARK_GRAY;
     layout->tapText->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    layout->tapText->width = SCREEN_WIDTH - 2*BORDER_MARGIN;
-    layout->tapText->height = nbgl_getFontLineHeight(layout->tapText->fontId);
+    layout->tapText->area.width = SCREEN_WIDTH - 2*BORDER_MARGIN;
+    layout->tapText->area.height = nbgl_getFontLineHeight(layout->tapText->fontId);
     layout->tapText->textAlignment = CENTER;
     layout->tapText->alignmentMarginY = BORDER_MARGIN;
     layout->tapText->alignment = BOTTOM_MIDDLE;
@@ -516,8 +516,8 @@ int nbgl_layoutAddTopRightButton(nbgl_layout_t *layout, const nbgl_icon_details_
     return -1;
 
   addObjectToLayout(layoutInt,(nbgl_obj_t*)button);
-  button->width = BUTTON_DIAMETER;
-  button->height = BUTTON_DIAMETER;
+  button->area.width = BUTTON_DIAMETER;
+  button->area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
   button->alignmentMarginX = BORDER_MARGIN;
   button->alignmentMarginY = BORDER_MARGIN;
@@ -559,7 +559,7 @@ int nbgl_layoutAddNavigationBar(nbgl_layout_t *layout, const nbgl_layoutNavigati
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)layoutInt->bottomContainer;
   layoutInt->nbChildren++;
 
-  layoutInt->container->height -= layoutInt->bottomContainer->height;
+  layoutInt->container->area.height -= layoutInt->bottomContainer->area.height;
 
   if (info->withSeparationLine) {
     nbgl_line_t *line = createHorizontalLine(layoutInt->layer);
@@ -568,7 +568,7 @@ int nbgl_layoutAddNavigationBar(nbgl_layout_t *layout, const nbgl_layoutNavigati
     layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)line;
     layoutInt->nbChildren++;
 
-    layoutInt->container->height -= 4;
+    layoutInt->container->area.height -= 4;
   }
 
   return 0;
@@ -602,7 +602,7 @@ int nbgl_layoutAddBottomButton(nbgl_layout_t *layout, const nbgl_icon_details_t 
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)layoutInt->bottomContainer;
   layoutInt->nbChildren++;
 
-  layoutInt->container->height -= layoutInt->bottomContainer->height;
+  layoutInt->container->area.height -= layoutInt->bottomContainer->area.height;
 
   return 0;
 }
@@ -635,8 +635,8 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
   container->children = nbgl_containerPoolGet(4,layoutInt->layer);
   container->nbChildren = 0;
 
-  container->width = GET_AVAILABLE_WIDTH(layoutInt);
-  container->height = TOUCHABLE_BAR_HEIGHT;
+  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->area.height = TOUCHABLE_BAR_HEIGHT;
   container->layout = HORIZONTAL;
   container->alignmentMarginX = BORDER_MARGIN;
   container->alignment = NO_ALIGNMENT;
@@ -662,12 +662,12 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
     textArea->text = PIC(barLayout->text);
     textArea->onDrawCallback = NULL;
     textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-    textArea->width = container->width;
+    textArea->area.width = container->area.width;
     if (barLayout->iconLeft != NULL)
-      textArea->width -= imageLeft->buffer->width+12;
+      textArea->area.width -= imageLeft->buffer->width+12;
     if (barLayout->iconRight != NULL)
-      textArea->width -= ((nbgl_icon_details_t *)PIC(barLayout->iconRight))->width;
-    textArea->height = container->height;
+      textArea->area.width -= ((nbgl_icon_details_t *)PIC(barLayout->iconRight))->width;
+    textArea->area.height = container->area.height;
     textArea->style = NO_STYLE;
     if ((barLayout->iconLeft != NULL) && (barLayout->centered != true))
       textArea->alignmentMarginX = 12;
@@ -709,14 +709,14 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
     textArea->text = PIC(barLayout->subText);
     textArea->textAlignment = MID_LEFT;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+    textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
     textArea->style = NO_STYLE;
     textArea->alignment = BOTTOM_LEFT;
     textArea->alignmentMarginY = BORDER_MARGIN;
-    textArea->width = container->width;
+    textArea->area.width = container->area.width;
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
-    container->height += textArea->height+16;
+    container->area.height += textArea->area.height+16;
   }
 
   // set this new container as child of main container
@@ -750,21 +750,21 @@ int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switc
 
   // get container children
   container->children = nbgl_containerPoolGet(3,layoutInt->layer);
-  container->width = GET_AVAILABLE_WIDTH(layoutInt);
-  container->height = 2*BORDER_MARGIN;
+  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->area.height = 2*BORDER_MARGIN;
   container->layout = VERTICAL;
   container->alignmentMarginX = BORDER_MARGIN;
   container->alignment = NO_ALIGNMENT;
   container->touchMask = (1<<TOUCHED);
 
-  textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA,layoutInt->layer);
+  textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
   textArea->textColor = BLACK;
   textArea->text = PIC(switchLayout->text);
   textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-  textArea->width = container->width - 60; // the switch icon has 60px width
-  textArea->height = nbgl_getTextHeight(BAGL_FONT_INTER_SEMIBOLD_24px,textArea->text);
-  container->height += textArea->height;
+  textArea->area.width = container->area.width - 60; // the switch icon has 60px width
+  textArea->area.height = nbgl_getTextHeight(BAGL_FONT_INTER_SEMIBOLD_24px, textArea->text);
+  container->area.height += textArea->area.height;
   textArea->alignment = TOP_LEFT;
   textArea->alignmentMarginY = BORDER_MARGIN;
   container->children[0] = (nbgl_obj_t*)textArea;
@@ -778,14 +778,14 @@ int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switc
   container->children[1] = (nbgl_obj_t*)switchObj;
 
   if (switchLayout->subText != NULL) {
-    subTextArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA,layoutInt->layer);
+    subTextArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
     subTextArea->textColor = BLACK;
     subTextArea->text = PIC(switchLayout->subText);
     subTextArea->textAlignment = MID_LEFT;
     subTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    subTextArea->width = container->width;
-    subTextArea->height = nbgl_getTextHeight(BAGL_FONT_INTER_REGULAR_24px,subTextArea->text);
-    container->height += subTextArea->height + INNER_MARGIN;
+    subTextArea->area.width = container->area.width;
+    subTextArea->area.height = nbgl_getTextHeight(BAGL_FONT_INTER_REGULAR_24px, subTextArea->text);
+    container->area.height += subTextArea->area.height + INNER_MARGIN;
     subTextArea->alignment = NO_ALIGNMENT;
     subTextArea->alignmentMarginY = INNER_MARGIN;
     container->children[2] = (nbgl_obj_t*)subTextArea;
@@ -827,7 +827,7 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     container->nbChildren++;
 
   container->children = nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
-  container->width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
 
   if (text != NULL) {
     textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA,layoutInt->layer);
@@ -836,12 +836,12 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     textArea->text = PIC(text);
     textArea->textAlignment = MID_LEFT;
     textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-    textArea->height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+    textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
     textArea->style = NO_STYLE;
     textArea->alignment = NO_ALIGNMENT;
     textArea->alignmentMarginY = BORDER_MARGIN;
-    textArea->width = container->width;
-    fullHeight += textArea->height;
+    textArea->area.width = container->area.width;
+    fullHeight += textArea->area.height;
     container->children[0] = (nbgl_obj_t*)textArea;
   }
   if (subText != NULL) {
@@ -850,11 +850,11 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     subTextArea->text = PIC(subText);
     subTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
     subTextArea->style = NO_STYLE;
-    subTextArea->width = container->width;
-    subTextArea->height = nbgl_getTextHeightInWidth(subTextArea->fontId,subTextArea->text,subTextArea->width,false);
+    subTextArea->area.width = container->area.width;
+    subTextArea->area.height = nbgl_getTextHeightInWidth(subTextArea->fontId,subTextArea->text,subTextArea->area.width,false);
     subTextArea->textAlignment = MID_LEFT;
     subTextArea->alignment = NO_ALIGNMENT;
-    fullHeight += subTextArea->height;
+    fullHeight += subTextArea->area.height;
     if (text != NULL) {
       subTextArea->alignmentMarginY = INTERNAL_MARGIN;
       fullHeight += INTERNAL_MARGIN;
@@ -865,7 +865,7 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
       container->children[0] = (nbgl_obj_t*)subTextArea;
     }
   }
-  container->height = fullHeight+2*BORDER_MARGIN;
+  container->area.height = fullHeight+2*BORDER_MARGIN;
   container->layout = VERTICAL;
   container->alignmentMarginX = BORDER_MARGIN;
   container->alignment = NO_ALIGNMENT;
@@ -895,8 +895,8 @@ int nbgl_layoutAddLargeCaseText(nbgl_layout_t *layout, const char *text) {
   textArea->text = PIC(text);
   textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_MEDIUM_32px;
-  textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-  textArea->height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->width,false);
+  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
   textArea->style = NO_STYLE;
   textArea->alignment = NO_ALIGNMENT;
   textArea->alignmentMarginX = BORDER_MARGIN;
@@ -957,8 +957,8 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
     }
 
     textArea->textAlignment = MID_LEFT;
-    textArea->width = 300;
-    textArea->height = 24;
+    textArea->area.width = 300;
+    textArea->area.height = 24;
     textArea->style = NO_STYLE;
     textArea->alignment = MID_LEFT;
     textArea->alignTo = (nbgl_obj_t*)container;
@@ -973,8 +973,8 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
     button->state = OFF_STATE;
     container->children[1] = (nbgl_obj_t*)button;
 
-    container->width = SCREEN_WIDTH-2*BORDER_MARGIN;
-    container->height = 32;
+    container->area.width = SCREEN_WIDTH-2*BORDER_MARGIN;
+    container->area.height = 32;
     container->alignment = NO_ALIGNMENT;
     container->alignmentMarginX = BORDER_MARGIN;
     container->alignmentMarginY = BORDER_MARGIN;
@@ -1033,7 +1033,7 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     image = (nbgl_image_t *)nbgl_objPoolGet(IMAGE,layoutInt->layer);
     image->foregroundColor = BLACK;
     image->buffer = PIC(info->icon);
-    image->bpp = NBGL_BPP_1;
+    image->area.bpp = NBGL_BPP_1;
     image->alignment = TOP_MIDDLE;
     image->alignTo = NULL;
 
@@ -1059,13 +1059,13 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     else {
       textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
     }
-    textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->width,false);
+    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
 
     if (info->style == LEDGER_INFO) {
       textArea->style = LEDGER_BORDER;
-      textArea->width = SCREEN_WIDTH - 2*40;
-      textArea->height += 2*16;
+      textArea->area.width = SCREEN_WIDTH - 2*40;
+      textArea->area.height += 2*16;
     }
     else
       textArea->style = NO_STYLE;
@@ -1079,7 +1079,7 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
       textArea->alignTo = NULL;
     }
 
-    fullHeight += textArea->height+textArea->alignmentMarginY;
+    fullHeight += textArea->area.height+textArea->alignmentMarginY;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
@@ -1097,8 +1097,8 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     textArea->text = PIC(info->text2);
     textArea->textAlignment = CENTER;
     textArea->fontId = (info->style != LARGE_CASE_BOLD_INFO) ? BAGL_FONT_INTER_REGULAR_24px: BAGL_FONT_INTER_SEMIBOLD_24px;
-    textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->width,false);
+    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
 
     textArea->style = NO_STYLE;
     if (container->nbChildren>0) {
@@ -1118,7 +1118,7 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
       textArea->alignment = TOP_MIDDLE;
     }
 
-    fullHeight += textArea->height + textArea->alignmentMarginY;
+    fullHeight += textArea->area.height + textArea->alignmentMarginY;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
@@ -1126,7 +1126,7 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
   // draw small horizontal line if PLUGIN_INFO
   if (info->style == PLUGIN_INFO) {
     nbgl_line_t *line = createHorizontalLine(layoutInt->layer);
-    line->width = 120;
+    line->area.width = 120;
     line->alignmentMarginY = 32;
     line->alignmentMarginX = 0;
     line->alignment = BOTTOM_MIDDLE;
@@ -1151,8 +1151,8 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     textArea->text = PIC(info->text3);
     textArea->textAlignment = CENTER;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->width,false);
+    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
     textArea->style = NO_STYLE;
     if (container->nbChildren>0) {
       textArea->alignment = BOTTOM_MIDDLE;
@@ -1164,12 +1164,12 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
       textArea->alignTo = NULL;
     }
 
-    fullHeight += textArea->height+textArea->alignmentMarginY;
+    fullHeight += textArea->area.height+textArea->alignmentMarginY;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
   }
-  container->height = fullHeight;
+  container->area.height = fullHeight;
   container->layout = VERTICAL;
   if (info->onTop) {
     container->alignmentMarginX = BORDER_MARGIN;
@@ -1181,7 +1181,7 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     container->alignment = CENTER;
   }
 
-  container->width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
 
   // set this new container as child of main container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
@@ -1215,9 +1215,9 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
   container->children = nbgl_containerPoolGet(2, layoutInt->layer);
   container->nbChildren = 0;
 
-  qrcode = (nbgl_qrcode_t *)nbgl_objPoolGet(QR_CODE,layoutInt->layer);
+  qrcode = (nbgl_qrcode_t *)nbgl_objPoolGet(QR_CODE, layoutInt->layer);
   // version is forced to V10 if url is longer than 62 characters
-  if (strlen(PIC(info->url))>62) {
+  if (strlen(PIC(info->url)) > 62) {
     qrcode->version = QRCODE_V10;
   }
   else {
@@ -1226,52 +1226,52 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
   qrcode->foregroundColor = BLACK;
   // in QR V4, we use 8*8 screen pixels for one QR pixel
   // in QR V10, we use 4*4 screen pixels for one QR pixel
-  qrcode->width = (qrcode->version == QRCODE_V4)?(QR_V4_NB_PIX_SIZE*8):(QR_V10_NB_PIX_SIZE*4);
-  qrcode->height = qrcode->width;
+  qrcode->area.width = (qrcode->version == QRCODE_V4) ? (QR_V4_NB_PIX_SIZE * 8) : (QR_V10_NB_PIX_SIZE * 4);
+  qrcode->area.height = qrcode->area.width;
   qrcode->text = PIC(info->url);
-  qrcode->bpp = NBGL_BPP_1;
+  qrcode->area.bpp = NBGL_BPP_1;
   qrcode->alignment = TOP_MIDDLE;
   qrcode->alignmentMarginY = 24;
 
-  fullHeight += qrcode->height;
+  fullHeight += qrcode->area.height;
   container->children[container->nbChildren] = (nbgl_obj_t*)qrcode;
   container->nbChildren++;
 
   if (info->text1 != NULL) {
-    textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA,layoutInt->layer);
+    textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
     textArea->textColor = BLACK;
     textArea->text = PIC(info->text1);
     textArea->textAlignment = CENTER;
     textArea->fontId = (info->largeText1 == true)? BAGL_FONT_INTER_MEDIUM_32px : BAGL_FONT_INTER_REGULAR_24px;
-    textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->width,false);
+    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
     textArea->alignment = BOTTOM_MIDDLE;
     textArea->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
     textArea->alignmentMarginY = 40;
 
-    fullHeight += textArea->height;
+    fullHeight += textArea->area.height;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
   }
   else if (info->text2 != NULL) {
-    textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA,layoutInt->layer);
+    textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
     textArea->textColor = DARK_GRAY;
     textArea->text = PIC(info->text2);
     textArea->textAlignment = CENTER;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->width,false);
+    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId, textArea->text, textArea->area.width, false);
     textArea->alignment = BOTTOM_MIDDLE;
     textArea->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
     textArea->alignmentMarginY = 40;
 
-    fullHeight += textArea->height;
+    fullHeight += textArea->area.height;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
   }
-  container->height = fullHeight;
+  container->area.height = fullHeight;
   container->layout = VERTICAL;
   // center the QRCode only if it's the first (and probably only) child
   if (layoutInt->container->nbChildren == 0) {
@@ -1283,7 +1283,7 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
     container->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
   }
 
-  container->width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
 
   // set this new container as child of main container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
@@ -1330,8 +1330,8 @@ int nbgl_layoutAddChoiceButtons(nbgl_layout_t *layout, const nbgl_layoutChoiceBu
   }
   bottomButton->innerColor = WHITE;
   bottomButton->foregroundColor = BLACK;
-  bottomButton->width = GET_AVAILABLE_WIDTH(layoutInt);
-  bottomButton->height = BUTTON_DIAMETER;
+  bottomButton->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  bottomButton->area.height = BUTTON_DIAMETER;
   bottomButton->radius = BUTTON_RADIUS;
   bottomButton->text = PIC(info->bottomText);
   bottomButton->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
@@ -1357,8 +1357,8 @@ int nbgl_layoutAddChoiceButtons(nbgl_layout_t *layout, const nbgl_layoutChoiceBu
   topButton->innerColor = BLACK;
   topButton->borderColor = BLACK;
   topButton->foregroundColor = WHITE;
-  topButton->width = bottomButton->width;
-  topButton->height = BUTTON_DIAMETER;
+  topButton->area.width = bottomButton->area.width;
+  topButton->area.height = BUTTON_DIAMETER;
   topButton->radius = BUTTON_RADIUS;
   topButton->text = PIC(info->topText);
   topButton->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
@@ -1413,8 +1413,8 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
     itemTextArea->text = PIC(pair->item);
     itemTextArea->textAlignment = MID_LEFT;
     itemTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    itemTextArea->width = usableWidth;
-    itemTextArea->height = nbgl_getTextHeightInWidth(itemTextArea->fontId,itemTextArea->text,usableWidth,false);
+    itemTextArea->area.width = usableWidth;
+    itemTextArea->area.height = nbgl_getTextHeightInWidth(itemTextArea->fontId,itemTextArea->text,usableWidth,false);
     itemTextArea->style = NO_STYLE;
     itemTextArea->alignment = NO_ALIGNMENT;
     itemTextArea->alignmentMarginX = 0;
@@ -1423,7 +1423,7 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
     container->children[container->nbChildren] = (nbgl_obj_t*)itemTextArea;
     container->nbChildren++;
 
-    fullHeight += itemTextArea->height;
+    fullHeight += itemTextArea->area.height;
 
     // init button for this choice
     valueTextArea->textColor = BLACK;
@@ -1435,11 +1435,11 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
       valueTextArea->fontId = BAGL_FONT_INTER_MEDIUM_32px;
     }
     if (pair->valueIcon == NULL) {
-      valueTextArea->width = usableWidth;
+      valueTextArea->area.width = usableWidth;
     }
     else {
       // we assume that value is single line
-      valueTextArea->width = nbgl_getTextWidth(valueTextArea->fontId, valueTextArea->text);
+      valueTextArea->area.width = nbgl_getTextWidth(valueTextArea->fontId, valueTextArea->text);
     }
 
     // handle the nbMaxLinesForValue parameter, used to automatically keep only
@@ -1451,7 +1451,7 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
       valueTextArea->nbMaxLines = list->nbMaxLinesForValue;
     }
     const nbgl_font_t *font = nbgl_getFont(valueTextArea->fontId);
-    valueTextArea->height = nbLines*font->line_height;
+    valueTextArea->area.height = nbLines*font->line_height;
     valueTextArea->style = NO_STYLE;
     valueTextArea->alignment = BOTTOM_LEFT;
     valueTextArea->alignmentMarginY = 4;
@@ -1460,7 +1460,7 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
     container->children[container->nbChildren] = (nbgl_obj_t*)valueTextArea;
     container->nbChildren++;
 
-    fullHeight += valueTextArea->height;
+    fullHeight += valueTextArea->area.height;
     if (pair->valueIcon != NULL) {
       nbgl_image_t *image = (nbgl_image_t *)nbgl_objPoolGet(IMAGE,layoutInt->layer);
       layoutObj_t *obj = addCallbackObj(layoutInt,(nbgl_obj_t*)image,list->token,TUNE_TAP_CASUAL);
@@ -1476,8 +1476,8 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
       container->nbChildren++;
     }
 
-    container->width = usableWidth;
-    container->height = fullHeight;
+    container->area.width = usableWidth;
+    container->area.height = fullHeight;
     container->layout = VERTICAL;
     container->alignmentMarginX = BORDER_MARGIN;
     container->alignmentMarginY = 12;
@@ -1511,8 +1511,8 @@ int nbgl_layoutAddProgressBar(nbgl_layout_t *layout, const nbgl_layoutProgressBa
     textArea->text = PIC(barLayout->text);
     textArea->textAlignment = MID_LEFT;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
-    textArea->height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+    textArea->area.width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
+    textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
     textArea->style = NO_STYLE;
     textArea->alignment = NO_ALIGNMENT;
     textArea->alignmentMarginX = BORDER_MARGIN;
@@ -1523,10 +1523,10 @@ int nbgl_layoutAddProgressBar(nbgl_layout_t *layout, const nbgl_layoutProgressBa
   progress->foregroundColor = BLACK;
   progress->withBorder = true;
   progress->state = barLayout->percentage;
-  progress->width = 120;
-  progress->height = 12;
+  progress->area.width = 120;
+  progress->area.height = 12;
   progress->alignment = NO_ALIGNMENT;
-  progress->alignmentMarginX = (GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout))-progress->width)/2;
+  progress->alignmentMarginX = (GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout))-progress->area.width)/2;
   progress->alignmentMarginY = BORDER_MARGIN;
   addObjectToLayout(layoutInt,(nbgl_obj_t*)progress);
 
@@ -1538,8 +1538,8 @@ int nbgl_layoutAddProgressBar(nbgl_layout_t *layout, const nbgl_layoutProgressBa
     subTextArea->text = PIC(barLayout->subText);
     subTextArea->textAlignment = MID_LEFT;
     subTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    subTextArea->width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
-    subTextArea->height = nbgl_getTextHeight(subTextArea->fontId,subTextArea->text);
+    subTextArea->area.width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
+    subTextArea->area.height = nbgl_getTextHeight(subTextArea->fontId,subTextArea->text);
     subTextArea->style = NO_STYLE;
     subTextArea->alignment = NO_ALIGNMENT;
     subTextArea->alignmentMarginX = BORDER_MARGIN;
@@ -1620,15 +1620,15 @@ int nbgl_layoutAddButton(nbgl_layout_t *layout, const nbgl_layoutButton_t *butto
   button->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   button->icon = PIC(buttonInfo->icon);
   if (buttonInfo->fittingContent == true) {
-    button->width = nbgl_getTextWidth(button->fontId,button->text)+64+((button->icon)?(button->icon->width+8):0);
-    button->height = 64;
+    button->area.width = nbgl_getTextWidth(button->fontId,button->text)+64+((button->icon)?(button->icon->width+8):0);
+    button->area.height = 64;
     button->radius = RADIUS_32_PIXELS;
     if (buttonInfo->onBottom != true)
-      button->alignmentMarginX += (SCREEN_WIDTH-2*BORDER_MARGIN-button->width)/2;
+      button->alignmentMarginX += (SCREEN_WIDTH-2*BORDER_MARGIN-button->area.width)/2;
   }
   else {
-    button->width = GET_AVAILABLE_WIDTH(layoutInt);
-    button->height = BUTTON_DIAMETER;
+    button->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    button->area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
   }
   button->alignTo = NULL;
@@ -1666,8 +1666,8 @@ int nbgl_layoutAddLongPressButton(nbgl_layout_t *layout, const char *text, uint8
   if (obj == NULL)
     return -1;
 
-  container->width = SCREEN_WIDTH;
-  container->height = 128;
+  container->area.width = SCREEN_WIDTH;
+  container->area.height = 128;
   container->layout = VERTICAL ;
   container->nbChildren = 4; // progress-bar + text + line + button
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
@@ -1680,8 +1680,8 @@ int nbgl_layoutAddLongPressButton(nbgl_layout_t *layout, const char *text, uint8
   button->innerColor = BLACK;
   button->foregroundColor = WHITE;
   button->borderColor = BLACK;
-  button->width = BUTTON_DIAMETER;
-  button->height = BUTTON_DIAMETER;
+  button->area.width = BUTTON_DIAMETER;
+  button->area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
   button->icon = PIC(&C_check32px);
   container->children[0] = (nbgl_obj_t*)button;
@@ -1691,8 +1691,8 @@ int nbgl_layoutAddLongPressButton(nbgl_layout_t *layout, const char *text, uint8
   textArea->text = PIC(text);
   textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_MEDIUM_32px;
-  textArea->width = container->width - 3 * BORDER_MARGIN - button->width;
-  textArea->height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+  textArea->area.width = container->area.width - 3 * BORDER_MARGIN - button->area.width;
+  textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
   textArea->style = NO_STYLE;
   textArea->alignment = MID_LEFT;
   textArea->alignmentMarginX = BORDER_MARGIN;
@@ -1705,8 +1705,8 @@ int nbgl_layoutAddLongPressButton(nbgl_layout_t *layout, const char *text, uint8
 
   progressBar = (nbgl_progress_bar_t *)nbgl_objPoolGet(PROGRESS_BAR,layoutInt->layer);
   progressBar->withBorder = false;
-  progressBar->width = container->width;
-  progressBar->height = 8;
+  progressBar->area.width = container->area.width;
+  progressBar->area.height = 8;
   progressBar->alignment = TOP_MIDDLE;
   progressBar->alignmentMarginY = 4;
   progressBar->alignTo = NULL;
@@ -1744,8 +1744,8 @@ int nbgl_layoutAddFooter(nbgl_layout_t *layout, const char *text, uint8_t token,
 
   textArea->alignment = BOTTOM_MIDDLE;
   textArea->textColor = BLACK;
-  textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-  textArea->height = BUTTON_DIAMETER;
+  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  textArea->area.height = BUTTON_DIAMETER;
   textArea->text = PIC(text);
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   textArea->textAlignment = CENTER;
@@ -1759,7 +1759,7 @@ int nbgl_layoutAddFooter(nbgl_layout_t *layout, const char *text, uint8_t token,
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)line;
   layoutInt->nbChildren++;
 
-  layoutInt->container->height -= textArea->height+line->height;
+  layoutInt->container->area.height -= textArea->area.height+line->area.height;
 
   return 0;
 }
@@ -1793,8 +1793,8 @@ int nbgl_layoutAddSplitFooter(nbgl_layout_t *layout, const char *leftText, uint8
 
   textArea->alignment = BOTTOM_LEFT;
   textArea->textColor = BLACK;
-  textArea->width = GET_AVAILABLE_WIDTH(layoutInt)/2;
-  textArea->height = BUTTON_DIAMETER;
+  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt)/2;
+  textArea->area.height = BUTTON_DIAMETER;
   textArea->text = PIC(leftText);
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   textArea->textAlignment = CENTER;
@@ -1810,8 +1810,8 @@ int nbgl_layoutAddSplitFooter(nbgl_layout_t *layout, const char *leftText, uint8
 
   textArea->alignment = BOTTOM_RIGHT;
   textArea->textColor = BLACK;
-  textArea->width = GET_AVAILABLE_WIDTH(layoutInt)/2;
-  textArea->height = BUTTON_DIAMETER;
+  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt)/2;
+  textArea->area.height = BUTTON_DIAMETER;
   textArea->text = PIC(rightText);
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   textArea->textAlignment = CENTER;
@@ -1829,15 +1829,15 @@ int nbgl_layoutAddSplitFooter(nbgl_layout_t *layout, const char *leftText, uint8
   // create vertical line separating both text areas
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE,layoutInt->layer);
   line->lineColor = LIGHT_GRAY;
-  line->width = 1;
-  line->height = textArea->height+4;
+  line->area.width = 1;
+  line->area.height = textArea->area.height+4;
   line->direction = VERTICAL;
   line->thickness = 1;
   line->alignment = BOTTOM_MIDDLE;
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)line;
   layoutInt->nbChildren++;
 
-  layoutInt->container->height -= textArea->height+4;
+  layoutInt->container->area.height -= textArea->area.height+4;
 
   return 0;
 }
@@ -1865,8 +1865,8 @@ int nbgl_layoutAddProgressIndicator(nbgl_layout_t *layout, uint8_t activePage, u
     return -1;
 
   container = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layoutInt->layer);
-  container->width = SCREEN_WIDTH;
-  container->height = BUTTON_DIAMETER+8;
+  container->area.width = SCREEN_WIDTH;
+  container->area.height = BUTTON_DIAMETER+8;
   container->layout = VERTICAL;
   container->nbChildren = 2;
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
@@ -1879,7 +1879,7 @@ int nbgl_layoutAddProgressIndicator(nbgl_layout_t *layout, uint8_t activePage, u
     navigationBar = (nbgl_page_indicator_t *)nbgl_objPoolGet(PAGE_INDICATOR,layoutInt->layer);
     navigationBar->activePage = activePage;
     navigationBar->nbPages = nbPages;
-    navigationBar->width = SCREEN_WIDTH-2*100;
+    navigationBar->area.width = SCREEN_WIDTH-2*100;
     navigationBar->alignment = CENTER;
     container->children[0] = (nbgl_obj_t*)navigationBar;
   }
@@ -1894,8 +1894,8 @@ int nbgl_layoutAddProgressIndicator(nbgl_layout_t *layout, uint8_t activePage, u
     button->innerColor = WHITE;
     button->foregroundColor = BLACK;
     button->borderColor = WHITE;
-    button->width = BUTTON_DIAMETER;
-    button->height = BUTTON_DIAMETER;
+    button->area.width = BUTTON_DIAMETER;
+    button->area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = PIC(&C_leftArrow32px);
@@ -1944,8 +1944,8 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, const char *text, bool fixed) {
   textArea->alignmentMarginY = 20;
   textArea->alignTo = (nbgl_obj_t*)spinner;
   textArea->alignment = BOTTOM_MIDDLE;
-  textArea->width = GET_AVAILABLE_WIDTH(layoutInt);
-  textArea->height = nbgl_getFontLineHeight(textArea->fontId);
+  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  textArea->area.height = nbgl_getFontLineHeight(textArea->fontId);
   textArea->style = NO_STYLE;
 
   // set this new spinner as child of the container
@@ -2080,8 +2080,8 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout, uint8_t nbUsedButtons
     return -1;
 
   container = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layoutInt->layer);
-  container->width = SCREEN_WIDTH;
-  container->height = 2*64+8;
+  container->area.width = SCREEN_WIDTH;
+  container->area.height = 2*64+8;
   container->layout = VERTICAL;
   container->nbChildren = NB_MAX_SUGGESTION_BUTTONS;
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
@@ -2099,8 +2099,8 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout, uint8_t nbUsedButtons
     choiceButtons[i]->innerColor = BLACK;
     choiceButtons[i]->borderColor = BLACK;
     choiceButtons[i]->foregroundColor = WHITE;
-    choiceButtons[i]->width = (SCREEN_WIDTH-2*BORDER_MARGIN-8)/2;
-    choiceButtons[i]->height = 64;
+    choiceButtons[i]->area.width = (SCREEN_WIDTH-2*BORDER_MARGIN-8)/2;
+    choiceButtons[i]->area.height = 64;
     choiceButtons[i]->radius = RADIUS_32_PIXELS;
     choiceButtons[i]->fontId = BAGL_FONT_INTER_SEMIBOLD_24px_1bpp;
     choiceButtons[i]->icon = NULL;
@@ -2202,8 +2202,8 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
   line->alignmentMarginY = offsetY;
   line->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
   line->alignment = TOP_MIDDLE;
-  line->width = SCREEN_WIDTH-2*32;
-  line->height = 4;
+  line->area.width = SCREEN_WIDTH-2*32;
+  line->area.height = 4;
   line->direction = HORIZONTAL;
   line->thickness = 2;
   line->offset = 2;
@@ -2221,8 +2221,8 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
     textArea->alignmentMarginY = 12;
     textArea->alignTo = (nbgl_obj_t*)line;
     textArea->alignment = TOP_LEFT;
-    textArea->width = 50;
-    textArea->height = nbgl_getFontLineHeight(textArea->fontId);
+    textArea->area.width = 50;
+    textArea->area.height = nbgl_getFontLineHeight(textArea->fontId);
     // set this new text area as child of the main container
     addObjectToLayout(layoutInt,(nbgl_obj_t*)textArea);
   }
@@ -2237,12 +2237,12 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
   textArea->alignTo = (nbgl_obj_t*)line;
   textArea->alignment = TOP_MIDDLE;
   if (numbered) {
-    textArea->width = line->width - 2*50;
+    textArea->area.width = line->area.width - 2*50;
   }
   else {
-    textArea->width = line->width;
+    textArea->area.width = line->area.width;
   }
-  textArea->height = nbgl_getFontLineHeight(textArea->fontId);
+  textArea->area.height = nbgl_getFontLineHeight(textArea->fontId);
   textArea->autoHideLongLine = true;
 
   obj = addCallbackObj(layoutInt,(nbgl_obj_t*)textArea,token,NBGL_NO_TUNE);
@@ -2298,7 +2298,7 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout, uint8_t index, bool numb
     nbgl_redrawObject((nbgl_obj_t*)textArea,NULL,false);
   }
   // if the text doesn't fit, indicate it by returning 1 instead of 0, for different refresh
-  if (nbgl_getSingleLineTextWidth(textArea->fontId, text) > textArea->width) {
+  if (nbgl_getSingleLineTextWidth(textArea->fontId, text) > textArea->area.width) {
     return 1;
   }
   return 0;
@@ -2342,8 +2342,8 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout, bool active, const c
   }
   button->text = PIC(text);
   button->fontId = BAGL_FONT_INTER_SEMIBOLD_24px_1bpp;
-  button->width = GET_AVAILABLE_WIDTH(layoutInt);
-  button->height = BUTTON_DIAMETER;
+  button->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  button->area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
   button->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
   // set this new button as child of the container
@@ -2484,10 +2484,10 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits) {
   container->nbChildren = nbDigits+1; // +1 for the line
   container->children = nbgl_containerPoolGet(container->nbChildren, layoutInt->layer);
   // 12 pixels between each icon (knowing that the effective round are 18px large and the icon 24px)
-  container->width = nbDigits*C_round_24px.width + (nbDigits+1)*12;
-  container->height = 48;
+  container->area.width = nbDigits*C_round_24px.width + (nbDigits+1)*12;
+  container->area.height = 48;
   // distance from digits to title is fixed to 20 px, except if title is more than 1 line and a back key is present
-  if ((layoutInt->container->nbChildren != 3) || (layoutInt->container->children[1]->height == 32)) {
+  if ((layoutInt->container->nbChildren != 3) || (layoutInt->container->children[1]->area.height == 32)) {
     container->alignmentMarginY = 20;
   }
   else {
@@ -2514,7 +2514,7 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits) {
     }
     else {
       image->alignment = NO_ALIGNMENT;
-      image->alignmentMarginY = (container->height - C_round_24px.width)/2;
+      image->alignmentMarginY = (container->area.height - C_round_24px.width)/2;
     }
   }
   // create gray line
@@ -2523,8 +2523,8 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits) {
   line->alignmentMarginY = 0;
   line->alignTo = NULL;
   line->alignment = BOTTOM_MIDDLE;
-  line->width = container->width;
-  line->height = 4;
+  line->area.width = container->area.width;
+  line->area.height = 4;
   line->direction = HORIZONTAL;
   line->thickness = 2;
   line->offset = 2;

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -367,8 +367,8 @@ static nbgl_line_t* createHorizontalLine(uint8_t layer) {
 
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE,layer);
   line->lineColor = LIGHT_GRAY;
-  line->area.width = SCREEN_WIDTH;
-  line->area.height = 4;
+  line->obj.area.width = SCREEN_WIDTH;
+  line->obj.area.height = 4;
   line->direction = HORIZONTAL;
   line->thickness = 1;
   return line;
@@ -379,11 +379,11 @@ static nbgl_line_t* createLeftVerticalLine(uint8_t layer) {
 
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE,layer);
   line->lineColor = LIGHT_GRAY;
-  line->area.width = 1;
-  line->area.height = SCREEN_HEIGHT;
+  line->obj.area.width = 1;
+  line->obj.area.height = SCREEN_HEIGHT;
   line->direction = VERTICAL;
   line->thickness = 1;
-  line->alignment = MID_LEFT;
+  line->obj.alignment = MID_LEFT;
   return line;
 }
 
@@ -459,8 +459,8 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description) {
     layout->layer = 0;
   }
   layout->container = (nbgl_container_t*)nbgl_objPoolGet(CONTAINER,layout->layer);
-  layout->container->area.width = SCREEN_WIDTH;
-  layout->container->area.height = SCREEN_HEIGHT;
+  layout->container->obj.area.width = SCREEN_WIDTH;
+  layout->container->obj.area.height = SCREEN_HEIGHT;
   layout->container->layout = VERTICAL ;
   layout->container->children = nbgl_containerPoolGet(NB_MAX_CONTAINER_CHILDREN,layout->layer);
   layout->children[layout->nbChildren] = (nbgl_obj_t*)layout->container;
@@ -475,7 +475,7 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description) {
     obj->obj = (nbgl_obj_t*)layout->container;
     obj->token = description->tapActionToken;
     obj->tuneId = description->tapTuneId;
-    layout->container->touchMask = (1<<TOUCHED);
+    layout->container->obj.touchMask = (1<<TOUCHED);
 
     // create 'tap to continue' text area
     layout->tapText = (nbgl_text_area_t*)nbgl_objPoolGet(TEXT_AREA, 0);
@@ -483,11 +483,11 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description) {
     layout->tapText->text = PIC(description->tapActionText);
     layout->tapText->textColor = DARK_GRAY;
     layout->tapText->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    layout->tapText->area.width = SCREEN_WIDTH - 2*BORDER_MARGIN;
-    layout->tapText->area.height = nbgl_getFontLineHeight(layout->tapText->fontId);
+    layout->tapText->obj.area.width = SCREEN_WIDTH - 2*BORDER_MARGIN;
+    layout->tapText->obj.area.height = nbgl_getFontLineHeight(layout->tapText->fontId);
     layout->tapText->textAlignment = CENTER;
-    layout->tapText->alignmentMarginY = BORDER_MARGIN;
-    layout->tapText->alignment = BOTTOM_MIDDLE;
+    layout->tapText->obj.alignmentMarginY = BORDER_MARGIN;
+    layout->tapText->obj.alignment = BOTTOM_MIDDLE;
   }
 
   return (nbgl_layout_t*)layout;
@@ -516,17 +516,17 @@ int nbgl_layoutAddTopRightButton(nbgl_layout_t *layout, const nbgl_icon_details_
     return -1;
 
   addObjectToLayout(layoutInt,(nbgl_obj_t*)button);
-  button->area.width = BUTTON_DIAMETER;
-  button->area.height = BUTTON_DIAMETER;
+  button->obj.area.width = BUTTON_DIAMETER;
+  button->obj.area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
-  button->alignmentMarginX = BORDER_MARGIN;
-  button->alignmentMarginY = BORDER_MARGIN;
+  button->obj.alignmentMarginX = BORDER_MARGIN;
+  button->obj.alignmentMarginY = BORDER_MARGIN;
   button->foregroundColor = BLACK;
   button->innerColor = WHITE;
   button->borderColor = LIGHT_GRAY;
-  button->touchMask = (1<<TOUCHED);
+  button->obj.touchMask = (1<<TOUCHED);
   button->icon = PIC(icon);
-  button->alignment = TOP_RIGHT;
+  button->obj.alignment = TOP_RIGHT;
 
   return 0;
 }
@@ -553,22 +553,22 @@ int nbgl_layoutAddNavigationBar(nbgl_layout_t *layout, const nbgl_layoutNavigati
 
   layoutInt->activePage = info->activePage;
   layoutInt->nbPages = info->nbPages;
-  layoutInt->bottomContainer->alignTo = NULL;
-  layoutInt->bottomContainer->alignment = BOTTOM_MIDDLE;
+  layoutInt->bottomContainer->obj.alignTo = NULL;
+  layoutInt->bottomContainer->obj.alignment = BOTTOM_MIDDLE;
   layoutInt->bottomContainerUsage = PAGE_INDICATOR; // used for navigation bar
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)layoutInt->bottomContainer;
   layoutInt->nbChildren++;
 
-  layoutInt->container->area.height -= layoutInt->bottomContainer->area.height;
+  layoutInt->container->obj.area.height -= layoutInt->bottomContainer->obj.area.height;
 
   if (info->withSeparationLine) {
     nbgl_line_t *line = createHorizontalLine(layoutInt->layer);
-    line->alignTo = (nbgl_obj_t*)layoutInt->bottomContainer;
-    line->alignment = TOP_MIDDLE;
+    line->obj.alignTo = (nbgl_obj_t*)layoutInt->bottomContainer;
+    line->obj.alignment = TOP_MIDDLE;
     layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)line;
     layoutInt->nbChildren++;
 
-    layoutInt->container->area.height -= 4;
+    layoutInt->container->obj.area.height -= 4;
   }
 
   return 0;
@@ -597,12 +597,12 @@ int nbgl_layoutAddBottomButton(nbgl_layout_t *layout, const nbgl_icon_details_t 
   obj = addCallbackObj(layoutInt,(nbgl_obj_t*)layoutInt->bottomContainer,token,tuneId);
   if (obj == NULL)
     return -1;
-  layoutInt->bottomContainer->alignment = BOTTOM_MIDDLE;
+  layoutInt->bottomContainer->obj.alignment = BOTTOM_MIDDLE;
   layoutInt->bottomContainerUsage = BUTTON; // used for a button
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)layoutInt->bottomContainer;
   layoutInt->nbChildren++;
 
-  layoutInt->container->area.height -= layoutInt->bottomContainer->area.height;
+  layoutInt->container->obj.area.height -= layoutInt->bottomContainer->obj.area.height;
 
   return 0;
 }
@@ -635,24 +635,24 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
   container->children = nbgl_containerPoolGet(4,layoutInt->layer);
   container->nbChildren = 0;
 
-  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-  container->area.height = TOUCHABLE_BAR_HEIGHT;
+  container->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->obj.area.height = TOUCHABLE_BAR_HEIGHT;
   container->layout = HORIZONTAL;
-  container->alignmentMarginX = BORDER_MARGIN;
-  container->alignment = NO_ALIGNMENT;
-  container->alignTo = NULL;
+  container->obj.alignmentMarginX = BORDER_MARGIN;
+  container->obj.alignment = NO_ALIGNMENT;
+  container->obj.alignTo = NULL;
   // the bar can only be touched if not inactive AND if one of the icon is present
   // otherwise it is seen as a title
   if ((barLayout->inactive != true) && ((barLayout->iconLeft != NULL)||(barLayout->iconRight != NULL))) {
-    container->touchMask = (1<<TOUCHED);
+    container->obj.touchMask = (1<<TOUCHED);
   }
 
   if (barLayout->iconLeft != NULL) {
     imageLeft = (nbgl_image_t *)nbgl_objPoolGet(IMAGE,layoutInt->layer);
     imageLeft->foregroundColor = color;
     imageLeft->buffer = PIC(barLayout->iconLeft);
-    imageLeft->alignment = MID_LEFT;
-    imageLeft->alignTo = (nbgl_obj_t*)NULL;
+    imageLeft->obj.alignment = MID_LEFT;
+    imageLeft->obj.alignTo = (nbgl_obj_t*)NULL;
     container->children[container->nbChildren] = (nbgl_obj_t*)imageLeft;
     container->nbChildren++;
   }
@@ -662,22 +662,22 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
     textArea->text = PIC(barLayout->text);
     textArea->onDrawCallback = NULL;
     textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-    textArea->area.width = container->area.width;
+    textArea->obj.area.width = container->obj.area.width;
     if (barLayout->iconLeft != NULL)
-      textArea->area.width -= imageLeft->buffer->width+12;
+      textArea->obj.area.width -= imageLeft->buffer->width+12;
     if (barLayout->iconRight != NULL)
-      textArea->area.width -= ((nbgl_icon_details_t *)PIC(barLayout->iconRight))->width;
-    textArea->area.height = container->area.height;
+      textArea->obj.area.width -= ((nbgl_icon_details_t *)PIC(barLayout->iconRight))->width;
+    textArea->obj.area.height = container->obj.area.height;
     textArea->style = NO_STYLE;
     if ((barLayout->iconLeft != NULL) && (barLayout->centered != true))
-      textArea->alignmentMarginX = 12;
+      textArea->obj.alignmentMarginX = 12;
     if (barLayout->iconLeft != NULL) {
-      textArea->alignTo = (nbgl_obj_t*)imageLeft;
-      textArea->alignment = MID_RIGHT;
+      textArea->obj.alignTo = (nbgl_obj_t*)imageLeft;
+      textArea->obj.alignment = MID_RIGHT;
     }
     else {
-      textArea->alignTo = (nbgl_obj_t*)NULL;
-      textArea->alignment = NO_ALIGNMENT;
+      textArea->obj.alignTo = (nbgl_obj_t*)NULL;
+      textArea->obj.alignment = NO_ALIGNMENT;
     }
     if (barLayout->centered != true) {
       textArea->textAlignment = MID_LEFT;
@@ -692,12 +692,12 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
     imageRight = (nbgl_image_t *)nbgl_objPoolGet(IMAGE,layoutInt->layer);
     imageRight->foregroundColor = color;
     imageRight->buffer = PIC(barLayout->iconRight);
-    imageRight->alignment = MID_RIGHT;
+    imageRight->obj.alignment = MID_RIGHT;
     if (barLayout->text == NULL) {
-      imageRight->alignTo = (nbgl_obj_t*)NULL;
+      imageRight->obj.alignTo = (nbgl_obj_t*)NULL;
     }
     else {
-      imageRight->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+      imageRight->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
     }
     container->children[container->nbChildren] = (nbgl_obj_t*)imageRight;
     container->nbChildren++;
@@ -709,14 +709,14 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
     textArea->text = PIC(barLayout->subText);
     textArea->textAlignment = MID_LEFT;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+    textArea->obj.area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
     textArea->style = NO_STYLE;
-    textArea->alignment = BOTTOM_LEFT;
-    textArea->alignmentMarginY = BORDER_MARGIN;
-    textArea->area.width = container->area.width;
+    textArea->obj.alignment = BOTTOM_LEFT;
+    textArea->obj.alignmentMarginY = BORDER_MARGIN;
+    textArea->obj.area.width = container->obj.area.width;
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
-    container->area.height += textArea->area.height+16;
+    container->obj.area.height += textArea->obj.area.height+16;
   }
 
   // set this new container as child of main container
@@ -750,31 +750,31 @@ int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switc
 
   // get container children
   container->children = nbgl_containerPoolGet(3,layoutInt->layer);
-  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-  container->area.height = 2*BORDER_MARGIN;
+  container->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->obj.area.height = 2*BORDER_MARGIN;
   container->layout = VERTICAL;
-  container->alignmentMarginX = BORDER_MARGIN;
-  container->alignment = NO_ALIGNMENT;
-  container->touchMask = (1<<TOUCHED);
+  container->obj.alignmentMarginX = BORDER_MARGIN;
+  container->obj.alignment = NO_ALIGNMENT;
+  container->obj.touchMask = (1<<TOUCHED);
 
   textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
   textArea->textColor = BLACK;
   textArea->text = PIC(switchLayout->text);
   textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-  textArea->area.width = container->area.width - 60; // the switch icon has 60px width
-  textArea->area.height = nbgl_getTextHeight(BAGL_FONT_INTER_SEMIBOLD_24px, textArea->text);
-  container->area.height += textArea->area.height;
-  textArea->alignment = TOP_LEFT;
-  textArea->alignmentMarginY = BORDER_MARGIN;
+  textArea->obj.area.width = container->obj.area.width - 60; // the switch icon has 60px width
+  textArea->obj.area.height = nbgl_getTextHeight(BAGL_FONT_INTER_SEMIBOLD_24px, textArea->text);
+  container->obj.area.height += textArea->obj.area.height;
+  textArea->obj.alignment = TOP_LEFT;
+  textArea->obj.alignmentMarginY = BORDER_MARGIN;
   container->children[0] = (nbgl_obj_t*)textArea;
 
   switchObj = (nbgl_switch_t *)nbgl_objPoolGet(SWITCH,layoutInt->layer);
   switchObj->onColor = BLACK;
   switchObj->offColor = LIGHT_GRAY;
   switchObj->state = switchLayout->initState;
-  switchObj->alignment = MID_RIGHT;
-  switchObj->alignTo = (nbgl_obj_t*)textArea;
+  switchObj->obj.alignment = MID_RIGHT;
+  switchObj->obj.alignTo = (nbgl_obj_t*)textArea;
   container->children[1] = (nbgl_obj_t*)switchObj;
 
   if (switchLayout->subText != NULL) {
@@ -783,11 +783,11 @@ int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switc
     subTextArea->text = PIC(switchLayout->subText);
     subTextArea->textAlignment = MID_LEFT;
     subTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    subTextArea->area.width = container->area.width;
-    subTextArea->area.height = nbgl_getTextHeight(BAGL_FONT_INTER_REGULAR_24px, subTextArea->text);
-    container->area.height += subTextArea->area.height + INNER_MARGIN;
-    subTextArea->alignment = NO_ALIGNMENT;
-    subTextArea->alignmentMarginY = INNER_MARGIN;
+    subTextArea->obj.area.width = container->obj.area.width;
+    subTextArea->obj.area.height = nbgl_getTextHeight(BAGL_FONT_INTER_REGULAR_24px, subTextArea->text);
+    container->obj.area.height += subTextArea->obj.area.height + INNER_MARGIN;
+    subTextArea->obj.alignment = NO_ALIGNMENT;
+    subTextArea->obj.alignmentMarginY = INNER_MARGIN;
     container->children[2] = (nbgl_obj_t*)subTextArea;
     container->nbChildren = 3;
   }
@@ -827,7 +827,7 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     container->nbChildren++;
 
   container->children = nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
-  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
 
   if (text != NULL) {
     textArea = (nbgl_text_area_t *)nbgl_objPoolGet(TEXT_AREA,layoutInt->layer);
@@ -836,12 +836,12 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     textArea->text = PIC(text);
     textArea->textAlignment = MID_LEFT;
     textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-    textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+    textArea->obj.area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
     textArea->style = NO_STYLE;
-    textArea->alignment = NO_ALIGNMENT;
-    textArea->alignmentMarginY = BORDER_MARGIN;
-    textArea->area.width = container->area.width;
-    fullHeight += textArea->area.height;
+    textArea->obj.alignment = NO_ALIGNMENT;
+    textArea->obj.alignmentMarginY = BORDER_MARGIN;
+    textArea->obj.area.width = container->obj.area.width;
+    fullHeight += textArea->obj.area.height;
     container->children[0] = (nbgl_obj_t*)textArea;
   }
   if (subText != NULL) {
@@ -850,25 +850,25 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     subTextArea->text = PIC(subText);
     subTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
     subTextArea->style = NO_STYLE;
-    subTextArea->area.width = container->area.width;
-    subTextArea->area.height = nbgl_getTextHeightInWidth(subTextArea->fontId,subTextArea->text,subTextArea->area.width,false);
+    subTextArea->obj.area.width = container->obj.area.width;
+    subTextArea->obj.area.height = nbgl_getTextHeightInWidth(subTextArea->fontId,subTextArea->text,subTextArea->obj.area.width,false);
     subTextArea->textAlignment = MID_LEFT;
-    subTextArea->alignment = NO_ALIGNMENT;
-    fullHeight += subTextArea->area.height;
+    subTextArea->obj.alignment = NO_ALIGNMENT;
+    fullHeight += subTextArea->obj.area.height;
     if (text != NULL) {
-      subTextArea->alignmentMarginY = INTERNAL_MARGIN;
+      subTextArea->obj.alignmentMarginY = INTERNAL_MARGIN;
       fullHeight += INTERNAL_MARGIN;
       container->children[1] = (nbgl_obj_t*)subTextArea;
     }
     else {
-      subTextArea->alignmentMarginY = BORDER_MARGIN;
+      subTextArea->obj.alignmentMarginY = BORDER_MARGIN;
       container->children[0] = (nbgl_obj_t*)subTextArea;
     }
   }
-  container->area.height = fullHeight+2*BORDER_MARGIN;
+  container->obj.area.height = fullHeight+2*BORDER_MARGIN;
   container->layout = VERTICAL;
-  container->alignmentMarginX = BORDER_MARGIN;
-  container->alignment = NO_ALIGNMENT;
+  container->obj.alignmentMarginX = BORDER_MARGIN;
+  container->obj.alignment = NO_ALIGNMENT;
   // set this new obj as child of main container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
 
@@ -895,15 +895,15 @@ int nbgl_layoutAddLargeCaseText(nbgl_layout_t *layout, const char *text) {
   textArea->text = PIC(text);
   textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_MEDIUM_32px;
-  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-  textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
+  textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  textArea->obj.area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->obj.area.width,false);
   textArea->style = NO_STYLE;
-  textArea->alignment = NO_ALIGNMENT;
-  textArea->alignmentMarginX = BORDER_MARGIN;
-  textArea->alignmentMarginY = BORDER_MARGIN;
+  textArea->obj.alignment = NO_ALIGNMENT;
+  textArea->obj.alignmentMarginX = BORDER_MARGIN;
+  textArea->obj.alignmentMarginY = BORDER_MARGIN;
   // if first object of container, increase the margin from top
   if (layoutInt->container->nbChildren == 0) {
-    textArea->alignmentMarginY += BORDER_MARGIN;
+    textArea->obj.alignmentMarginY += BORDER_MARGIN;
   }
 
   // set this new obj as child of main container
@@ -957,30 +957,30 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
     }
 
     textArea->textAlignment = MID_LEFT;
-    textArea->area.width = 300;
-    textArea->area.height = 24;
+    textArea->obj.area.width = 300;
+    textArea->obj.area.height = 24;
     textArea->style = NO_STYLE;
-    textArea->alignment = MID_LEFT;
-    textArea->alignTo = (nbgl_obj_t*)container;
+    textArea->obj.alignment = MID_LEFT;
+    textArea->obj.alignTo = (nbgl_obj_t*)container;
     container->children[0] = (nbgl_obj_t*)textArea;
 
     // init button for this choice
     button->activeColor = BLACK;
     button->borderColor = LIGHT_GRAY;
-    button->alignmentMarginX = INNER_MARGIN-4;
-    button->alignTo = (nbgl_obj_t*)container;
-    button->alignment = MID_RIGHT;
+    button->obj.alignmentMarginX = INNER_MARGIN-4;
+    button->obj.alignTo = (nbgl_obj_t*)container;
+    button->obj.alignment = MID_RIGHT;
     button->state = OFF_STATE;
     container->children[1] = (nbgl_obj_t*)button;
 
-    container->area.width = SCREEN_WIDTH-2*BORDER_MARGIN;
-    container->area.height = 32;
-    container->alignment = NO_ALIGNMENT;
-    container->alignmentMarginX = BORDER_MARGIN;
-    container->alignmentMarginY = BORDER_MARGIN;
-    container->alignTo = (nbgl_obj_t*)NULL;
+    container->obj.area.width = SCREEN_WIDTH-2*BORDER_MARGIN;
+    container->obj.area.height = 32;
+    container->obj.alignment = NO_ALIGNMENT;
+    container->obj.alignmentMarginX = BORDER_MARGIN;
+    container->obj.alignmentMarginY = BORDER_MARGIN;
+    container->obj.alignTo = (nbgl_obj_t*)NULL;
     // whole container should be touchable
-    container->touchMask = (1<<TOUCHED);
+    container->obj.touchMask = (1<<TOUCHED);
 
     // highlight init choice
     if (i == choices->initChoice) {
@@ -994,7 +994,7 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
       textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
     }
     line = createHorizontalLine(layoutInt->layer);
-    line->alignmentMarginY = BORDER_MARGIN;
+    line->obj.alignmentMarginY = BORDER_MARGIN;
 
     // set these new objs as child of main container
     addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
@@ -1033,9 +1033,9 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     image = (nbgl_image_t *)nbgl_objPoolGet(IMAGE,layoutInt->layer);
     image->foregroundColor = BLACK;
     image->buffer = PIC(info->icon);
-    image->area.bpp = NBGL_BPP_1;
-    image->alignment = TOP_MIDDLE;
-    image->alignTo = NULL;
+    image->obj.area.bpp = NBGL_BPP_1;
+    image->obj.alignment = TOP_MIDDLE;
+    image->obj.alignTo = NULL;
 
     fullHeight += image->buffer->height;
     if ((info->style != PLUGIN_INFO)) {
@@ -1059,27 +1059,27 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     else {
       textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
     }
-    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
+    textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->obj.area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->obj.area.width,false);
 
     if (info->style == LEDGER_INFO) {
       textArea->style = LEDGER_BORDER;
-      textArea->area.width = SCREEN_WIDTH - 2*40;
-      textArea->area.height += 2*16;
+      textArea->obj.area.width = SCREEN_WIDTH - 2*40;
+      textArea->obj.area.height += 2*16;
     }
     else
       textArea->style = NO_STYLE;
     if (container->nbChildren>0) {
-      textArea->alignment = BOTTOM_MIDDLE;
-      textArea->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
-      textArea->alignmentMarginY = BORDER_MARGIN+4;
+      textArea->obj.alignment = BOTTOM_MIDDLE;
+      textArea->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+      textArea->obj.alignmentMarginY = BORDER_MARGIN+4;
     }
     else {
-      textArea->alignment = TOP_MIDDLE;
-      textArea->alignTo = NULL;
+      textArea->obj.alignment = TOP_MIDDLE;
+      textArea->obj.alignTo = NULL;
     }
 
-    fullHeight += textArea->area.height+textArea->alignmentMarginY;
+    fullHeight += textArea->obj.area.height+textArea->obj.alignmentMarginY;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
@@ -1097,28 +1097,28 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     textArea->text = PIC(info->text2);
     textArea->textAlignment = CENTER;
     textArea->fontId = (info->style != LARGE_CASE_BOLD_INFO) ? BAGL_FONT_INTER_REGULAR_24px: BAGL_FONT_INTER_SEMIBOLD_24px;
-    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
+    textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->obj.area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->obj.area.width,false);
 
     textArea->style = NO_STYLE;
     if (container->nbChildren>0) {
-      textArea->alignment = BOTTOM_MIDDLE;
-      textArea->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
-      textArea->alignmentMarginY = BORDER_MARGIN;
+      textArea->obj.alignment = BOTTOM_MIDDLE;
+      textArea->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+      textArea->obj.alignmentMarginY = BORDER_MARGIN;
       if (info->text1 != NULL) {
         // if previous element is text1, only space of 16 px
-        textArea->alignmentMarginY -= 4;
+        textArea->obj.alignmentMarginY -= 4;
       }
       else {
         // else if icon, space of 24 px
-        textArea->alignmentMarginY += 4;
+        textArea->obj.alignmentMarginY += 4;
       }
     }
     else {
-      textArea->alignment = TOP_MIDDLE;
+      textArea->obj.alignment = TOP_MIDDLE;
     }
 
-    fullHeight += textArea->area.height + textArea->alignmentMarginY;
+    fullHeight += textArea->obj.area.height + textArea->obj.alignmentMarginY;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
@@ -1126,20 +1126,20 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
   // draw small horizontal line if PLUGIN_INFO
   if (info->style == PLUGIN_INFO) {
     nbgl_line_t *line = createHorizontalLine(layoutInt->layer);
-    line->area.width = 120;
-    line->alignmentMarginY = 32;
-    line->alignmentMarginX = 0;
-    line->alignment = BOTTOM_MIDDLE;
-    line->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+    line->obj.area.width = 120;
+    line->obj.alignmentMarginY = 32;
+    line->obj.alignmentMarginX = 0;
+    line->obj.alignment = BOTTOM_MIDDLE;
+    line->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
     fullHeight += 32;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)line;
     container->nbChildren++;
     if (image) {
       // add icon here, under line
-      image->alignmentMarginY = 32;
-      image->alignment = BOTTOM_MIDDLE;
-      image->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+      image->obj.alignmentMarginY = 32;
+      image->obj.alignment = BOTTOM_MIDDLE;
+      image->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
       container->children[container->nbChildren] = (nbgl_obj_t*)image;
       container->nbChildren++;
       fullHeight += 32;
@@ -1151,37 +1151,37 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     textArea->text = PIC(info->text3);
     textArea->textAlignment = CENTER;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
+    textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->obj.area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->obj.area.width,false);
     textArea->style = NO_STYLE;
     if (container->nbChildren>0) {
-      textArea->alignment = BOTTOM_MIDDLE;
-      textArea->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
-      textArea->alignmentMarginY = BORDER_MARGIN;
+      textArea->obj.alignment = BOTTOM_MIDDLE;
+      textArea->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+      textArea->obj.alignmentMarginY = BORDER_MARGIN;
     }
     else {
-      textArea->alignment = TOP_MIDDLE;
-      textArea->alignTo = NULL;
+      textArea->obj.alignment = TOP_MIDDLE;
+      textArea->obj.alignTo = NULL;
     }
 
-    fullHeight += textArea->area.height+textArea->alignmentMarginY;
+    fullHeight += textArea->obj.area.height+textArea->obj.alignmentMarginY;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
   }
-  container->area.height = fullHeight;
+  container->obj.area.height = fullHeight;
   container->layout = VERTICAL;
   if (info->onTop) {
-    container->alignmentMarginX = BORDER_MARGIN;
-    container->alignmentMarginY = BORDER_MARGIN+ info->offsetY;
-    container->alignment = NO_ALIGNMENT;
+    container->obj.alignmentMarginX = BORDER_MARGIN;
+    container->obj.alignmentMarginY = BORDER_MARGIN+ info->offsetY;
+    container->obj.alignment = NO_ALIGNMENT;
   }
   else {
-    container->alignmentMarginY = info->offsetY;
-    container->alignment = CENTER;
+    container->obj.alignmentMarginY = info->offsetY;
+    container->obj.alignment = CENTER;
   }
 
-  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
 
   // set this new container as child of main container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
@@ -1226,14 +1226,14 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
   qrcode->foregroundColor = BLACK;
   // in QR V4, we use 8*8 screen pixels for one QR pixel
   // in QR V10, we use 4*4 screen pixels for one QR pixel
-  qrcode->area.width = (qrcode->version == QRCODE_V4) ? (QR_V4_NB_PIX_SIZE * 8) : (QR_V10_NB_PIX_SIZE * 4);
-  qrcode->area.height = qrcode->area.width;
+  qrcode->obj.area.width = (qrcode->version == QRCODE_V4) ? (QR_V4_NB_PIX_SIZE * 8) : (QR_V10_NB_PIX_SIZE * 4);
+  qrcode->obj.area.height = qrcode->obj.area.width;
   qrcode->text = PIC(info->url);
-  qrcode->area.bpp = NBGL_BPP_1;
-  qrcode->alignment = TOP_MIDDLE;
-  qrcode->alignmentMarginY = 24;
+  qrcode->obj.area.bpp = NBGL_BPP_1;
+  qrcode->obj.alignment = TOP_MIDDLE;
+  qrcode->obj.alignmentMarginY = 24;
 
-  fullHeight += qrcode->area.height;
+  fullHeight += qrcode->obj.area.height;
   container->children[container->nbChildren] = (nbgl_obj_t*)qrcode;
   container->nbChildren++;
 
@@ -1243,13 +1243,13 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
     textArea->text = PIC(info->text1);
     textArea->textAlignment = CENTER;
     textArea->fontId = (info->largeText1 == true)? BAGL_FONT_INTER_MEDIUM_32px : BAGL_FONT_INTER_REGULAR_24px;
-    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->area.width,false);
-    textArea->alignment = BOTTOM_MIDDLE;
-    textArea->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
-    textArea->alignmentMarginY = 40;
+    textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->obj.area.height = nbgl_getTextHeightInWidth(textArea->fontId,textArea->text,textArea->obj.area.width,false);
+    textArea->obj.alignment = BOTTOM_MIDDLE;
+    textArea->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+    textArea->obj.alignmentMarginY = 40;
 
-    fullHeight += textArea->area.height;
+    fullHeight += textArea->obj.area.height;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
@@ -1260,30 +1260,30 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
     textArea->text = PIC(info->text2);
     textArea->textAlignment = CENTER;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-    textArea->area.height = nbgl_getTextHeightInWidth(textArea->fontId, textArea->text, textArea->area.width, false);
-    textArea->alignment = BOTTOM_MIDDLE;
-    textArea->alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
-    textArea->alignmentMarginY = 40;
+    textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    textArea->obj.area.height = nbgl_getTextHeightInWidth(textArea->fontId, textArea->text, textArea->obj.area.width, false);
+    textArea->obj.alignment = BOTTOM_MIDDLE;
+    textArea->obj.alignTo = (nbgl_obj_t*)container->children[container->nbChildren-1];
+    textArea->obj.alignmentMarginY = 40;
 
-    fullHeight += textArea->area.height;
+    fullHeight += textArea->obj.area.height;
 
     container->children[container->nbChildren] = (nbgl_obj_t*)textArea;
     container->nbChildren++;
   }
-  container->area.height = fullHeight;
+  container->obj.area.height = fullHeight;
   container->layout = VERTICAL;
   // center the QRCode only if it's the first (and probably only) child
   if (layoutInt->container->nbChildren == 0) {
-    container->alignment = CENTER;
+    container->obj.alignment = CENTER;
   }
   else {
-    container->alignment = BOTTOM_MIDDLE;
-    container->alignmentMarginY = BORDER_MARGIN;
-    container->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
+    container->obj.alignment = BOTTOM_MIDDLE;
+    container->obj.alignmentMarginY = BORDER_MARGIN;
+    container->obj.alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
   }
 
-  container->area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  container->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
 
   // set this new container as child of main container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
@@ -1319,23 +1319,23 @@ int nbgl_layoutAddChoiceButtons(nbgl_layout_t *layout, const nbgl_layoutChoiceBu
     return -1;
   // associate with with index 1
   obj->index = 1;
-  bottomButton->alignment = BOTTOM_MIDDLE;
+  bottomButton->obj.alignment = BOTTOM_MIDDLE;
   if (info->style == ROUNDED_AND_FOOTER_STYLE) {
-    bottomButton->alignmentMarginY = 4; // 4 pixels from screen bottom
+    bottomButton->obj.alignmentMarginY = 4; // 4 pixels from screen bottom
     bottomButton->borderColor = WHITE;
   }
   else if (info->style == BOTH_ROUNDED_STYLE) {
-    bottomButton->alignmentMarginY = BORDER_MARGIN; // 24 pixels from screen bottom
+    bottomButton->obj.alignmentMarginY = BORDER_MARGIN; // 24 pixels from screen bottom
     bottomButton->borderColor = LIGHT_GRAY;
   }
   bottomButton->innerColor = WHITE;
   bottomButton->foregroundColor = BLACK;
-  bottomButton->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-  bottomButton->area.height = BUTTON_DIAMETER;
+  bottomButton->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  bottomButton->obj.area.height = BUTTON_DIAMETER;
   bottomButton->radius = BUTTON_RADIUS;
   bottomButton->text = PIC(info->bottomText);
   bottomButton->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-  bottomButton->touchMask = (1 << TOUCHED);
+  bottomButton->obj.touchMask = (1 << TOUCHED);
   // set this new button as child of the container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)bottomButton);
 
@@ -1346,23 +1346,23 @@ int nbgl_layoutAddChoiceButtons(nbgl_layout_t *layout, const nbgl_layoutChoiceBu
     return -1;
   // associate with with index 0
   obj->index = 0;
-  topButton->alignment = TOP_MIDDLE;
-  topButton->alignTo = (nbgl_obj_t*)bottomButton;
+  topButton->obj.alignment = TOP_MIDDLE;
+  topButton->obj.alignTo = (nbgl_obj_t*)bottomButton;
   if (info->style == BOTH_ROUNDED_STYLE) {
-    topButton->alignmentMarginY = INNER_MARGIN; // 12 pixels from bottom button
+    topButton->obj.alignmentMarginY = INNER_MARGIN; // 12 pixels from bottom button
   }
   else {
-    topButton->alignmentMarginY = 4; // 4 pixels from bottom button
+    topButton->obj.alignmentMarginY = 4; // 4 pixels from bottom button
   }
   topButton->innerColor = BLACK;
   topButton->borderColor = BLACK;
   topButton->foregroundColor = WHITE;
-  topButton->area.width = bottomButton->area.width;
-  topButton->area.height = BUTTON_DIAMETER;
+  topButton->obj.area.width = bottomButton->obj.area.width;
+  topButton->obj.area.height = BUTTON_DIAMETER;
   topButton->radius = BUTTON_RADIUS;
   topButton->text = PIC(info->topText);
   topButton->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
-  topButton->touchMask = (1 << TOUCHED);
+  topButton->obj.touchMask = (1 << TOUCHED);
   // set this new button as child of the container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)topButton);
 
@@ -1413,17 +1413,17 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
     itemTextArea->text = PIC(pair->item);
     itemTextArea->textAlignment = MID_LEFT;
     itemTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    itemTextArea->area.width = usableWidth;
-    itemTextArea->area.height = nbgl_getTextHeightInWidth(itemTextArea->fontId,itemTextArea->text,usableWidth,false);
+    itemTextArea->obj.area.width = usableWidth;
+    itemTextArea->obj.area.height = nbgl_getTextHeightInWidth(itemTextArea->fontId,itemTextArea->text,usableWidth,false);
     itemTextArea->style = NO_STYLE;
-    itemTextArea->alignment = NO_ALIGNMENT;
-    itemTextArea->alignmentMarginX = 0;
-    itemTextArea->alignmentMarginY = 0;
-    itemTextArea->alignTo = NULL;
+    itemTextArea->obj.alignment = NO_ALIGNMENT;
+    itemTextArea->obj.alignmentMarginX = 0;
+    itemTextArea->obj.alignmentMarginY = 0;
+    itemTextArea->obj.alignTo = NULL;
     container->children[container->nbChildren] = (nbgl_obj_t*)itemTextArea;
     container->nbChildren++;
 
-    fullHeight += itemTextArea->area.height;
+    fullHeight += itemTextArea->obj.area.height;
 
     // init button for this choice
     valueTextArea->textColor = BLACK;
@@ -1435,11 +1435,11 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
       valueTextArea->fontId = BAGL_FONT_INTER_MEDIUM_32px;
     }
     if (pair->valueIcon == NULL) {
-      valueTextArea->area.width = usableWidth;
+      valueTextArea->obj.area.width = usableWidth;
     }
     else {
       // we assume that value is single line
-      valueTextArea->area.width = nbgl_getTextWidth(valueTextArea->fontId, valueTextArea->text);
+      valueTextArea->obj.area.width = nbgl_getTextWidth(valueTextArea->fontId, valueTextArea->text);
     }
 
     // handle the nbMaxLinesForValue parameter, used to automatically keep only
@@ -1451,37 +1451,37 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
       valueTextArea->nbMaxLines = list->nbMaxLinesForValue;
     }
     const nbgl_font_t *font = nbgl_getFont(valueTextArea->fontId);
-    valueTextArea->area.height = nbLines*font->line_height;
+    valueTextArea->obj.area.height = nbLines*font->line_height;
     valueTextArea->style = NO_STYLE;
-    valueTextArea->alignment = BOTTOM_LEFT;
-    valueTextArea->alignmentMarginY = 4;
-    valueTextArea->alignTo = (nbgl_obj_t*)itemTextArea;
+    valueTextArea->obj.alignment = BOTTOM_LEFT;
+    valueTextArea->obj.alignmentMarginY = 4;
+    valueTextArea->obj.alignTo = (nbgl_obj_t*)itemTextArea;
     valueTextArea->wrapping = list->wrapping;
     container->children[container->nbChildren] = (nbgl_obj_t*)valueTextArea;
     container->nbChildren++;
 
-    fullHeight += valueTextArea->area.height;
+    fullHeight += valueTextArea->obj.area.height;
     if (pair->valueIcon != NULL) {
       nbgl_image_t *image = (nbgl_image_t *)nbgl_objPoolGet(IMAGE,layoutInt->layer);
       layoutObj_t *obj = addCallbackObj(layoutInt,(nbgl_obj_t*)image,list->token,TUNE_TAP_CASUAL);
       obj->index = i;
       image->foregroundColor = BLACK;
       image->buffer = PIC(pair->valueIcon);
-      image->alignment = MID_RIGHT;
-      image->alignmentMarginX = 4;
-      image->alignTo = (nbgl_obj_t*)valueTextArea;
-      image->touchMask = (1 << TOUCHED);
+      image->obj.alignment = MID_RIGHT;
+      image->obj.alignmentMarginX = 4;
+      image->obj.alignTo = (nbgl_obj_t*)valueTextArea;
+      image->obj.touchMask = (1 << TOUCHED);
 
       container->children[container->nbChildren] = (nbgl_obj_t*)image;
       container->nbChildren++;
     }
 
-    container->area.width = usableWidth;
-    container->area.height = fullHeight;
+    container->obj.area.width = usableWidth;
+    container->obj.area.height = fullHeight;
     container->layout = VERTICAL;
-    container->alignmentMarginX = BORDER_MARGIN;
-    container->alignmentMarginY = 12;
-    container->alignment = NO_ALIGNMENT;
+    container->obj.alignmentMarginX = BORDER_MARGIN;
+    container->obj.alignmentMarginY = 12;
+    container->obj.alignment = NO_ALIGNMENT;
 
     addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
   }
@@ -1511,23 +1511,23 @@ int nbgl_layoutAddProgressBar(nbgl_layout_t *layout, const nbgl_layoutProgressBa
     textArea->text = PIC(barLayout->text);
     textArea->textAlignment = MID_LEFT;
     textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    textArea->area.width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
-    textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+    textArea->obj.area.width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
+    textArea->obj.area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
     textArea->style = NO_STYLE;
-    textArea->alignment = NO_ALIGNMENT;
-    textArea->alignmentMarginX = BORDER_MARGIN;
-    textArea->alignmentMarginY = BORDER_MARGIN;
+    textArea->obj.alignment = NO_ALIGNMENT;
+    textArea->obj.alignmentMarginX = BORDER_MARGIN;
+    textArea->obj.alignmentMarginY = BORDER_MARGIN;
     addObjectToLayout(layoutInt,(nbgl_obj_t*)textArea);
   }
   progress = (nbgl_progress_bar_t *)nbgl_objPoolGet(PROGRESS_BAR,((nbgl_layoutInternal_t *)layout)->layer);
   progress->foregroundColor = BLACK;
   progress->withBorder = true;
   progress->state = barLayout->percentage;
-  progress->area.width = 120;
-  progress->area.height = 12;
-  progress->alignment = NO_ALIGNMENT;
-  progress->alignmentMarginX = (GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout))-progress->area.width)/2;
-  progress->alignmentMarginY = BORDER_MARGIN;
+  progress->obj.area.width = 120;
+  progress->obj.area.height = 12;
+  progress->obj.alignment = NO_ALIGNMENT;
+  progress->obj.alignmentMarginX = (GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout))-progress->obj.area.width)/2;
+  progress->obj.alignmentMarginY = BORDER_MARGIN;
   addObjectToLayout(layoutInt,(nbgl_obj_t*)progress);
 
   if (barLayout->subText != NULL) {
@@ -1538,12 +1538,12 @@ int nbgl_layoutAddProgressBar(nbgl_layout_t *layout, const nbgl_layoutProgressBa
     subTextArea->text = PIC(barLayout->subText);
     subTextArea->textAlignment = MID_LEFT;
     subTextArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-    subTextArea->area.width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
-    subTextArea->area.height = nbgl_getTextHeight(subTextArea->fontId,subTextArea->text);
+    subTextArea->obj.area.width = GET_AVAILABLE_WIDTH(((nbgl_layoutInternal_t *)layout));
+    subTextArea->obj.area.height = nbgl_getTextHeight(subTextArea->fontId,subTextArea->text);
     subTextArea->style = NO_STYLE;
-    subTextArea->alignment = NO_ALIGNMENT;
-    subTextArea->alignmentMarginX = BORDER_MARGIN;
-    subTextArea->alignmentMarginY = BORDER_MARGIN;
+    subTextArea->obj.alignment = NO_ALIGNMENT;
+    subTextArea->obj.alignmentMarginX = BORDER_MARGIN;
+    subTextArea->obj.alignmentMarginY = BORDER_MARGIN;
     addObjectToLayout(layoutInt,(nbgl_obj_t*)subTextArea);
   }
 
@@ -1563,7 +1563,7 @@ int nbgl_layoutAddSeparationLine(nbgl_layout_t *layout) {
 
   LOG_DEBUG(LAYOUT_LOGGER,"nbgl_layoutAddSeparationLine():\n");
   line = createHorizontalLine(layoutInt->layer);
-  line->alignmentMarginY = -4;
+  line->obj.alignmentMarginY = -4;
   addObjectToLayout(layoutInt,(nbgl_obj_t*)line);
   return 0;
 }
@@ -1589,13 +1589,13 @@ int nbgl_layoutAddButton(nbgl_layout_t *layout, const nbgl_layoutButton_t *butto
   if (obj == NULL)
     return -1;
 
-  button->alignmentMarginY = BORDER_MARGIN;
+  button->obj.alignmentMarginY = BORDER_MARGIN;
   if (buttonInfo->onBottom != true) {
-    button->alignmentMarginX = BORDER_MARGIN;
-    button->alignment = NO_ALIGNMENT;
+    button->obj.alignmentMarginX = BORDER_MARGIN;
+    button->obj.alignment = NO_ALIGNMENT;
   }
   else {
-    button->alignment = BOTTOM_MIDDLE;
+    button->obj.alignment = BOTTOM_MIDDLE;
   }
   if (buttonInfo->style == BLACK_BACKGROUND) {
     button->innerColor = BLACK;
@@ -1620,19 +1620,19 @@ int nbgl_layoutAddButton(nbgl_layout_t *layout, const nbgl_layoutButton_t *butto
   button->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   button->icon = PIC(buttonInfo->icon);
   if (buttonInfo->fittingContent == true) {
-    button->area.width = nbgl_getTextWidth(button->fontId,button->text)+64+((button->icon)?(button->icon->width+8):0);
-    button->area.height = 64;
+    button->obj.area.width = nbgl_getTextWidth(button->fontId,button->text)+64+((button->icon)?(button->icon->width+8):0);
+    button->obj.area.height = 64;
     button->radius = RADIUS_32_PIXELS;
     if (buttonInfo->onBottom != true)
-      button->alignmentMarginX += (SCREEN_WIDTH-2*BORDER_MARGIN-button->area.width)/2;
+      button->obj.alignmentMarginX += (SCREEN_WIDTH-2*BORDER_MARGIN-button->obj.area.width)/2;
   }
   else {
-    button->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-    button->area.height = BUTTON_DIAMETER;
+    button->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+    button->obj.area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
   }
-  button->alignTo = NULL;
-  button->touchMask = (1 << TOUCHED);
+  button->obj.alignTo = NULL;
+  button->obj.touchMask = (1 << TOUCHED);
   // set this new button as child of the container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)button);
 
@@ -1666,22 +1666,22 @@ int nbgl_layoutAddLongPressButton(nbgl_layout_t *layout, const char *text, uint8
   if (obj == NULL)
     return -1;
 
-  container->area.width = SCREEN_WIDTH;
-  container->area.height = 128;
+  container->obj.area.width = SCREEN_WIDTH;
+  container->obj.area.height = 128;
   container->layout = VERTICAL ;
   container->nbChildren = 4; // progress-bar + text + line + button
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
-  container->alignment = BOTTOM_MIDDLE;
-  container->touchMask = ((1<<TOUCHING)|(1<<TOUCH_RELEASED)|(1<<OUT_OF_TOUCH));
+  container->obj.alignment = BOTTOM_MIDDLE;
+  container->obj.touchMask = ((1<<TOUCHING)|(1<<TOUCH_RELEASED)|(1<<OUT_OF_TOUCH));
 
   button = (nbgl_button_t *)nbgl_objPoolGet(BUTTON,layoutInt->layer);
-  button->alignmentMarginX = BORDER_MARGIN;
-  button->alignment = MID_RIGHT;
+  button->obj.alignmentMarginX = BORDER_MARGIN;
+  button->obj.alignment = MID_RIGHT;
   button->innerColor = BLACK;
   button->foregroundColor = WHITE;
   button->borderColor = BLACK;
-  button->area.width = BUTTON_DIAMETER;
-  button->area.height = BUTTON_DIAMETER;
+  button->obj.area.width = BUTTON_DIAMETER;
+  button->obj.area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
   button->icon = PIC(&C_check32px);
   container->children[0] = (nbgl_obj_t*)button;
@@ -1691,25 +1691,25 @@ int nbgl_layoutAddLongPressButton(nbgl_layout_t *layout, const char *text, uint8
   textArea->text = PIC(text);
   textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_MEDIUM_32px;
-  textArea->area.width = container->area.width - 3 * BORDER_MARGIN - button->area.width;
-  textArea->area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
+  textArea->obj.area.width = container->obj.area.width - 3 * BORDER_MARGIN - button->obj.area.width;
+  textArea->obj.area.height = nbgl_getTextHeight(textArea->fontId,textArea->text);
   textArea->style = NO_STYLE;
-  textArea->alignment = MID_LEFT;
-  textArea->alignmentMarginX = BORDER_MARGIN;
+  textArea->obj.alignment = MID_LEFT;
+  textArea->obj.alignmentMarginX = BORDER_MARGIN;
   container->children[1] = (nbgl_obj_t*)textArea;
 
   line = createHorizontalLine(layoutInt->layer);
   line->offset = 3;
-  line->alignment = TOP_MIDDLE;
+  line->obj.alignment = TOP_MIDDLE;
   container->children[2] = (nbgl_obj_t*)line;
 
   progressBar = (nbgl_progress_bar_t *)nbgl_objPoolGet(PROGRESS_BAR,layoutInt->layer);
   progressBar->withBorder = false;
-  progressBar->area.width = container->area.width;
-  progressBar->area.height = 8;
-  progressBar->alignment = TOP_MIDDLE;
-  progressBar->alignmentMarginY = 4;
-  progressBar->alignTo = NULL;
+  progressBar->obj.area.width = container->obj.area.width;
+  progressBar->obj.area.height = 8;
+  progressBar->obj.alignment = TOP_MIDDLE;
+  progressBar->obj.alignmentMarginY = 4;
+  progressBar->obj.alignTo = NULL;
   container->children[3] = (nbgl_obj_t*)progressBar;
 
   // set this new container as child of the main container
@@ -1742,24 +1742,24 @@ int nbgl_layoutAddFooter(nbgl_layout_t *layout, const char *text, uint8_t token,
   if (obj == NULL)
     return -1;
 
-  textArea->alignment = BOTTOM_MIDDLE;
+  textArea->obj.alignment = BOTTOM_MIDDLE;
   textArea->textColor = BLACK;
-  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-  textArea->area.height = BUTTON_DIAMETER;
+  textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  textArea->obj.area.height = BUTTON_DIAMETER;
   textArea->text = PIC(text);
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   textArea->textAlignment = CENTER;
-  textArea->touchMask = (1 << TOUCHED);
+  textArea->obj.touchMask = (1 << TOUCHED);
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)textArea;
   layoutInt->nbChildren++;
 
   line = createHorizontalLine(layoutInt->layer);
-  line->alignTo = (nbgl_obj_t*)textArea;
-  line->alignment = TOP_MIDDLE;
+  line->obj.alignTo = (nbgl_obj_t*)textArea;
+  line->obj.alignment = TOP_MIDDLE;
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)line;
   layoutInt->nbChildren++;
 
-  layoutInt->container->area.height -= textArea->area.height+line->area.height;
+  layoutInt->container->obj.area.height -= textArea->obj.area.height+line->obj.area.height;
 
   return 0;
 }
@@ -1791,14 +1791,14 @@ int nbgl_layoutAddSplitFooter(nbgl_layout_t *layout, const char *leftText, uint8
   if (obj == NULL)
     return -1;
 
-  textArea->alignment = BOTTOM_LEFT;
+  textArea->obj.alignment = BOTTOM_LEFT;
   textArea->textColor = BLACK;
-  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt)/2;
-  textArea->area.height = BUTTON_DIAMETER;
+  textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt)/2;
+  textArea->obj.area.height = BUTTON_DIAMETER;
   textArea->text = PIC(leftText);
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   textArea->textAlignment = CENTER;
-  textArea->touchMask = (1 << TOUCHED);
+  textArea->obj.touchMask = (1 << TOUCHED);
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)textArea;
   layoutInt->nbChildren++;
 
@@ -1808,36 +1808,36 @@ int nbgl_layoutAddSplitFooter(nbgl_layout_t *layout, const char *leftText, uint8
   if (obj == NULL)
     return -1;
 
-  textArea->alignment = BOTTOM_RIGHT;
+  textArea->obj.alignment = BOTTOM_RIGHT;
   textArea->textColor = BLACK;
-  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt)/2;
-  textArea->area.height = BUTTON_DIAMETER;
+  textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt)/2;
+  textArea->obj.area.height = BUTTON_DIAMETER;
   textArea->text = PIC(rightText);
   textArea->fontId = BAGL_FONT_INTER_SEMIBOLD_24px;
   textArea->textAlignment = CENTER;
-  textArea->touchMask = (1 << TOUCHED);
+  textArea->obj.touchMask = (1 << TOUCHED);
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)textArea;
   layoutInt->nbChildren++;
 
   // create horizontal line separating footer from main container
   line = createHorizontalLine(layoutInt->layer);
-  line->alignTo = layoutInt->children[layoutInt->nbChildren-2];
-  line->alignment = TOP_LEFT;
+  line->obj.alignTo = layoutInt->children[layoutInt->nbChildren-2];
+  line->obj.alignment = TOP_LEFT;
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)line;
   layoutInt->nbChildren++;
 
   // create vertical line separating both text areas
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE,layoutInt->layer);
   line->lineColor = LIGHT_GRAY;
-  line->area.width = 1;
-  line->area.height = textArea->area.height+4;
+  line->obj.area.width = 1;
+  line->obj.area.height = textArea->obj.area.height+4;
   line->direction = VERTICAL;
   line->thickness = 1;
-  line->alignment = BOTTOM_MIDDLE;
+  line->obj.alignment = BOTTOM_MIDDLE;
   layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t*)line;
   layoutInt->nbChildren++;
 
-  layoutInt->container->area.height -= textArea->area.height+4;
+  layoutInt->container->obj.area.height -= textArea->obj.area.height+4;
 
   return 0;
 }
@@ -1865,13 +1865,13 @@ int nbgl_layoutAddProgressIndicator(nbgl_layout_t *layout, uint8_t activePage, u
     return -1;
 
   container = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layoutInt->layer);
-  container->area.width = SCREEN_WIDTH;
-  container->area.height = BUTTON_DIAMETER+8;
+  container->obj.area.width = SCREEN_WIDTH;
+  container->obj.area.height = BUTTON_DIAMETER+8;
   container->layout = VERTICAL;
   container->nbChildren = 2;
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
-  container->alignment = TOP_MIDDLE;
-  container->alignTo = NULL;
+  container->obj.alignment = TOP_MIDDLE;
+  container->obj.alignTo = NULL;
 
   if (nbPages > 1) {
     nbgl_page_indicator_t *navigationBar;
@@ -1879,8 +1879,8 @@ int nbgl_layoutAddProgressIndicator(nbgl_layout_t *layout, uint8_t activePage, u
     navigationBar = (nbgl_page_indicator_t *)nbgl_objPoolGet(PAGE_INDICATOR,layoutInt->layer);
     navigationBar->activePage = activePage;
     navigationBar->nbPages = nbPages;
-    navigationBar->area.width = SCREEN_WIDTH-2*100;
-    navigationBar->alignment = CENTER;
+    navigationBar->obj.area.width = SCREEN_WIDTH-2*100;
+    navigationBar->obj.alignment = CENTER;
     container->children[0] = (nbgl_obj_t*)navigationBar;
   }
 
@@ -1890,16 +1890,16 @@ int nbgl_layoutAddProgressIndicator(nbgl_layout_t *layout, uint8_t activePage, u
     if (obj == NULL)
       return -1;
 
-    button->alignment = MID_LEFT;
+    button->obj.alignment = MID_LEFT;
     button->innerColor = WHITE;
     button->foregroundColor = BLACK;
     button->borderColor = WHITE;
-    button->area.width = BUTTON_DIAMETER;
-    button->area.height = BUTTON_DIAMETER;
+    button->obj.area.width = BUTTON_DIAMETER;
+    button->obj.area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = PIC(&C_leftArrow32px);
-    button->touchMask = (1<<TOUCHED);
+    button->obj.touchMask = (1<<TOUCHED);
     container->children[1] = (nbgl_obj_t*)button;
   }
 
@@ -1929,9 +1929,9 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, const char *text, bool fixed) {
   // create spinner
   spinner = (nbgl_spinner_t*)nbgl_objPoolGet(SPINNER, layoutInt->layer);
   spinner->position = fixed? 0xFF : 0;
-  spinner->alignmentMarginY = -20;
-  spinner->alignTo = NULL;
-  spinner->alignment = CENTER;
+  spinner->obj.alignmentMarginY = -20;
+  spinner->obj.alignTo = NULL;
+  spinner->obj.alignment = CENTER;
   // set this new spinner as child of the container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)spinner);
 
@@ -1941,11 +1941,11 @@ int nbgl_layoutAddSpinner(nbgl_layout_t *layout, const char *text, bool fixed) {
   textArea->text = PIC(text);
   textArea->textAlignment = CENTER;
   textArea->fontId = BAGL_FONT_INTER_REGULAR_24px;
-  textArea->alignmentMarginY = 20;
-  textArea->alignTo = (nbgl_obj_t*)spinner;
-  textArea->alignment = BOTTOM_MIDDLE;
-  textArea->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-  textArea->area.height = nbgl_getFontLineHeight(textArea->fontId);
+  textArea->obj.alignmentMarginY = 20;
+  textArea->obj.alignTo = (nbgl_obj_t*)spinner;
+  textArea->obj.alignment = BOTTOM_MIDDLE;
+  textArea->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  textArea->obj.area.height = nbgl_getFontLineHeight(textArea->fontId);
   textArea->style = NO_STYLE;
 
   // set this new spinner as child of the container
@@ -1982,8 +1982,8 @@ int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInf
 
   // create keyboard
   keyboard = (nbgl_keyboard_t*)nbgl_objPoolGet(KEYBOARD, layoutInt->layer);
-  keyboard->alignmentMarginY = 64;
-  keyboard->alignment = BOTTOM_MIDDLE;
+  keyboard->obj.alignmentMarginY = 64;
+  keyboard->obj.alignment = BOTTOM_MIDDLE;
   keyboard->borderColor = LIGHT_GRAY;
   keyboard->callback = PIC(kbdInfo->callback);
   keyboard->lettersOnly = kbdInfo->lettersOnly;
@@ -2017,7 +2017,7 @@ int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout, uint8_t index, uint32_t key
 
   // get keyboard at given index
   keyboard = (nbgl_keyboard_t*)layoutInt->container->children[index];
-  if ((keyboard == NULL) || (keyboard->type != KEYBOARD)) {
+  if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
     return -1;
   }
   keyboard->keyMask = keyMask;
@@ -2047,7 +2047,7 @@ bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index) {
 
   // get keyboard at given index
   keyboard = (nbgl_keyboard_t*)layoutInt->container->children[index];
-  if ((keyboard == NULL) || (keyboard->type != KEYBOARD)) {
+  if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
     return -1;
   }
   if (keyboard->needsRefresh) {
@@ -2080,14 +2080,14 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout, uint8_t nbUsedButtons
     return -1;
 
   container = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layoutInt->layer);
-  container->area.width = SCREEN_WIDTH;
-  container->area.height = 2*64+8;
+  container->obj.area.width = SCREEN_WIDTH;
+  container->obj.area.height = 2*64+8;
   container->layout = VERTICAL;
   container->nbChildren = NB_MAX_SUGGESTION_BUTTONS;
   container->children = (nbgl_obj_t**)nbgl_containerPoolGet(container->nbChildren,layoutInt->layer);
-  container->alignmentMarginY = BORDER_MARGIN;
-  container->alignment = TOP_MIDDLE;
-  container->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
+  container->obj.alignmentMarginY = BORDER_MARGIN;
+  container->obj.alignment = TOP_MIDDLE;
+  container->obj.alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
 
   // create suggestion buttons, even if not displayed at first
   nbgl_objPoolGetArray(BUTTON,NB_MAX_SUGGESTION_BUTTONS,0,(nbgl_obj_t**)&choiceButtons);
@@ -2099,24 +2099,24 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout, uint8_t nbUsedButtons
     choiceButtons[i]->innerColor = BLACK;
     choiceButtons[i]->borderColor = BLACK;
     choiceButtons[i]->foregroundColor = WHITE;
-    choiceButtons[i]->area.width = (SCREEN_WIDTH-2*BORDER_MARGIN-8)/2;
-    choiceButtons[i]->area.height = 64;
+    choiceButtons[i]->obj.area.width = (SCREEN_WIDTH-2*BORDER_MARGIN-8)/2;
+    choiceButtons[i]->obj.area.height = 64;
     choiceButtons[i]->radius = RADIUS_32_PIXELS;
     choiceButtons[i]->fontId = BAGL_FONT_INTER_SEMIBOLD_24px_1bpp;
     choiceButtons[i]->icon = NULL;
     if ((i%2) == 0) {
-      choiceButtons[i]->alignmentMarginX = BORDER_MARGIN;
+      choiceButtons[i]->obj.alignmentMarginX = BORDER_MARGIN;
       if (i != 0)
-        choiceButtons[i]->alignmentMarginY = 8;
-      choiceButtons[i]->alignment = NO_ALIGNMENT;
+        choiceButtons[i]->obj.alignmentMarginY = 8;
+      choiceButtons[i]->obj.alignment = NO_ALIGNMENT;
     }
     else {
-      choiceButtons[i]->alignmentMarginX = 8;
-      choiceButtons[i]->alignment = MID_RIGHT;
-      choiceButtons[i]->alignTo = (nbgl_obj_t*)choiceButtons[i-1];
+      choiceButtons[i]->obj.alignmentMarginX = 8;
+      choiceButtons[i]->obj.alignment = MID_RIGHT;
+      choiceButtons[i]->obj.alignTo = (nbgl_obj_t*)choiceButtons[i-1];
     }
     choiceButtons[i]->text = buttonTexts[i];
-    choiceButtons[i]->touchMask = (1<<TOUCHED);
+    choiceButtons[i]->obj.touchMask = (1<<TOUCHED);
     // some buttons may not be visible
     if (i<nbUsedButtons)
       container->children[i] = (nbgl_obj_t*)choiceButtons[i];
@@ -2149,7 +2149,7 @@ int nbgl_layoutUpdateSuggestionButtons(nbgl_layout_t *layout, uint8_t index, uin
     return -1;
 
   container = (nbgl_container_t *)layoutInt->container->children[index];
-  if ((container == NULL) || (container->type != CONTAINER)) {
+  if ((container == NULL) || (container->obj.type != CONTAINER)) {
     return -1;
   }
 
@@ -2199,11 +2199,11 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
   // create gray line
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE, layoutInt->layer);
   line->lineColor = LIGHT_GRAY;
-  line->alignmentMarginY = offsetY;
-  line->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
-  line->alignment = TOP_MIDDLE;
-  line->area.width = SCREEN_WIDTH-2*32;
-  line->area.height = 4;
+  line->obj.alignmentMarginY = offsetY;
+  line->obj.alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
+  line->obj.alignment = TOP_MIDDLE;
+  line->obj.area.width = SCREEN_WIDTH-2*32;
+  line->obj.area.height = 4;
   line->direction = HORIZONTAL;
   line->thickness = 2;
   line->offset = 2;
@@ -2218,11 +2218,11 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
     textArea->text = numText;
     textArea->textAlignment = MID_LEFT;
     textArea->fontId = BAGL_FONT_INTER_MEDIUM_32px_1bpp;
-    textArea->alignmentMarginY = 12;
-    textArea->alignTo = (nbgl_obj_t*)line;
-    textArea->alignment = TOP_LEFT;
-    textArea->area.width = 50;
-    textArea->area.height = nbgl_getFontLineHeight(textArea->fontId);
+    textArea->obj.alignmentMarginY = 12;
+    textArea->obj.alignTo = (nbgl_obj_t*)line;
+    textArea->obj.alignment = TOP_LEFT;
+    textArea->obj.area.width = 50;
+    textArea->obj.area.height = nbgl_getFontLineHeight(textArea->fontId);
     // set this new text area as child of the main container
     addObjectToLayout(layoutInt,(nbgl_obj_t*)textArea);
   }
@@ -2233,23 +2233,23 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, bool numbered, uint8_t numb
   textArea->text = text;
   textArea->textAlignment = MID_LEFT;
   textArea->fontId = BAGL_FONT_INTER_MEDIUM_32px_1bpp;
-  textArea->alignmentMarginY = 12;
-  textArea->alignTo = (nbgl_obj_t*)line;
-  textArea->alignment = TOP_MIDDLE;
+  textArea->obj.alignmentMarginY = 12;
+  textArea->obj.alignTo = (nbgl_obj_t*)line;
+  textArea->obj.alignment = TOP_MIDDLE;
   if (numbered) {
-    textArea->area.width = line->area.width - 2*50;
+    textArea->obj.area.width = line->obj.area.width - 2*50;
   }
   else {
-    textArea->area.width = line->area.width;
+    textArea->obj.area.width = line->obj.area.width;
   }
-  textArea->area.height = nbgl_getFontLineHeight(textArea->fontId);
+  textArea->obj.area.height = nbgl_getFontLineHeight(textArea->fontId);
   textArea->autoHideLongLine = true;
 
   obj = addCallbackObj(layoutInt,(nbgl_obj_t*)textArea,token,NBGL_NO_TUNE);
   if (obj == NULL)
     return -1;
   textArea->token = token;
-  textArea->touchMask = (1<<TOUCHED);
+  textArea->obj.touchMask = (1<<TOUCHED);
 
   // set this new text area as child of the container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)textArea);
@@ -2281,7 +2281,7 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout, uint8_t index, bool numb
 
   // update main text area
   textArea = (nbgl_text_area_t*)layoutInt->container->children[index];
-  if ((textArea == NULL) || (textArea->type != TEXT_AREA)) {
+  if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
     return -1;
   }
   textArea->text = text;
@@ -2298,7 +2298,7 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout, uint8_t index, bool numb
     nbgl_redrawObject((nbgl_obj_t*)textArea,NULL,false);
   }
   // if the text doesn't fit, indicate it by returning 1 instead of 0, for different refresh
-  if (nbgl_getSingleLineTextWidth(textArea->fontId, text) > textArea->area.width) {
+  if (nbgl_getSingleLineTextWidth(textArea->fontId, text) > textArea->obj.area.width) {
     return 1;
   }
   return 0;
@@ -2328,13 +2328,13 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout, bool active, const c
   if (obj == NULL)
     return -1;
 
-  button->alignmentMarginY = BORDER_MARGIN;
-  button->alignment = TOP_MIDDLE;
+  button->obj.alignmentMarginY = BORDER_MARGIN;
+  button->obj.alignment = TOP_MIDDLE;
   button->foregroundColor = WHITE;
   if (active) {
     button->innerColor = BLACK;
     button->borderColor = BLACK;
-    button->touchMask = (1 << TOUCHED);
+    button->obj.touchMask = (1 << TOUCHED);
   }
   else {
     button->borderColor = LIGHT_GRAY;
@@ -2342,10 +2342,10 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout, bool active, const c
   }
   button->text = PIC(text);
   button->fontId = BAGL_FONT_INTER_SEMIBOLD_24px_1bpp;
-  button->area.width = GET_AVAILABLE_WIDTH(layoutInt);
-  button->area.height = BUTTON_DIAMETER;
+  button->obj.area.width = GET_AVAILABLE_WIDTH(layoutInt);
+  button->obj.area.height = BUTTON_DIAMETER;
   button->radius = BUTTON_RADIUS;
-  button->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
+  button->obj.alignTo = layoutInt->container->children[layoutInt->container->nbChildren-1];
   // set this new button as child of the container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)button);
 
@@ -2372,7 +2372,7 @@ int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout, uint8_t index, bo
 
   // update main text area
   button = (nbgl_button_t*)layoutInt->container->children[index];
-  if ((button == NULL) || (button->type != BUTTON)) {
+  if ((button == NULL) || (button->obj.type != BUTTON)) {
     return -1;
   }
   button->text = text;
@@ -2380,7 +2380,7 @@ int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout, uint8_t index, bo
   if (active) {
     button->innerColor = BLACK;
     button->borderColor = BLACK;
-    button->touchMask = (1 << TOUCHED);
+    button->obj.touchMask = (1 << TOUCHED);
   }
   else {
     button->borderColor = LIGHT_GRAY;
@@ -2412,9 +2412,9 @@ int nbgl_layoutAddKeypad(nbgl_layout_t *layout, keyboardCallback_t callback, boo
 
   // create keypad
   keypad = (nbgl_keypad_t*)nbgl_objPoolGet(KEYPAD, layoutInt->layer);
-  keypad->alignmentMarginY = 0;
-  keypad->alignment = BOTTOM_MIDDLE;
-  keypad->alignTo = NULL;
+  keypad->obj.alignmentMarginY = 0;
+  keypad->obj.alignment = BOTTOM_MIDDLE;
+  keypad->obj.alignTo = NULL;
   keypad->borderColor = LIGHT_GRAY;
   keypad->callback = PIC(callback);
   keypad->enableDigits = true;
@@ -2448,7 +2448,7 @@ int nbgl_layoutUpdateKeypad(nbgl_layout_t *layout, uint8_t index, bool enableVal
 
   // get existing keypad
   keypad = (nbgl_keypad_t*)layoutInt->container->children[index];
-  if ((keypad == NULL) || (keypad->type != KEYPAD)) {
+  if ((keypad == NULL) || (keypad->obj.type != KEYPAD)) {
     return -1;
   }
   keypad->enableValidate = enableValidate;
@@ -2484,19 +2484,19 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits) {
   container->nbChildren = nbDigits+1; // +1 for the line
   container->children = nbgl_containerPoolGet(container->nbChildren, layoutInt->layer);
   // 12 pixels between each icon (knowing that the effective round are 18px large and the icon 24px)
-  container->area.width = nbDigits*C_round_24px.width + (nbDigits+1)*12;
-  container->area.height = 48;
+  container->obj.area.width = nbDigits*C_round_24px.width + (nbDigits+1)*12;
+  container->obj.area.height = 48;
   // distance from digits to title is fixed to 20 px, except if title is more than 1 line and a back key is present
   if ((layoutInt->container->nbChildren != 3) || (layoutInt->container->children[1]->area.height == 32)) {
-    container->alignmentMarginY = 20;
+    container->obj.alignmentMarginY = 20;
   }
   else {
-    container->alignmentMarginY = 12;
+    container->obj.alignmentMarginY = 12;
   }
 
   // item N-2 is the title
-  container->alignTo = layoutInt->container->children[layoutInt->container->nbChildren-2];
-  container->alignment = BOTTOM_MIDDLE;
+  container->obj.alignTo = layoutInt->container->children[layoutInt->container->nbChildren-2];
+  container->obj.alignment = BOTTOM_MIDDLE;
 
   // set this new container as child of the main container
   addObjectToLayout(layoutInt,(nbgl_obj_t*)container);
@@ -2507,24 +2507,24 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits) {
     nbgl_image_t* image = (nbgl_image_t*)container->children[i];
     image->buffer = &C_round_24px;
     image->foregroundColor = WHITE;
-    image->alignmentMarginX = 12;
+    image->obj.alignmentMarginX = 12;
     if (i>0) {
-      image->alignment = MID_RIGHT;
-      image->alignTo = (nbgl_obj_t*)container->children[i-1];
+      image->obj.alignment = MID_RIGHT;
+      image->obj.alignTo = (nbgl_obj_t*)container->children[i-1];
     }
     else {
-      image->alignment = NO_ALIGNMENT;
-      image->alignmentMarginY = (container->area.height - C_round_24px.width)/2;
+      image->obj.alignment = NO_ALIGNMENT;
+      image->obj.alignmentMarginY = (container->obj.area.height - C_round_24px.width)/2;
     }
   }
   // create gray line
   line = (nbgl_line_t*)nbgl_objPoolGet(LINE, layoutInt->layer);
   line->lineColor = LIGHT_GRAY;
-  line->alignmentMarginY = 0;
-  line->alignTo = NULL;
-  line->alignment = BOTTOM_MIDDLE;
-  line->area.width = container->area.width;
-  line->area.height = 4;
+  line->obj.alignmentMarginY = 0;
+  line->obj.alignTo = NULL;
+  line->obj.alignment = BOTTOM_MIDDLE;
+  line->obj.area.width = container->obj.area.width;
+  line->obj.area.height = 4;
   line->direction = HORIZONTAL;
   line->thickness = 2;
   line->offset = 2;
@@ -2554,7 +2554,7 @@ int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t 
   // get container
   container = (nbgl_container_t*)layoutInt->container->children[index];
   // sanity check
-  if ((container == NULL) || (container->type != CONTAINER)) {
+  if ((container == NULL) || (container->obj.type != CONTAINER)) {
     return -1;
   }
   if (nbActive > container->nbChildren) {
@@ -2563,14 +2563,14 @@ int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t 
   if (nbActive == 0) {
     // deactivate the first digit
     image = (nbgl_image_t*)container->children[0];
-    if ((image == NULL) || (image->type != IMAGE)) {
+    if ((image == NULL) || (image->obj.type != IMAGE)) {
       return -1;
     }
     image->foregroundColor = WHITE;
   }
   else {
     image = (nbgl_image_t*)container->children[nbActive-1];
-    if ((image == NULL) || (image->type != IMAGE)) {
+    if ((image == NULL) || (image->obj.type != IMAGE)) {
       return -1;
     }
     // if the last "active" is already active, it means that we are decreasing the number of active

--- a/lib_nbgl/src/nbgl_navigation.c
+++ b/lib_nbgl/src/nbgl_navigation.c
@@ -107,56 +107,56 @@ nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, b
   nbgl_container_t *navContainer;
 
   navContainer = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layer);
-  navContainer->area.width = SCREEN_WIDTH - 2*BORDER_MARGIN;
-  navContainer->area.height = BUTTON_DIAMETER+2*BORDER_MARGIN;
+  navContainer->obj.area.width = SCREEN_WIDTH - 2*BORDER_MARGIN;
+  navContainer->obj.area.height = BUTTON_DIAMETER+2*BORDER_MARGIN;
   navContainer->layout = HORIZONTAL ;
   navContainer->nbChildren = NB_MAX_CHILDREN;
   navContainer->children = (nbgl_obj_t**)nbgl_containerPoolGet(navContainer->nbChildren, layer);
-  navContainer->alignmentMarginX = 0;
-  navContainer->alignmentMarginY = 0;
-  navContainer->alignment = NO_ALIGNMENT;
+  navContainer->obj.alignmentMarginX = 0;
+  navContainer->obj.alignmentMarginY = 0;
+  navContainer->obj.alignment = NO_ALIGNMENT;
 
   if (withExitKey) {
     button = (nbgl_button_t*)nbgl_objPoolGet(BUTTON,layer);
     button->innerColor = WHITE;
     button->borderColor = LIGHT_GRAY;
-    button->area.width = BUTTON_DIAMETER;
-    button->area.height = BUTTON_DIAMETER;
+    button->obj.area.width = BUTTON_DIAMETER;
+    button->obj.area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = &C_cross32px;
-    button->alignmentMarginX = 0;
-    button->alignmentMarginY = 0;
+    button->obj.alignmentMarginX = 0;
+    button->obj.alignmentMarginY = 0;
 
-    button->alignment = (nbPages > 1) ? MID_LEFT:CENTER;
-    button->alignTo = NULL;
-    button->touchMask = (1<<TOUCHED);
+    button->obj.alignment = (nbPages > 1) ? MID_LEFT:CENTER;
+    button->obj.alignTo = NULL;
+    button->obj.touchMask = (1<<TOUCHED);
     navContainer->children[EXIT_BUTTON_INDEX] = (nbgl_obj_t*)button;
   }
   if (nbPages > 1) {
     button = (nbgl_button_t*)nbgl_objPoolGet(BUTTON,layer);
     button->innerColor = WHITE;
     button->borderColor = LIGHT_GRAY;
-    button->area.width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
+    button->obj.area.width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
     if (!withExitKey)
-      button->area.width += BUTTON_DIAMETER/2;
-    button->area.height = BUTTON_DIAMETER;
+      button->obj.area.width += BUTTON_DIAMETER/2;
+    button->obj.area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = &C_leftArrow32px;
-    button->alignmentMarginY = 0;
+    button->obj.alignmentMarginY = 0;
     if (withExitKey) {
-      button->alignmentMarginX = INTERNAL_SMALL_MARGIN;
-      button->alignment = MID_RIGHT;
-      button->alignTo = navContainer->children[EXIT_BUTTON_INDEX];
+      button->obj.alignmentMarginX = INTERNAL_SMALL_MARGIN;
+      button->obj.alignment = MID_RIGHT;
+      button->obj.alignTo = navContainer->children[EXIT_BUTTON_INDEX];
     }
     else {
-      button->alignmentMarginX = 0;
-      button->alignment = MID_LEFT;
-      button->alignTo = NULL;
+      button->obj.alignmentMarginX = 0;
+      button->obj.alignment = MID_LEFT;
+      button->obj.alignTo = NULL;
 
     }
-    button->touchMask = (1<<TOUCHED);
+    button->obj.touchMask = (1<<TOUCHED);
     navContainer->children[PREVIOUS_PAGE_INDEX] = (nbgl_obj_t*)button;
 
     // create next page button
@@ -164,18 +164,18 @@ nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, b
     button->innerColor = WHITE;
     button->borderColor = LIGHT_GRAY;
     button->foregroundColor = BLACK;
-    button->area.width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
+    button->obj.area.width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
     if (!withExitKey)
-      button->area.width += BUTTON_DIAMETER/2;
-    button->area.height = BUTTON_DIAMETER;
+      button->obj.area.width += BUTTON_DIAMETER/2;
+    button->obj.area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = &C_rightArrow32px;
-    button->alignmentMarginX = INTERNAL_SMALL_MARGIN;
-    button->alignmentMarginY = 0;
-    button->alignment = MID_RIGHT;
-    button->alignTo = navContainer->children[PREVIOUS_PAGE_INDEX];
-    button->touchMask = (1<<TOUCHED);
+    button->obj.alignmentMarginX = INTERNAL_SMALL_MARGIN;
+    button->obj.alignmentMarginY = 0;
+    button->obj.alignment = MID_RIGHT;
+    button->obj.alignTo = navContainer->children[PREVIOUS_PAGE_INDEX];
+    button->obj.touchMask = (1<<TOUCHED);
     navContainer->children[NEXT_PAGE_INDEX] = (nbgl_obj_t*)button;
 
     configButtons(navContainer, nbPages, activePage);

--- a/lib_nbgl/src/nbgl_navigation.c
+++ b/lib_nbgl/src/nbgl_navigation.c
@@ -107,8 +107,8 @@ nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, b
   nbgl_container_t *navContainer;
 
   navContainer = (nbgl_container_t *)nbgl_objPoolGet(CONTAINER, layer);
-  navContainer->width = SCREEN_WIDTH - 2*BORDER_MARGIN;
-  navContainer->height = BUTTON_DIAMETER+2*BORDER_MARGIN;
+  navContainer->area.width = SCREEN_WIDTH - 2*BORDER_MARGIN;
+  navContainer->area.height = BUTTON_DIAMETER+2*BORDER_MARGIN;
   navContainer->layout = HORIZONTAL ;
   navContainer->nbChildren = NB_MAX_CHILDREN;
   navContainer->children = (nbgl_obj_t**)nbgl_containerPoolGet(navContainer->nbChildren, layer);
@@ -120,8 +120,8 @@ nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, b
     button = (nbgl_button_t*)nbgl_objPoolGet(BUTTON,layer);
     button->innerColor = WHITE;
     button->borderColor = LIGHT_GRAY;
-    button->width = BUTTON_DIAMETER;
-    button->height = BUTTON_DIAMETER;
+    button->area.width = BUTTON_DIAMETER;
+    button->area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = &C_cross32px;
@@ -137,10 +137,10 @@ nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, b
     button = (nbgl_button_t*)nbgl_objPoolGet(BUTTON,layer);
     button->innerColor = WHITE;
     button->borderColor = LIGHT_GRAY;
-    button->width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
+    button->area.width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
     if (!withExitKey)
-      button->width += BUTTON_DIAMETER/2;
-    button->height = BUTTON_DIAMETER;
+      button->area.width += BUTTON_DIAMETER/2;
+    button->area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = &C_leftArrow32px;
@@ -164,10 +164,10 @@ nbgl_container_t *nbgl_navigationPopulate(uint8_t nbPages, uint8_t activePage, b
     button->innerColor = WHITE;
     button->borderColor = LIGHT_GRAY;
     button->foregroundColor = BLACK;
-    button->width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
+    button->area.width = (SCREEN_WIDTH - (2*BORDER_MARGIN+2*INTERNAL_SMALL_MARGIN+BUTTON_DIAMETER))/2;
     if (!withExitKey)
-      button->width += BUTTON_DIAMETER/2;
-    button->height = BUTTON_DIAMETER;
+      button->area.width += BUTTON_DIAMETER/2;
+    button->area.height = BUTTON_DIAMETER;
     button->radius = BUTTON_RADIUS;
     button->text = NULL;
     button->icon = &C_rightArrow32px;

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -65,7 +65,7 @@ static void compute_relativePosition(nbgl_obj_t* obj, nbgl_obj_t *prevObj) {
     if (parent->layout == VERTICAL) {
       obj->rel_x0 = obj->alignmentMarginX;
       if (prevObj!=NULL) {
-        obj->rel_y0 = prevObj->rel_y0 + prevObj->height + obj->alignmentMarginY;
+        obj->rel_y0 = prevObj->rel_y0 + prevObj->area.height + obj->alignmentMarginY;
       }
       else {
         obj->rel_y0 = obj->alignmentMarginY;
@@ -73,7 +73,7 @@ static void compute_relativePosition(nbgl_obj_t* obj, nbgl_obj_t *prevObj) {
     }
     else { // HORIZONTAL
       if (prevObj!=NULL) {
-        obj->rel_x0 = prevObj->rel_x0 + prevObj->width + obj->alignmentMarginX;
+        obj->rel_x0 = prevObj->rel_x0 + prevObj->area.width + obj->alignmentMarginX;
       }
       else {
         obj->rel_x0 = obj->alignmentMarginX;
@@ -99,36 +99,36 @@ static void compute_relativePosition(nbgl_obj_t* obj, nbgl_obj_t *prevObj) {
           obj->rel_y0 = obj->alignmentMarginY;
           break;
         case TOP_MIDDLE:
-          obj->rel_x0 = (parent->width - obj->width)/2 + obj->alignmentMarginX;
+          obj->rel_x0 = (parent->area.width - obj->area.width)/2 + obj->alignmentMarginX;
           obj->rel_y0 = obj->alignmentMarginY;
           break;
         case TOP_RIGHT:
-          obj->rel_x0 = (parent->width - obj->width) - obj->alignmentMarginX;
+          obj->rel_x0 = (parent->area.width - obj->area.width) - obj->alignmentMarginX;
           obj->rel_y0 = obj->alignmentMarginY;
           break;
         case MID_LEFT:
           obj->rel_x0 = obj->alignmentMarginX;
-          obj->rel_y0 = (parent->height - obj->height)/2 + obj->alignmentMarginY;
+          obj->rel_y0 = (parent->area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case CENTER:
-          obj->rel_x0 = (parent->width - obj->width)/2 + obj->alignmentMarginX;
-          obj->rel_y0 = (parent->height - obj->height)/2 + obj->alignmentMarginY;
+          obj->rel_x0 = (parent->area.width - obj->area.width)/2 + obj->alignmentMarginX;
+          obj->rel_y0 = (parent->area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case MID_RIGHT:
-          obj->rel_x0 = (parent->width - obj->width) - obj->alignmentMarginX;
-          obj->rel_y0 = (parent->height - obj->height)/2 + obj->alignmentMarginY;
+          obj->rel_x0 = (parent->area.width - obj->area.width) - obj->alignmentMarginX;
+          obj->rel_y0 = (parent->area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case BOTTOM_LEFT:
           obj->rel_x0 = obj->alignmentMarginX;
-          obj->rel_y0 = (parent->height - obj->height) - obj->alignmentMarginY;
+          obj->rel_y0 = (parent->area.height - obj->area.height) - obj->alignmentMarginY;
           break;
         case BOTTOM_MIDDLE:
-          obj->rel_x0 = (parent->width - obj->width)/2 + obj->alignmentMarginX;
-          obj->rel_y0 = (parent->height - obj->height) - obj->alignmentMarginY;
+          obj->rel_x0 = (parent->area.width - obj->area.width)/2 + obj->alignmentMarginX;
+          obj->rel_y0 = (parent->area.height - obj->area.height) - obj->alignmentMarginY;
           break;
         case BOTTOM_RIGHT:
-          obj->rel_x0 = (parent->width - obj->width) - obj->alignmentMarginX;
-          obj->rel_y0 = (parent->height - obj->height) - obj->alignmentMarginY;
+          obj->rel_x0 = (parent->area.width - obj->area.width) - obj->alignmentMarginX;
+          obj->rel_y0 = (parent->area.height - obj->area.height) - obj->alignmentMarginY;
           break;
         default:
           //not supported
@@ -140,54 +140,54 @@ static void compute_relativePosition(nbgl_obj_t* obj, nbgl_obj_t *prevObj) {
       switch (obj->alignment) {
         case TOP_LEFT:
           obj->rel_x0 = alignToObj->rel_x0 + obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 - obj->height - obj->alignmentMarginY;
+          obj->rel_y0 = alignToObj->rel_y0 - obj->area.height - obj->alignmentMarginY;
           break;
         case TOP_MIDDLE:
-          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->width - obj->width)/2 + obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 - obj->height - obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->area.width - obj->area.width)/2 + obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 - obj->area.height - obj->alignmentMarginY;
           break;
         case TOP_RIGHT:
-          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->width - obj->width) - obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 - obj->height - obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->area.width - obj->area.width) - obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 - obj->area.height - obj->alignmentMarginY;
           break;
 
         case LEFT_TOP:
-          obj->rel_x0 = alignToObj->rel_x0 - obj->width - obj->alignmentMarginX;
+          obj->rel_x0 = alignToObj->rel_x0 - obj->area.width - obj->alignmentMarginX;
           obj->rel_y0 = alignToObj->rel_y0 + obj->alignmentMarginY;
           break;
         case MID_LEFT:
-          obj->rel_x0 = alignToObj->rel_x0 - obj->width - obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->height - obj->height)/2 + obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 - obj->area.width - obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case LEFT_BOTTOM:
-          obj->rel_x0 = alignToObj->rel_x0 - obj->width - obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->height - obj->height) + obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 - obj->area.width - obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->area.height - obj->area.height) + obj->alignmentMarginY;
           break;
 
         case RIGHT_TOP:
-          obj->rel_x0 = alignToObj->rel_x0 + alignToObj->width + obj->alignmentMarginX;
+          obj->rel_x0 = alignToObj->rel_x0 + alignToObj->area.width + obj->alignmentMarginX;
           obj->rel_y0 = alignToObj->rel_y0 + obj->alignmentMarginY;
           break;
         case MID_RIGHT:
-          obj->rel_x0 = alignToObj->rel_x0 + alignToObj->width + obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->height - obj->height)/2 + obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 + alignToObj->area.width + obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case RIGHT_BOTTOM:
-          obj->rel_x0 = alignToObj->rel_x0 + alignToObj->width + obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->height - obj->height) + obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 + alignToObj->area.width + obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 + (alignToObj->area.height - obj->area.height) + obj->alignmentMarginY;
           break;
 
         case BOTTOM_LEFT:
           obj->rel_x0 = alignToObj->rel_x0 + obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 + alignToObj->height + obj->alignmentMarginY;
+          obj->rel_y0 = alignToObj->rel_y0 + alignToObj->area.height + obj->alignmentMarginY;
           break;
         case BOTTOM_MIDDLE:
-          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->width - obj->width)/2 + obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 + alignToObj->height + obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->area.width - obj->area.width)/2 + obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 + alignToObj->area.height + obj->alignmentMarginY;
           break;
         case BOTTOM_RIGHT:
-          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->width - obj->width) - obj->alignmentMarginX;
-          obj->rel_y0 = alignToObj->rel_y0 + alignToObj->height + obj->alignmentMarginY;
+          obj->rel_x0 = alignToObj->rel_x0 + (alignToObj->area.width - obj->area.width) - obj->alignmentMarginX;
+          obj->rel_y0 = alignToObj->rel_y0 + alignToObj->area.height + obj->alignmentMarginY;
           break;
         default:
           //not supported
@@ -208,17 +208,17 @@ static void compute_position(nbgl_obj_t* obj, nbgl_obj_t *prevObj) {
     // HUGE issue
     return;
   }
-  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent.type = %d, parent->x0 = %d, obj->rel_x0=%d\n",parent->type,parent->x0,obj->rel_x0);
-  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent->y0 = %d, obj->rel_y0=%d\n",parent->y0,obj->rel_y0);
+  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent.type = %d, parent->area.x0 = %d, obj->rel_x0=%d\n",parent->type,parent->area.x0,obj->rel_x0);
+  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent->area.y0 = %d, obj->rel_y0=%d\n",parent->area.y0,obj->rel_y0);
 
-  obj->x0 = parent->x0+obj->rel_x0;
-  obj->y0 = parent->y0+obj->rel_y0;
+  obj->area.x0 = parent->area.x0+obj->rel_x0;
+  obj->area.y0 = parent->area.y0+obj->rel_y0;
 
-  if ((obj->x0+obj->width)>SCREEN_WIDTH) {
-    LOG_FATAL(OBJ_LOGGER,"compute_position(), forbidden width, obj->type = %d, x0=%d, width=%d\n",obj->type,obj->x0,obj->width);
+  if ((obj->area.x0+obj->area.width)>SCREEN_WIDTH) {
+    LOG_FATAL(OBJ_LOGGER,"compute_position(), forbidden width, obj->type = %d, x0=%d, width=%d\n",obj->type,obj->area.x0,obj->area.width);
   }
-  if ((obj->y0+obj->height)>SCREEN_HEIGHT) {
-    LOG_FATAL(OBJ_LOGGER,"compute_position(), forbidden height, obj->type = %d, y0=%d, height=%d\n",obj->type,obj->y0,obj->height);
+  if ((obj->area.y0+obj->area.height)>SCREEN_HEIGHT) {
+    LOG_FATAL(OBJ_LOGGER,"compute_position(), forbidden height, obj->type = %d, y0=%d, height=%d\n",obj->type,obj->area.y0,obj->area.height);
   }
 }
 
@@ -228,11 +228,11 @@ static void draw_screen(nbgl_container_t *obj) {
   if (objDrawingDisabled) {
     return;
   }
-  rectArea.backgroundColor = obj->backgroundColor;
-  rectArea.x0 = obj->x0;
-  rectArea.y0 = obj->y0;
-  rectArea.width = obj->width;
-  rectArea.height = obj->height;
+  rectArea.backgroundColor = obj->area.backgroundColor;
+  rectArea.x0 = obj->area.x0;
+  rectArea.y0 = obj->area.y0;
+  rectArea.width = obj->area.width;
+  rectArea.height = obj->area.height;
   nbgl_frontDrawRect(&rectArea);
 }
 
@@ -243,9 +243,9 @@ static void draw_container(nbgl_container_t* obj, nbgl_obj_t *prevObj, bool comp
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_container(), x0 = %d, y0 = %d, width = %d\n", obj->x0, obj->y0, obj->width);
+  LOG_DEBUG(OBJ_LOGGER,"draw_container(), x0 = %d, y0 = %d, width = %d\n", obj->area.x0, obj->area.y0, obj->area.width);
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
   if (obj->forceClean) {
     nbgl_frontDrawRect((nbgl_area_t*)obj);
   }
@@ -269,10 +269,10 @@ static void draw_button(nbgl_button_t* obj, nbgl_obj_t *prevObj, bool computePos
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_button(), x0 = %d, y0 = %d, width = %d, height = %d\n", obj->x0, obj->y0, obj->width, obj->height);
+  LOG_DEBUG(OBJ_LOGGER,"draw_button(), x0 = %d, y0 = %d, width = %d, height = %d\n", obj->area.x0, obj->area.y0, obj->area.width, obj->area.height);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
   // draw the rounded corner rectangle
   if (obj->innerColor == obj->borderColor) {
     nbgl_drawRoundedRect((nbgl_area_t*)obj,
@@ -301,13 +301,13 @@ static void draw_button(nbgl_button_t* obj, nbgl_obj_t *prevObj, bool computePos
     nbgl_area_t rectArea;
     textWidth = nbgl_getTextWidth(obj->fontId, text);
     if (obj->icon != NULL) {
-      rectArea.x0 = obj->x0 + obj->width/2  - (textWidth+obj->icon->width+8)/2 + obj->icon->width + 8;
+      rectArea.x0 = obj->area.x0 + obj->area.width/2  - (textWidth+obj->icon->width+8)/2 + obj->icon->width + 8;
     }
     else {
-      rectArea.x0 = obj->x0 + (obj->width - textWidth)/2;
+      rectArea.x0 = obj->area.x0 + (obj->area.width - textWidth)/2;
     }
     LOG_DEBUG(OBJ_LOGGER,"draw_button(), text = %s\n", text);
-    rectArea.y0 = obj->y0 + (obj->height - nbgl_getFontHeight(obj->fontId))/2;
+    rectArea.y0 = obj->area.y0 + (obj->area.height - nbgl_getFontHeight(obj->fontId))/2;
     rectArea.width = textWidth;
     rectArea.height = nbgl_getFontHeight(obj->fontId);
     rectArea.backgroundColor = obj->innerColor;
@@ -319,13 +319,13 @@ static void draw_button(nbgl_button_t* obj, nbgl_obj_t *prevObj, bool computePos
     nbgl_area_t rectArea;
 
     if (text != NULL) {
-      iconX0 = obj->x0 + (obj->width - (textWidth+obj->icon->width+8))/2;
+      iconX0 = obj->area.x0 + (obj->area.width - (textWidth+obj->icon->width+8))/2;
     }
     else {
-      iconX0 = obj->x0 + (obj->width- obj->icon->width)/2;
+      iconX0 = obj->area.x0 + (obj->area.width- obj->icon->width)/2;
     }
-    LOG_DEBUG(OBJ_LOGGER,"draw_button(), obj->height = %d, obj->iconHeight = %d\n", obj->height , obj->icon->height);
-    iconY0 = obj->y0 + (obj->height - obj->icon->height)/2;
+    LOG_DEBUG(OBJ_LOGGER,"draw_button(), obj->area.height = %d, obj->iconHeight = %d\n", obj->area.height , obj->icon->height);
+    iconY0 = obj->area.y0 + (obj->area.height - obj->icon->height)/2;
 
     rectArea.backgroundColor = obj->innerColor;
     rectArea.x0 = iconX0;
@@ -352,16 +352,16 @@ static void draw_line(nbgl_line_t* obj, nbgl_obj_t *prevObj, bool computePositio
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_line(), x0 = %d, y0 = %d\n", obj->x0, obj->y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_line(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
-  LOG_DEBUG(OBJ_LOGGER,"draw_line(), backgroundColor = %d, lineColor = %d\n", obj->backgroundColor,obj->lineColor);
-  rectArea.x0 = obj->x0;
-  rectArea.y0 = obj->y0;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  LOG_DEBUG(OBJ_LOGGER,"draw_line(), backgroundColor = %d, lineColor = %d\n", obj->area.backgroundColor,obj->lineColor);
+  rectArea.x0 = obj->area.x0;
+  rectArea.y0 = obj->area.y0;
   if (obj->direction == VERTICAL) {
-    rectArea.width = obj->width = obj->thickness;
+    rectArea.width = obj->area.width = obj->thickness;
     rectArea.backgroundColor = obj->lineColor;
-    rectArea.height = obj->height;
+    rectArea.height = obj->area.height;
     nbgl_frontDrawRect(&rectArea);
   }
   else {
@@ -382,9 +382,9 @@ static void draw_line(nbgl_line_t* obj, nbgl_obj_t *prevObj, bool computePositio
       LOG_WARN(OBJ_LOGGER,"draw_line(), forbidden thickness = %d\n", obj->thickness);
       return;
     }
-    rectArea.width = obj->width;
-    rectArea.height = obj->height = 4;
-    rectArea.backgroundColor = obj->backgroundColor;
+    rectArea.width = obj->area.width;
+    rectArea.height = obj->area.height = 4;
+    rectArea.backgroundColor = obj->area.backgroundColor;
     nbgl_frontDrawHorizontalLine(&rectArea,mask,obj->lineColor);
   }
 }
@@ -407,22 +407,22 @@ static void draw_image(nbgl_image_t* obj, nbgl_obj_t *prevObj, bool computePosit
   }
 
   // use dimension and bpp from the icon details
-  obj->width = iconDetails->width;
-  obj->height = iconDetails->height;
-  obj->bpp = iconDetails->bpp;
+  obj->area.width = iconDetails->width;
+  obj->area.height = iconDetails->height;
+  obj->area.bpp = iconDetails->bpp;
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
   }
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_image(), x0 = %d, y0 = %d\n", obj->x0, obj->y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_image(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
-  if (obj->bpp == NBGL_BPP_1) {
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  if (obj->area.bpp == NBGL_BPP_1) {
     colorMap = obj->foregroundColor;
   }
-  else if (obj->bpp == NBGL_BPP_2) {
+  else if (obj->area.bpp == NBGL_BPP_2) {
     colorMap = ((WHITE<<6)|(LIGHT_GRAY<<4)|(DARK_GRAY<<2)|BLACK);
   }
   else {
@@ -440,24 +440,24 @@ static void draw_switch(nbgl_switch_t* obj, nbgl_obj_t *prevObj, bool computePos
   nbgl_area_t rectArea;
 
   // force dimensions
-  obj->width = C_switch_60_40.width;
-  obj->height = C_switch_60_40.height;
+  obj->area.width = C_switch_60_40.width;
+  obj->area.height = C_switch_60_40.height;
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
   }
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_switch(), x0 = %d, y0 = %d\n", obj->x0, obj->y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_switch(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
-  rectArea.x0 = obj->x0;
-  rectArea.y0 = obj->y0;
-  rectArea.width = obj->width;
-  rectArea.height = obj->height;
-  rectArea.backgroundColor = obj->backgroundColor;
+  rectArea.x0 = obj->area.x0;
+  rectArea.y0 = obj->area.y0;
+  rectArea.width = obj->area.width;
+  rectArea.height = obj->area.height;
+  rectArea.backgroundColor = obj->area.backgroundColor;
   rectArea.bpp = NBGL_BPP_1;
   if (obj->state == OFF_STATE) {
     nbgl_frontDrawImage(&rectArea,(uint8_t*)C_switch_60_40.bitmap,NO_TRANSFORMATION,obj->offColor);
@@ -472,24 +472,24 @@ static void draw_radioButton(nbgl_radio_t* obj, nbgl_obj_t *prevObj, bool comput
   nbgl_area_t rectArea;
 
   // force dimensions
-  obj->width = 32;
-  obj->height = 32;
+  obj->area.width = 32;
+  obj->area.height = 32;
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
   }
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_radioButton(), x0 = %d, y0 = %d, state = %d\n", obj->x0, obj->y0, obj->state);
+  LOG_DEBUG(OBJ_LOGGER,"draw_radioButton(), x0 = %d, y0 = %d, state = %d\n", obj->area.x0, obj->area.y0, obj->state);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
-  rectArea.x0 = obj->x0;
-  rectArea.y0 = obj->y0;
-  rectArea.width = obj->width;
-  rectArea.height = obj->height;
-  rectArea.backgroundColor = obj->backgroundColor;
+  rectArea.x0 = obj->area.x0;
+  rectArea.y0 = obj->area.y0;
+  rectArea.width = obj->area.width;
+  rectArea.height = obj->area.height;
+  rectArea.backgroundColor = obj->area.backgroundColor;
   rectArea.bpp = NBGL_BPP_1;
   if (obj->state == OFF_STATE) {
     nbgl_frontDrawImage(&rectArea,(uint8_t*)C_radio_inactive_32px.bitmap,NO_TRANSFORMATION,obj->borderColor);
@@ -516,27 +516,27 @@ static void draw_progressBar(nbgl_progress_bar_t* obj, nbgl_obj_t *prevObj, bool
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_progressBar(), x0 = %d, y0 = %d, level = %d %%\n", obj->x0, obj->y0, obj->state);
+  LOG_DEBUG(OBJ_LOGGER,"draw_progressBar(), x0 = %d, y0 = %d, level = %d %%\n", obj->area.x0, obj->area.y0, obj->state);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
   // draw external part if necessary
   if (obj->withBorder) {
     nbgl_drawRoundedBorderedRect((nbgl_area_t*)obj,
-                                RADIUS_0_PIXELS, stroke, obj->backgroundColor, obj->foregroundColor);
+                                RADIUS_0_PIXELS, stroke, obj->area.backgroundColor, obj->foregroundColor);
   } else {
     nbgl_drawRoundedRect((nbgl_area_t*)obj,
-                              RADIUS_0_PIXELS, obj->backgroundColor);
+                              RADIUS_0_PIXELS, obj->area.backgroundColor);
   }
   // draw level
-  levelWidth = MIN(obj->width * obj->state / 100, obj->width);
+  levelWidth = MIN(obj->area.width * obj->state / 100, obj->area.width);
   if (levelWidth > 0) {
-    uint16_t tmp_width = obj->width;
-    obj->width = levelWidth;
+    uint16_t tmp_width = obj->area.width;
+    obj->area.width = levelWidth;
     nbgl_drawRoundedRect((nbgl_area_t*)obj,
                                RADIUS_0_PIXELS, obj->foregroundColor);
-    obj->width = tmp_width;
+    obj->area.width = tmp_width;
   }
 }
 
@@ -556,7 +556,7 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
     uint8_t i;
 #define INTER_DASHES 10 // pixels
     // force height
-    obj->height = 4;
+    obj->area.height = 4;
 
     if (computePosition) {
       compute_position((nbgl_obj_t *)obj,prevObj);
@@ -564,17 +564,17 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
     if (objDrawingDisabled) {
       return;
     }
-    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->x0, obj->y0, obj->activePage, obj->nbPages);
+    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->area.x0, obj->area.y0, obj->activePage, obj->nbPages);
 
     // inherit background from parent
-    obj->backgroundColor = obj->parent->backgroundColor;
+    obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
-    dashWidth = (obj->width - ((obj->nbPages-1) * INTER_DASHES))/obj->nbPages;
-    rectArea.x0 = obj->x0;
-    rectArea.y0 = obj->y0;
+    dashWidth = (obj->area.width - ((obj->nbPages-1) * INTER_DASHES))/obj->nbPages;
+    rectArea.x0 = obj->area.x0;
+    rectArea.y0 = obj->area.y0;
     rectArea.width = dashWidth;
-    rectArea.height = obj->height;
-    rectArea.backgroundColor = obj->backgroundColor;
+    rectArea.height = obj->area.height;
+    rectArea.backgroundColor = obj->area.backgroundColor;
     rectArea.bpp = NBGL_BPP_1;
     // draw dashes
     for (i=0;i<=obj->activePage;i++) {
@@ -591,9 +591,9 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
 
     SPRINTF(navText,"%d of %d", obj->activePage+1, obj->nbPages);
     // force height
-    obj->height = nbgl_getFontHeight(BAGL_FONT_INTER_REGULAR_24px);
+    obj->area.height = nbgl_getFontHeight(BAGL_FONT_INTER_REGULAR_24px);
     // the width must be at least 80
-    obj->width = nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px,navText);
+    obj->area.width = nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px,navText);
 
     if (computePosition) {
       compute_position((nbgl_obj_t *)obj,prevObj);
@@ -601,17 +601,17 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
     if (objDrawingDisabled) {
       return;
     }
-    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->x0, obj->y0, obj->activePage, obj->nbPages);
+    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->area.x0, obj->area.y0, obj->activePage, obj->nbPages);
 
     // inherit background from parent
-    obj->backgroundColor = obj->parent->backgroundColor;
+    obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
     // draw active page
-    rectArea.x0 = obj->x0;
-    rectArea.y0 = obj->y0;
-    rectArea.width = obj->width;
-    rectArea.height = obj->height;
-    rectArea.backgroundColor = obj->backgroundColor;
+    rectArea.x0 = obj->area.x0;
+    rectArea.y0 = obj->area.y0;
+    rectArea.width = obj->area.width;
+    rectArea.height = obj->area.height;
+    rectArea.backgroundColor = obj->area.backgroundColor;
     rectArea.bpp = NBGL_BPP_1;
     nbgl_drawText(&rectArea, navText, 9, BAGL_FONT_INTER_REGULAR_24px, DARK_GRAY);
   }
@@ -653,44 +653,44 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
     return;
   }
 
-  LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), wrapping = %d, x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->wrapping, obj->x0, obj->y0, obj->width, obj->height, text);
+  LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), wrapping = %d, x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->wrapping, obj->area.x0, obj->area.y0, obj->area.width, obj->area.height, text);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
   // draw background to make sure it's clean
-  rectArea.x0 = obj->x0;
-  rectArea.y0 = obj->y0;
-  rectArea.width = obj->width;
-  rectArea.height = obj->height;
-  rectArea.backgroundColor = obj->backgroundColor;
+  rectArea.x0 = obj->area.x0;
+  rectArea.y0 = obj->area.y0;
+  rectArea.width = obj->area.width;
+  rectArea.height = obj->area.height;
+  rectArea.backgroundColor = obj->area.backgroundColor;
   nbgl_frontDrawRect(&rectArea);
   // draw border with given style
   if (obj->style == LEDGER_BORDER) {
     // draw horizontal segments (4 pixels stroke)
-    rectArea.x0 = obj->x0;
-    rectArea.y0 = obj->y0;
+    rectArea.x0 = obj->area.x0;
+    rectArea.y0 = obj->area.y0;
     rectArea.width = 24;
     rectArea.height = 4;
     nbgl_frontDrawHorizontalLine(&rectArea, 0xF, obj->textColor); // top left
-    rectArea.x0 = obj->x0+obj->width-rectArea.width;
+    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
     nbgl_frontDrawHorizontalLine(&rectArea,0xF, obj->textColor); // top right
-    rectArea.y0 = obj->y0+obj->height-4;
+    rectArea.y0 = obj->area.y0+obj->area.height-4;
     nbgl_frontDrawHorizontalLine(&rectArea,0xF, obj->textColor); //bottom right
-    rectArea.x0 = obj->x0;
+    rectArea.x0 = obj->area.x0;
     nbgl_frontDrawHorizontalLine(&rectArea,0xF, obj->textColor); // bottom left
     // draw vertical segments (4 pixels stroke)
-    rectArea.x0 = obj->x0;
-    rectArea.y0 = obj->y0+4;
+    rectArea.x0 = obj->area.x0;
+    rectArea.y0 = obj->area.y0+4;
     rectArea.width = 4;
     rectArea.height = 12;
     rectArea.backgroundColor = obj->textColor;
     nbgl_frontDrawRect(&rectArea); // top left
-    rectArea.x0 = obj->x0+obj->width-rectArea.width;
+    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
     nbgl_frontDrawRect(&rectArea); // top right
-    rectArea.y0 = obj->y0+obj->height-rectArea.height-4;
+    rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height-4;
     nbgl_frontDrawRect(&rectArea); //bottom right
-    rectArea.x0 = obj->x0;
+    rectArea.x0 = obj->area.x0;
     nbgl_frontDrawRect(&rectArea); // bottom left
   }
 
@@ -699,18 +699,18 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
   // special case of autoHideLongLine, when the text is too long for a line, draw '...' at the beginning
   if (obj->autoHideLongLine == true) {
     textWidth = nbgl_getSingleLineTextWidth(obj->fontId,text);
-    if (textWidth > obj->width) {
+    if (textWidth > obj->area.width) {
       uint16_t lineWidth,lineLen;
       uint16_t dotsWidth;
 
       // at first draw "..." at beginning
       dotsWidth = nbgl_getTextWidth(obj->fontId,"...");
-      rectArea.x0 = obj->x0;
-      rectArea.y0 = obj->y0 + (obj->height - fontHeight)/2;
+      rectArea.x0 = obj->area.x0;
+      rectArea.y0 = obj->area.y0 + (obj->area.height - fontHeight)/2;
       rectArea.width = dotsWidth;
       nbgl_drawText(&rectArea, "...", 3, obj->fontId, obj->textColor);
       // then draw the end of text
-      nbgl_getTextMaxLenAndWidthFromEnd(obj->fontId,text,obj->width-dotsWidth,&lineLen,&lineWidth);
+      nbgl_getTextMaxLenAndWidthFromEnd(obj->fontId,text,obj->area.width-dotsWidth,&lineLen,&lineWidth);
       rectArea.x0 += dotsWidth;
       rectArea.width = lineWidth;
       nbgl_drawText(&rectArea, &text[nbgl_getTextLength(text)-lineLen], lineLen, obj->fontId, obj->textColor);
@@ -719,7 +719,7 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
   }
 
   // get nb lines in the given width (depending of wrapping)
-  nbLines = nbgl_getTextNbLinesInWidth(obj->fontId,text,obj->width,obj->wrapping);
+  nbLines = nbgl_getTextNbLinesInWidth(obj->fontId,text,obj->area.width,obj->wrapping);
   // saturate nb lines if nbMaxLines is greater than 0
   if ((obj->nbMaxLines > 0) && (obj->nbMaxLines < nbLines)) {
     nbLines = obj->nbMaxLines;
@@ -727,35 +727,35 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
 
   textHeight = (nbLines-1)*lineHeight+fontHeight;
 
-  midHeight = (obj->height - textHeight)/2;
+  midHeight = (obj->area.height - textHeight)/2;
   // Be sure midHeight is modulo 4
   if (midHeight % 4) {
     midHeight -= midHeight % 4;
   }
 
-  rectArea.backgroundColor = obj->backgroundColor;
+  rectArea.backgroundColor = obj->area.backgroundColor;
   rectArea.height = fontHeight;
   // draw each line
   for (line=0;line<nbLines;line++) {
     uint16_t lineWidth,lineLen;
 
-    nbgl_getTextMaxLenAndWidth(obj->fontId,text,obj->width,&lineLen,&lineWidth,obj->wrapping);
+    nbgl_getTextMaxLenAndWidth(obj->fontId,text,obj->area.width,&lineLen,&lineWidth,obj->wrapping);
     if (obj->textAlignment == MID_LEFT) {
-      rectArea.x0 = obj->x0;
+      rectArea.x0 = obj->area.x0;
     }
     else if (obj->textAlignment == CENTER) {
-      rectArea.x0 = obj->x0 + (obj->width - lineWidth)/2;
+      rectArea.x0 = obj->area.x0 + (obj->area.width - lineWidth)/2;
     }
     else if (obj->textAlignment == MID_RIGHT) {
-      rectArea.x0 = obj->x0 + obj->width - lineWidth;
+      rectArea.x0 = obj->area.x0 + obj->area.width - lineWidth;
     }
     else {
       LOG_FATAL(OBJ_LOGGER,"Forbidden obj->textAlignment = %d\n",obj->textAlignment);
     }
-    rectArea.y0 = obj->y0 + midHeight + line*lineHeight;
+    rectArea.y0 = obj->area.y0 + midHeight + line*lineHeight;
     rectArea.width = lineWidth;
 
-    LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), %s line %d, lineLen %d lineWidth = %d, obj->height = %d, textHeight = %d, obj->nbMaxLines = %d\n",text,  line,lineLen, lineWidth,obj->height, textHeight, obj->nbMaxLines);
+    LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), %s line %d, lineLen %d lineWidth = %d, obj->area.height = %d, textHeight = %d, obj->nbMaxLines = %d\n",text,  line,lineLen, lineWidth,obj->area.height, textHeight, obj->nbMaxLines);
     if ((obj->nbMaxLines == 0) || (line < (obj->nbMaxLines-1))) {
       nbgl_drawText(&rectArea, text, lineLen, obj->fontId, obj->textColor);
     }
@@ -794,16 +794,16 @@ static void draw_qrCode(nbgl_qrcode_t* obj, nbgl_obj_t *prevObj, bool computePos
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_qrCode(), x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->x0, obj->y0, obj->width, obj->height, obj->text);
+  LOG_DEBUG(OBJ_LOGGER,"draw_qrCode(), x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->area.x0, obj->area.y0, obj->area.width, obj->area.height, obj->text);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
-  rectArea.x0 = obj->x0;
-  rectArea.y0 = obj->y0;
-  rectArea.width = obj->width;
-  rectArea.height = obj->height;
-  rectArea.backgroundColor = obj->backgroundColor;
+  rectArea.x0 = obj->area.x0;
+  rectArea.y0 = obj->area.y0;
+  rectArea.width = obj->area.width;
+  rectArea.height = obj->area.height;
+  rectArea.backgroundColor = obj->area.backgroundColor;
 #ifdef NBGL_QRCODE
   nbgl_drawQrCode(&rectArea,(obj->version == QRCODE_V4) ? 4:10,obj->text,obj->foregroundColor);
 #endif // NBGL_QRCODE
@@ -818,10 +818,10 @@ static void draw_qrCode(nbgl_qrcode_t* obj, nbgl_obj_t *prevObj, bool computePos
  * @param computePosition if TRUE, force to compute the object position
  */
 static void draw_keyboard(nbgl_keyboard_t* obj, nbgl_obj_t *prevObj, bool computePosition) {
-  obj->width = SCREEN_WIDTH;
-  obj->height = 3*KEYBOARD_KEY_HEIGHT;
+  obj->area.width = SCREEN_WIDTH;
+  obj->area.height = 3*KEYBOARD_KEY_HEIGHT;
   if (!obj->lettersOnly) {
-    obj->height += KEYBOARD_KEY_HEIGHT;
+    obj->area.height += KEYBOARD_KEY_HEIGHT;
   }
 
   if (computePosition) {
@@ -830,10 +830,10 @@ static void draw_keyboard(nbgl_keyboard_t* obj, nbgl_obj_t *prevObj, bool comput
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_keyboard(), x0 = %d, y0 = %d\n", obj->x0, obj->y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_keyboard(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
 #ifdef NBGL_KEYBOARD
   nbgl_objDrawKeyboard(obj);
@@ -849,8 +849,8 @@ static void draw_keyboard(nbgl_keyboard_t* obj, nbgl_obj_t *prevObj, bool comput
  * @param computePosition if TRUE, force to compute the object position
  */
 static void draw_keypad(nbgl_keypad_t* obj, nbgl_obj_t *prevObj, bool computePosition) {
-  obj->width = SCREEN_WIDTH;
-  obj->height = 4*KEYPAD_KEY_HEIGHT;
+  obj->area.width = SCREEN_WIDTH;
+  obj->area.height = 4*KEYPAD_KEY_HEIGHT;
 
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
@@ -858,10 +858,10 @@ static void draw_keypad(nbgl_keypad_t* obj, nbgl_obj_t *prevObj, bool computePos
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_keypad(), x0 = %d, y0 = %d\n", obj->x0, obj->y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_keypad(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
 
 #ifdef NBGL_KEYPAD
   nbgl_objDrawKeypad(obj);
@@ -880,8 +880,8 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
   nbgl_area_t rectArea;
   color_t foreColor;
 
-  obj->width = 60;
-  obj->height = 44;
+  obj->area.width = 60;
+  obj->area.height = 44;
 
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
@@ -889,51 +889,51 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_spinner(), x0 = %d, y0 = %d\n", obj->x0, obj->y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_spinner(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
 
   // inherit background from parent
-  obj->backgroundColor = obj->parent->backgroundColor;
+  obj->area.backgroundColor = obj->parent->area.backgroundColor;
   // foreground color is the opposite of background one
-  foreColor = (obj->backgroundColor == WHITE) ? BLACK : WHITE;
+  foreColor = (obj->area.backgroundColor == WHITE) ? BLACK : WHITE;
 
   rectArea.bpp = NBGL_BPP_1;
-  rectArea.backgroundColor = obj->backgroundColor;
+  rectArea.backgroundColor = obj->area.backgroundColor;
   // if position is OxFF, it means "fixed" so draw 4 corners
   if (obj->position == 0xFF) {
     // draw horizontal segments
-    rectArea.x0 = obj->x0;
-    rectArea.y0 = obj->y0;
+    rectArea.x0 = obj->area.x0;
+    rectArea.y0 = obj->area.y0;
     rectArea.width = 20;
     rectArea.height = 4;
     nbgl_frontDrawHorizontalLine(&rectArea, 0x7, foreColor); // top left
-    rectArea.x0 = obj->x0+obj->width-rectArea.width;
+    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
     nbgl_frontDrawHorizontalLine(&rectArea,0x7, foreColor); // top right
-    rectArea.y0 = obj->y0+obj->height-4;
+    rectArea.y0 = obj->area.y0+obj->area.height-4;
     nbgl_frontDrawHorizontalLine(&rectArea,0xE, foreColor); //bottom right
-    rectArea.x0 = obj->x0;
+    rectArea.x0 = obj->area.x0;
     nbgl_frontDrawHorizontalLine(&rectArea,0xE, foreColor); // bottom left
     // draw vertical segments
-    rectArea.x0 = obj->x0;
-    rectArea.y0 = obj->y0;
+    rectArea.x0 = obj->area.x0;
+    rectArea.y0 = obj->area.y0;
     rectArea.width = 3;
     rectArea.height = 12;
     rectArea.backgroundColor = foreColor;
     nbgl_frontDrawRect(&rectArea); // top left
-    rectArea.x0 = obj->x0+obj->width-rectArea.width;
+    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
     nbgl_frontDrawRect(&rectArea); // top right
-    rectArea.y0 = obj->y0+obj->height-rectArea.height;
+    rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height;
     nbgl_frontDrawRect(&rectArea); //bottom right
-    rectArea.x0 = obj->x0;
+    rectArea.x0 = obj->area.x0;
     nbgl_frontDrawRect(&rectArea); // bottom left
   }
   else {
     uint8_t mask;
     // clean up full rectangle
-    rectArea.x0 = obj->x0;
-    rectArea.y0 = obj->y0;
-    rectArea.width = obj->width;
-    rectArea.height = obj->height;
-    rectArea.backgroundColor = obj->backgroundColor;
+    rectArea.x0 = obj->area.x0;
+    rectArea.y0 = obj->area.y0;
+    rectArea.width = obj->area.width;
+    rectArea.height = obj->area.height;
+    rectArea.backgroundColor = obj->area.backgroundColor;
     nbgl_frontDrawRect(&rectArea); // top left
 
     // draw horizontal segment in foreColor
@@ -941,23 +941,23 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
     rectArea.height = 4;
     switch (obj->position) {
     case 0: // top left corner
-      rectArea.x0 = obj->x0;
-      rectArea.y0 = obj->y0;
+      rectArea.x0 = obj->area.x0;
+      rectArea.y0 = obj->area.y0;
       mask = 0x7;
       break;
     case 1: // top right
-      rectArea.x0 = obj->x0+obj->width-rectArea.width;
-      rectArea.y0 = obj->y0;
+      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+      rectArea.y0 = obj->area.y0;
       mask = 0x7;
       break;
     case 2: //bottom right
-      rectArea.x0 = obj->x0+obj->width-rectArea.width;
-      rectArea.y0 = obj->y0+obj->height-4;
+      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+      rectArea.y0 = obj->area.y0+obj->area.height-4;
       mask = 0xE;
       break;
     case 3: // bottom left
-      rectArea.x0 = obj->x0;
-      rectArea.y0 = obj->y0+obj->height-4;
+      rectArea.x0 = obj->area.x0;
+      rectArea.y0 = obj->area.y0+obj->area.height-4;
       mask = 0xE;
       break;
     default:
@@ -971,20 +971,20 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
     rectArea.backgroundColor = foreColor;
     switch (obj->position) {
     case 0:// top left corner
-      rectArea.x0 = obj->x0;
-      rectArea.y0 = obj->y0;
+      rectArea.x0 = obj->area.x0;
+      rectArea.y0 = obj->area.y0;
       break;
     case 1:// top right corner
-      rectArea.x0 = obj->x0+obj->width-rectArea.width;
-      rectArea.y0 = obj->y0;
+      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+      rectArea.y0 = obj->area.y0;
       break;
     case 2:// bottom right corner
-      rectArea.x0 = obj->x0+obj->width-rectArea.width;
-      rectArea.y0 = obj->y0+obj->height-rectArea.height;
+      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+      rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height;
       break;
     case 3:// bottom left corner
-      rectArea.x0 = obj->x0;
-      rectArea.y0 = obj->y0+obj->height-rectArea.height;
+      rectArea.x0 = obj->area.x0;
+      rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height;
       break;
     default:
       return;
@@ -1011,7 +1011,7 @@ static void draw_image_file(nbgl_image_file_t* obj, nbgl_obj_t *prevObj, bool co
     return;
   }
 
-  LOG_DEBUG(OBJ_LOGGER,"draw_image_file(), x0 = %d, y0 = %d\n", obj->x0, obj->y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_image_file(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
   nbgl_frontDrawImageFile((nbgl_area_t *)obj, (uint8_t*)obj->buffer, 0, ramBuffer);
 }
 
@@ -1100,20 +1100,20 @@ void extendRefreshArea(nbgl_obj_t *obj) {
   y1 = refreshArea.y0+refreshArea.height;
 
   // if obj top-left is on left of current top-left corner, move top-left corner
-  if (obj->x0 < refreshArea.x0) {
-    refreshArea.x0 = obj->x0;
+  if (obj->area.x0 < refreshArea.x0) {
+    refreshArea.x0 = obj->area.x0;
   }
   // if obj bottom-right is on right of current bottom-right corner, move bottom-right corner
-  if (((obj->x0+obj->width) > x1) || (refreshArea.width == 0)) {
-    x1 = obj->x0+obj->width;
+  if (((obj->area.x0+obj->area.width) > x1) || (refreshArea.width == 0)) {
+    x1 = obj->area.x0+obj->area.width;
   }
   // if obj top-left is on top of current top-left corner, move top-left corner
-  if (obj->y0 < refreshArea.y0) {
-    refreshArea.y0 = obj->y0;
+  if (obj->area.y0 < refreshArea.y0) {
+    refreshArea.y0 = obj->area.y0;
   }
   // if obj bottom-right is on bottom of current bottom-right corner, move bottom-right corner
-  if (((obj->y0+obj->height) > y1) || (refreshArea.height == 0)) {
-    y1 = obj->y0+obj->height;
+  if (((obj->area.y0+obj->area.height) > y1) || (refreshArea.height == 0)) {
+    y1 = obj->area.y0+obj->area.height;
   }
 
   // sanity check
@@ -1128,8 +1128,8 @@ void extendRefreshArea(nbgl_obj_t *obj) {
   refreshArea.height = y1 - refreshArea.y0;
 
   // revaluate area bpp
-  if (obj->bpp > refreshArea.bpp) {
-    refreshArea.bpp = obj->bpp;
+  if (obj->area.bpp > refreshArea.bpp) {
+    refreshArea.bpp = obj->area.bpp;
   }
 }
 

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -99,36 +99,36 @@ static void compute_relativePosition(nbgl_obj_t* obj, nbgl_obj_t *prevObj) {
           obj->rel_y0 = obj->alignmentMarginY;
           break;
         case TOP_MIDDLE:
-          obj->rel_x0 = (parent->area.width - obj->area.width)/2 + obj->alignmentMarginX;
+          obj->rel_x0 = (parent->obj.area.width - obj->area.width)/2 + obj->alignmentMarginX;
           obj->rel_y0 = obj->alignmentMarginY;
           break;
         case TOP_RIGHT:
-          obj->rel_x0 = (parent->area.width - obj->area.width) - obj->alignmentMarginX;
+          obj->rel_x0 = (parent->obj.area.width - obj->area.width) - obj->alignmentMarginX;
           obj->rel_y0 = obj->alignmentMarginY;
           break;
         case MID_LEFT:
           obj->rel_x0 = obj->alignmentMarginX;
-          obj->rel_y0 = (parent->area.height - obj->area.height)/2 + obj->alignmentMarginY;
+          obj->rel_y0 = (parent->obj.area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case CENTER:
-          obj->rel_x0 = (parent->area.width - obj->area.width)/2 + obj->alignmentMarginX;
-          obj->rel_y0 = (parent->area.height - obj->area.height)/2 + obj->alignmentMarginY;
+          obj->rel_x0 = (parent->obj.area.width - obj->area.width)/2 + obj->alignmentMarginX;
+          obj->rel_y0 = (parent->obj.area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case MID_RIGHT:
-          obj->rel_x0 = (parent->area.width - obj->area.width) - obj->alignmentMarginX;
-          obj->rel_y0 = (parent->area.height - obj->area.height)/2 + obj->alignmentMarginY;
+          obj->rel_x0 = (parent->obj.area.width - obj->area.width) - obj->alignmentMarginX;
+          obj->rel_y0 = (parent->obj.area.height - obj->area.height)/2 + obj->alignmentMarginY;
           break;
         case BOTTOM_LEFT:
           obj->rel_x0 = obj->alignmentMarginX;
-          obj->rel_y0 = (parent->area.height - obj->area.height) - obj->alignmentMarginY;
+          obj->rel_y0 = (parent->obj.area.height - obj->area.height) - obj->alignmentMarginY;
           break;
         case BOTTOM_MIDDLE:
-          obj->rel_x0 = (parent->area.width - obj->area.width)/2 + obj->alignmentMarginX;
-          obj->rel_y0 = (parent->area.height - obj->area.height) - obj->alignmentMarginY;
+          obj->rel_x0 = (parent->obj.area.width - obj->area.width)/2 + obj->alignmentMarginX;
+          obj->rel_y0 = (parent->obj.area.height - obj->area.height) - obj->alignmentMarginY;
           break;
         case BOTTOM_RIGHT:
-          obj->rel_x0 = (parent->area.width - obj->area.width) - obj->alignmentMarginX;
-          obj->rel_y0 = (parent->area.height - obj->area.height) - obj->alignmentMarginY;
+          obj->rel_x0 = (parent->obj.area.width - obj->area.width) - obj->alignmentMarginX;
+          obj->rel_y0 = (parent->obj.area.height - obj->area.height) - obj->alignmentMarginY;
           break;
         default:
           //not supported
@@ -208,11 +208,11 @@ static void compute_position(nbgl_obj_t* obj, nbgl_obj_t *prevObj) {
     // HUGE issue
     return;
   }
-  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent.type = %d, parent->area.x0 = %d, obj->rel_x0=%d\n",parent->type,parent->area.x0,obj->rel_x0);
-  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent->area.y0 = %d, obj->rel_y0=%d\n",parent->area.y0,obj->rel_y0);
+  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent.type = %d, parent->obj.area.x0 = %d, obj->rel_x0=%d\n",parent->type,parent->obj.area.x0,obj->rel_x0);
+  //LOG_DEBUG(OBJ_LOGGER,"compute_position(), parent->obj.area.y0 = %d, obj->rel_y0=%d\n",parent->obj.area.y0,obj->rel_y0);
 
-  obj->area.x0 = parent->area.x0+obj->rel_x0;
-  obj->area.y0 = parent->area.y0+obj->rel_y0;
+  obj->area.x0 = parent->obj.area.x0+obj->rel_x0;
+  obj->area.y0 = parent->obj.area.y0+obj->rel_y0;
 
   if ((obj->area.x0+obj->area.width)>SCREEN_WIDTH) {
     LOG_FATAL(OBJ_LOGGER,"compute_position(), forbidden width, obj->type = %d, x0=%d, width=%d\n",obj->type,obj->area.x0,obj->area.width);
@@ -228,11 +228,11 @@ static void draw_screen(nbgl_container_t *obj) {
   if (objDrawingDisabled) {
     return;
   }
-  rectArea.backgroundColor = obj->area.backgroundColor;
-  rectArea.x0 = obj->area.x0;
-  rectArea.y0 = obj->area.y0;
-  rectArea.width = obj->area.width;
-  rectArea.height = obj->area.height;
+  rectArea.backgroundColor = obj->obj.area.backgroundColor;
+  rectArea.x0 = obj->obj.area.x0;
+  rectArea.y0 = obj->obj.area.y0;
+  rectArea.width = obj->obj.area.width;
+  rectArea.height = obj->obj.area.height;
   nbgl_frontDrawRect(&rectArea);
 }
 
@@ -243,9 +243,9 @@ static void draw_container(nbgl_container_t* obj, nbgl_obj_t *prevObj, bool comp
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_container(), x0 = %d, y0 = %d, width = %d\n", obj->area.x0, obj->area.y0, obj->area.width);
+  LOG_DEBUG(OBJ_LOGGER,"draw_container(), x0 = %d, y0 = %d, width = %d\n", obj->obj.area.x0, obj->obj.area.y0, obj->obj.area.width);
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
   if (obj->forceClean) {
     nbgl_frontDrawRect((nbgl_area_t*)obj);
   }
@@ -269,10 +269,10 @@ static void draw_button(nbgl_button_t* obj, nbgl_obj_t *prevObj, bool computePos
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_button(), x0 = %d, y0 = %d, width = %d, height = %d\n", obj->area.x0, obj->area.y0, obj->area.width, obj->area.height);
+  LOG_DEBUG(OBJ_LOGGER,"draw_button(), x0 = %d, y0 = %d, width = %d, height = %d\n", obj->obj.area.x0, obj->obj.area.y0, obj->obj.area.width, obj->obj.area.height);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
   // draw the rounded corner rectangle
   if (obj->innerColor == obj->borderColor) {
     nbgl_drawRoundedRect((nbgl_area_t*)obj,
@@ -301,13 +301,13 @@ static void draw_button(nbgl_button_t* obj, nbgl_obj_t *prevObj, bool computePos
     nbgl_area_t rectArea;
     textWidth = nbgl_getTextWidth(obj->fontId, text);
     if (obj->icon != NULL) {
-      rectArea.x0 = obj->area.x0 + obj->area.width/2  - (textWidth+obj->icon->width+8)/2 + obj->icon->width + 8;
+      rectArea.x0 = obj->obj.area.x0 + obj->obj.area.width/2  - (textWidth+obj->icon->width+8)/2 + obj->icon->width + 8;
     }
     else {
-      rectArea.x0 = obj->area.x0 + (obj->area.width - textWidth)/2;
+      rectArea.x0 = obj->obj.area.x0 + (obj->obj.area.width - textWidth)/2;
     }
     LOG_DEBUG(OBJ_LOGGER,"draw_button(), text = %s\n", text);
-    rectArea.y0 = obj->area.y0 + (obj->area.height - nbgl_getFontHeight(obj->fontId))/2;
+    rectArea.y0 = obj->obj.area.y0 + (obj->obj.area.height - nbgl_getFontHeight(obj->fontId))/2;
     rectArea.width = textWidth;
     rectArea.height = nbgl_getFontHeight(obj->fontId);
     rectArea.backgroundColor = obj->innerColor;
@@ -319,13 +319,13 @@ static void draw_button(nbgl_button_t* obj, nbgl_obj_t *prevObj, bool computePos
     nbgl_area_t rectArea;
 
     if (text != NULL) {
-      iconX0 = obj->area.x0 + (obj->area.width - (textWidth+obj->icon->width+8))/2;
+      iconX0 = obj->obj.area.x0 + (obj->obj.area.width - (textWidth+obj->icon->width+8))/2;
     }
     else {
-      iconX0 = obj->area.x0 + (obj->area.width- obj->icon->width)/2;
+      iconX0 = obj->obj.area.x0 + (obj->obj.area.width- obj->icon->width)/2;
     }
-    LOG_DEBUG(OBJ_LOGGER,"draw_button(), obj->area.height = %d, obj->iconHeight = %d\n", obj->area.height , obj->icon->height);
-    iconY0 = obj->area.y0 + (obj->area.height - obj->icon->height)/2;
+    LOG_DEBUG(OBJ_LOGGER,"draw_button(), obj->obj.area.height = %d, obj->iconHeight = %d\n", obj->obj.area.height , obj->icon->height);
+    iconY0 = obj->obj.area.y0 + (obj->obj.area.height - obj->icon->height)/2;
 
     rectArea.backgroundColor = obj->innerColor;
     rectArea.x0 = iconX0;
@@ -352,16 +352,16 @@ static void draw_line(nbgl_line_t* obj, nbgl_obj_t *prevObj, bool computePositio
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_line(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_line(), x0 = %d, y0 = %d\n", obj->obj.area.x0, obj->obj.area.y0);
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
-  LOG_DEBUG(OBJ_LOGGER,"draw_line(), backgroundColor = %d, lineColor = %d\n", obj->area.backgroundColor,obj->lineColor);
-  rectArea.x0 = obj->area.x0;
-  rectArea.y0 = obj->area.y0;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
+  LOG_DEBUG(OBJ_LOGGER,"draw_line(), backgroundColor = %d, lineColor = %d\n", obj->obj.area.backgroundColor,obj->lineColor);
+  rectArea.x0 = obj->obj.area.x0;
+  rectArea.y0 = obj->obj.area.y0;
   if (obj->direction == VERTICAL) {
-    rectArea.width = obj->area.width = obj->thickness;
+    rectArea.width = obj->obj.area.width = obj->thickness;
     rectArea.backgroundColor = obj->lineColor;
-    rectArea.height = obj->area.height;
+    rectArea.height = obj->obj.area.height;
     nbgl_frontDrawRect(&rectArea);
   }
   else {
@@ -382,9 +382,9 @@ static void draw_line(nbgl_line_t* obj, nbgl_obj_t *prevObj, bool computePositio
       LOG_WARN(OBJ_LOGGER,"draw_line(), forbidden thickness = %d\n", obj->thickness);
       return;
     }
-    rectArea.width = obj->area.width;
-    rectArea.height = obj->area.height = 4;
-    rectArea.backgroundColor = obj->area.backgroundColor;
+    rectArea.width = obj->obj.area.width;
+    rectArea.height = obj->obj.area.height = 4;
+    rectArea.backgroundColor = obj->obj.area.backgroundColor;
     nbgl_frontDrawHorizontalLine(&rectArea,mask,obj->lineColor);
   }
 }
@@ -407,22 +407,22 @@ static void draw_image(nbgl_image_t* obj, nbgl_obj_t *prevObj, bool computePosit
   }
 
   // use dimension and bpp from the icon details
-  obj->area.width = iconDetails->width;
-  obj->area.height = iconDetails->height;
-  obj->area.bpp = iconDetails->bpp;
+  obj->obj.area.width = iconDetails->width;
+  obj->obj.area.height = iconDetails->height;
+  obj->obj.area.bpp = iconDetails->bpp;
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
   }
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_image(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_image(), x0 = %d, y0 = %d\n", obj->obj.area.x0, obj->obj.area.y0);
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
-  if (obj->area.bpp == NBGL_BPP_1) {
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
+  if (obj->obj.area.bpp == NBGL_BPP_1) {
     colorMap = obj->foregroundColor;
   }
-  else if (obj->area.bpp == NBGL_BPP_2) {
+  else if (obj->obj.area.bpp == NBGL_BPP_2) {
     colorMap = ((WHITE<<6)|(LIGHT_GRAY<<4)|(DARK_GRAY<<2)|BLACK);
   }
   else {
@@ -440,24 +440,24 @@ static void draw_switch(nbgl_switch_t* obj, nbgl_obj_t *prevObj, bool computePos
   nbgl_area_t rectArea;
 
   // force dimensions
-  obj->area.width = C_switch_60_40.width;
-  obj->area.height = C_switch_60_40.height;
+  obj->obj.area.width = C_switch_60_40.width;
+  obj->obj.area.height = C_switch_60_40.height;
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
   }
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_switch(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_switch(), x0 = %d, y0 = %d\n", obj->obj.area.x0, obj->obj.area.y0);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
-  rectArea.x0 = obj->area.x0;
-  rectArea.y0 = obj->area.y0;
-  rectArea.width = obj->area.width;
-  rectArea.height = obj->area.height;
-  rectArea.backgroundColor = obj->area.backgroundColor;
+  rectArea.x0 = obj->obj.area.x0;
+  rectArea.y0 = obj->obj.area.y0;
+  rectArea.width = obj->obj.area.width;
+  rectArea.height = obj->obj.area.height;
+  rectArea.backgroundColor = obj->obj.area.backgroundColor;
   rectArea.bpp = NBGL_BPP_1;
   if (obj->state == OFF_STATE) {
     nbgl_frontDrawImage(&rectArea,(uint8_t*)C_switch_60_40.bitmap,NO_TRANSFORMATION,obj->offColor);
@@ -472,24 +472,24 @@ static void draw_radioButton(nbgl_radio_t* obj, nbgl_obj_t *prevObj, bool comput
   nbgl_area_t rectArea;
 
   // force dimensions
-  obj->area.width = 32;
-  obj->area.height = 32;
+  obj->obj.area.width = 32;
+  obj->obj.area.height = 32;
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
   }
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_radioButton(), x0 = %d, y0 = %d, state = %d\n", obj->area.x0, obj->area.y0, obj->state);
+  LOG_DEBUG(OBJ_LOGGER,"draw_radioButton(), x0 = %d, y0 = %d, state = %d\n", obj->obj.area.x0, obj->obj.area.y0, obj->state);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
-  rectArea.x0 = obj->area.x0;
-  rectArea.y0 = obj->area.y0;
-  rectArea.width = obj->area.width;
-  rectArea.height = obj->area.height;
-  rectArea.backgroundColor = obj->area.backgroundColor;
+  rectArea.x0 = obj->obj.area.x0;
+  rectArea.y0 = obj->obj.area.y0;
+  rectArea.width = obj->obj.area.width;
+  rectArea.height = obj->obj.area.height;
+  rectArea.backgroundColor = obj->obj.area.backgroundColor;
   rectArea.bpp = NBGL_BPP_1;
   if (obj->state == OFF_STATE) {
     nbgl_frontDrawImage(&rectArea,(uint8_t*)C_radio_inactive_32px.bitmap,NO_TRANSFORMATION,obj->borderColor);
@@ -516,27 +516,27 @@ static void draw_progressBar(nbgl_progress_bar_t* obj, nbgl_obj_t *prevObj, bool
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_progressBar(), x0 = %d, y0 = %d, level = %d %%\n", obj->area.x0, obj->area.y0, obj->state);
+  LOG_DEBUG(OBJ_LOGGER,"draw_progressBar(), x0 = %d, y0 = %d, level = %d %%\n", obj->obj.area.x0, obj->obj.area.y0, obj->state);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
   // draw external part if necessary
   if (obj->withBorder) {
     nbgl_drawRoundedBorderedRect((nbgl_area_t*)obj,
-                                RADIUS_0_PIXELS, stroke, obj->area.backgroundColor, obj->foregroundColor);
+                                RADIUS_0_PIXELS, stroke, obj->obj.area.backgroundColor, obj->foregroundColor);
   } else {
     nbgl_drawRoundedRect((nbgl_area_t*)obj,
-                              RADIUS_0_PIXELS, obj->area.backgroundColor);
+                              RADIUS_0_PIXELS, obj->obj.area.backgroundColor);
   }
   // draw level
-  levelWidth = MIN(obj->area.width * obj->state / 100, obj->area.width);
+  levelWidth = MIN(obj->obj.area.width * obj->state / 100, obj->obj.area.width);
   if (levelWidth > 0) {
-    uint16_t tmp_width = obj->area.width;
-    obj->area.width = levelWidth;
+    uint16_t tmp_width = obj->obj.area.width;
+    obj->obj.area.width = levelWidth;
     nbgl_drawRoundedRect((nbgl_area_t*)obj,
                                RADIUS_0_PIXELS, obj->foregroundColor);
-    obj->area.width = tmp_width;
+    obj->obj.area.width = tmp_width;
   }
 }
 
@@ -556,7 +556,7 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
     uint8_t i;
 #define INTER_DASHES 10 // pixels
     // force height
-    obj->area.height = 4;
+    obj->obj.area.height = 4;
 
     if (computePosition) {
       compute_position((nbgl_obj_t *)obj,prevObj);
@@ -564,17 +564,17 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
     if (objDrawingDisabled) {
       return;
     }
-    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->area.x0, obj->area.y0, obj->activePage, obj->nbPages);
+    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->obj.area.x0, obj->obj.area.y0, obj->activePage, obj->nbPages);
 
     // inherit background from parent
-    obj->area.backgroundColor = obj->parent->area.backgroundColor;
+    obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
-    dashWidth = (obj->area.width - ((obj->nbPages-1) * INTER_DASHES))/obj->nbPages;
-    rectArea.x0 = obj->area.x0;
-    rectArea.y0 = obj->area.y0;
+    dashWidth = (obj->obj.area.width - ((obj->nbPages-1) * INTER_DASHES))/obj->nbPages;
+    rectArea.x0 = obj->obj.area.x0;
+    rectArea.y0 = obj->obj.area.y0;
     rectArea.width = dashWidth;
-    rectArea.height = obj->area.height;
-    rectArea.backgroundColor = obj->area.backgroundColor;
+    rectArea.height = obj->obj.area.height;
+    rectArea.backgroundColor = obj->obj.area.backgroundColor;
     rectArea.bpp = NBGL_BPP_1;
     // draw dashes
     for (i=0;i<=obj->activePage;i++) {
@@ -591,9 +591,9 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
 
     SPRINTF(navText,"%d of %d", obj->activePage+1, obj->nbPages);
     // force height
-    obj->area.height = nbgl_getFontHeight(BAGL_FONT_INTER_REGULAR_24px);
+    obj->obj.area.height = nbgl_getFontHeight(BAGL_FONT_INTER_REGULAR_24px);
     // the width must be at least 80
-    obj->area.width = nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px,navText);
+    obj->obj.area.width = nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px,navText);
 
     if (computePosition) {
       compute_position((nbgl_obj_t *)obj,prevObj);
@@ -601,17 +601,17 @@ static void draw_pageIndicator(nbgl_page_indicator_t* obj, nbgl_obj_t *prevObj, 
     if (objDrawingDisabled) {
       return;
     }
-    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->area.x0, obj->area.y0, obj->activePage, obj->nbPages);
+    LOG_DEBUG(OBJ_LOGGER,"draw_pageIndicator(), x0 = %d, y0 = %d, page = %d/%d\n", obj->obj.area.x0, obj->obj.area.y0, obj->activePage, obj->nbPages);
 
     // inherit background from parent
-    obj->area.backgroundColor = obj->parent->area.backgroundColor;
+    obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
     // draw active page
-    rectArea.x0 = obj->area.x0;
-    rectArea.y0 = obj->area.y0;
-    rectArea.width = obj->area.width;
-    rectArea.height = obj->area.height;
-    rectArea.backgroundColor = obj->area.backgroundColor;
+    rectArea.x0 = obj->obj.area.x0;
+    rectArea.y0 = obj->obj.area.y0;
+    rectArea.width = obj->obj.area.width;
+    rectArea.height = obj->obj.area.height;
+    rectArea.backgroundColor = obj->obj.area.backgroundColor;
     rectArea.bpp = NBGL_BPP_1;
     nbgl_drawText(&rectArea, navText, 9, BAGL_FONT_INTER_REGULAR_24px, DARK_GRAY);
   }
@@ -653,44 +653,44 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
     return;
   }
 
-  LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), wrapping = %d, x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->wrapping, obj->area.x0, obj->area.y0, obj->area.width, obj->area.height, text);
+  LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), wrapping = %d, x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->wrapping, obj->obj.area.x0, obj->obj.area.y0, obj->obj.area.width, obj->obj.area.height, text);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
   // draw background to make sure it's clean
-  rectArea.x0 = obj->area.x0;
-  rectArea.y0 = obj->area.y0;
-  rectArea.width = obj->area.width;
-  rectArea.height = obj->area.height;
-  rectArea.backgroundColor = obj->area.backgroundColor;
+  rectArea.x0 = obj->obj.area.x0;
+  rectArea.y0 = obj->obj.area.y0;
+  rectArea.width = obj->obj.area.width;
+  rectArea.height = obj->obj.area.height;
+  rectArea.backgroundColor = obj->obj.area.backgroundColor;
   nbgl_frontDrawRect(&rectArea);
   // draw border with given style
   if (obj->style == LEDGER_BORDER) {
     // draw horizontal segments (4 pixels stroke)
-    rectArea.x0 = obj->area.x0;
-    rectArea.y0 = obj->area.y0;
+    rectArea.x0 = obj->obj.area.x0;
+    rectArea.y0 = obj->obj.area.y0;
     rectArea.width = 24;
     rectArea.height = 4;
     nbgl_frontDrawHorizontalLine(&rectArea, 0xF, obj->textColor); // top left
-    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+    rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
     nbgl_frontDrawHorizontalLine(&rectArea,0xF, obj->textColor); // top right
-    rectArea.y0 = obj->area.y0+obj->area.height-4;
+    rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-4;
     nbgl_frontDrawHorizontalLine(&rectArea,0xF, obj->textColor); //bottom right
-    rectArea.x0 = obj->area.x0;
+    rectArea.x0 = obj->obj.area.x0;
     nbgl_frontDrawHorizontalLine(&rectArea,0xF, obj->textColor); // bottom left
     // draw vertical segments (4 pixels stroke)
-    rectArea.x0 = obj->area.x0;
-    rectArea.y0 = obj->area.y0+4;
+    rectArea.x0 = obj->obj.area.x0;
+    rectArea.y0 = obj->obj.area.y0+4;
     rectArea.width = 4;
     rectArea.height = 12;
     rectArea.backgroundColor = obj->textColor;
     nbgl_frontDrawRect(&rectArea); // top left
-    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+    rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
     nbgl_frontDrawRect(&rectArea); // top right
-    rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height-4;
+    rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-rectArea.height-4;
     nbgl_frontDrawRect(&rectArea); //bottom right
-    rectArea.x0 = obj->area.x0;
+    rectArea.x0 = obj->obj.area.x0;
     nbgl_frontDrawRect(&rectArea); // bottom left
   }
 
@@ -699,18 +699,18 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
   // special case of autoHideLongLine, when the text is too long for a line, draw '...' at the beginning
   if (obj->autoHideLongLine == true) {
     textWidth = nbgl_getSingleLineTextWidth(obj->fontId,text);
-    if (textWidth > obj->area.width) {
+    if (textWidth > obj->obj.area.width) {
       uint16_t lineWidth,lineLen;
       uint16_t dotsWidth;
 
       // at first draw "..." at beginning
       dotsWidth = nbgl_getTextWidth(obj->fontId,"...");
-      rectArea.x0 = obj->area.x0;
-      rectArea.y0 = obj->area.y0 + (obj->area.height - fontHeight)/2;
+      rectArea.x0 = obj->obj.area.x0;
+      rectArea.y0 = obj->obj.area.y0 + (obj->obj.area.height - fontHeight)/2;
       rectArea.width = dotsWidth;
       nbgl_drawText(&rectArea, "...", 3, obj->fontId, obj->textColor);
       // then draw the end of text
-      nbgl_getTextMaxLenAndWidthFromEnd(obj->fontId,text,obj->area.width-dotsWidth,&lineLen,&lineWidth);
+      nbgl_getTextMaxLenAndWidthFromEnd(obj->fontId,text,obj->obj.area.width-dotsWidth,&lineLen,&lineWidth);
       rectArea.x0 += dotsWidth;
       rectArea.width = lineWidth;
       nbgl_drawText(&rectArea, &text[nbgl_getTextLength(text)-lineLen], lineLen, obj->fontId, obj->textColor);
@@ -719,7 +719,7 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
   }
 
   // get nb lines in the given width (depending of wrapping)
-  nbLines = nbgl_getTextNbLinesInWidth(obj->fontId,text,obj->area.width,obj->wrapping);
+  nbLines = nbgl_getTextNbLinesInWidth(obj->fontId,text,obj->obj.area.width,obj->wrapping);
   // saturate nb lines if nbMaxLines is greater than 0
   if ((obj->nbMaxLines > 0) && (obj->nbMaxLines < nbLines)) {
     nbLines = obj->nbMaxLines;
@@ -727,35 +727,35 @@ static void draw_textArea(nbgl_text_area_t* obj, nbgl_obj_t *prevObj, bool compu
 
   textHeight = (nbLines-1)*lineHeight+fontHeight;
 
-  midHeight = (obj->area.height - textHeight)/2;
+  midHeight = (obj->obj.area.height - textHeight)/2;
   // Be sure midHeight is modulo 4
   if (midHeight % 4) {
     midHeight -= midHeight % 4;
   }
 
-  rectArea.backgroundColor = obj->area.backgroundColor;
+  rectArea.backgroundColor = obj->obj.area.backgroundColor;
   rectArea.height = fontHeight;
   // draw each line
   for (line=0;line<nbLines;line++) {
     uint16_t lineWidth,lineLen;
 
-    nbgl_getTextMaxLenAndWidth(obj->fontId,text,obj->area.width,&lineLen,&lineWidth,obj->wrapping);
+    nbgl_getTextMaxLenAndWidth(obj->fontId,text,obj->obj.area.width,&lineLen,&lineWidth,obj->wrapping);
     if (obj->textAlignment == MID_LEFT) {
-      rectArea.x0 = obj->area.x0;
+      rectArea.x0 = obj->obj.area.x0;
     }
     else if (obj->textAlignment == CENTER) {
-      rectArea.x0 = obj->area.x0 + (obj->area.width - lineWidth)/2;
+      rectArea.x0 = obj->obj.area.x0 + (obj->obj.area.width - lineWidth)/2;
     }
     else if (obj->textAlignment == MID_RIGHT) {
-      rectArea.x0 = obj->area.x0 + obj->area.width - lineWidth;
+      rectArea.x0 = obj->obj.area.x0 + obj->obj.area.width - lineWidth;
     }
     else {
       LOG_FATAL(OBJ_LOGGER,"Forbidden obj->textAlignment = %d\n",obj->textAlignment);
     }
-    rectArea.y0 = obj->area.y0 + midHeight + line*lineHeight;
+    rectArea.y0 = obj->obj.area.y0 + midHeight + line*lineHeight;
     rectArea.width = lineWidth;
 
-    LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), %s line %d, lineLen %d lineWidth = %d, obj->area.height = %d, textHeight = %d, obj->nbMaxLines = %d\n",text,  line,lineLen, lineWidth,obj->area.height, textHeight, obj->nbMaxLines);
+    LOG_DEBUG(OBJ_LOGGER,"draw_textArea(), %s line %d, lineLen %d lineWidth = %d, obj->obj.area.height = %d, textHeight = %d, obj->nbMaxLines = %d\n",text,  line,lineLen, lineWidth,obj->obj.area.height, textHeight, obj->nbMaxLines);
     if ((obj->nbMaxLines == 0) || (line < (obj->nbMaxLines-1))) {
       nbgl_drawText(&rectArea, text, lineLen, obj->fontId, obj->textColor);
     }
@@ -794,16 +794,16 @@ static void draw_qrCode(nbgl_qrcode_t* obj, nbgl_obj_t *prevObj, bool computePos
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_qrCode(), x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->area.x0, obj->area.y0, obj->area.width, obj->area.height, obj->text);
+  LOG_DEBUG(OBJ_LOGGER,"draw_qrCode(), x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n", obj->obj.area.x0, obj->obj.area.y0, obj->obj.area.width, obj->obj.area.height, obj->text);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
-  rectArea.x0 = obj->area.x0;
-  rectArea.y0 = obj->area.y0;
-  rectArea.width = obj->area.width;
-  rectArea.height = obj->area.height;
-  rectArea.backgroundColor = obj->area.backgroundColor;
+  rectArea.x0 = obj->obj.area.x0;
+  rectArea.y0 = obj->obj.area.y0;
+  rectArea.width = obj->obj.area.width;
+  rectArea.height = obj->obj.area.height;
+  rectArea.backgroundColor = obj->obj.area.backgroundColor;
 #ifdef NBGL_QRCODE
   nbgl_drawQrCode(&rectArea,(obj->version == QRCODE_V4) ? 4:10,obj->text,obj->foregroundColor);
 #endif // NBGL_QRCODE
@@ -818,10 +818,10 @@ static void draw_qrCode(nbgl_qrcode_t* obj, nbgl_obj_t *prevObj, bool computePos
  * @param computePosition if TRUE, force to compute the object position
  */
 static void draw_keyboard(nbgl_keyboard_t* obj, nbgl_obj_t *prevObj, bool computePosition) {
-  obj->area.width = SCREEN_WIDTH;
-  obj->area.height = 3*KEYBOARD_KEY_HEIGHT;
+  obj->obj.area.width = SCREEN_WIDTH;
+  obj->obj.area.height = 3*KEYBOARD_KEY_HEIGHT;
   if (!obj->lettersOnly) {
-    obj->area.height += KEYBOARD_KEY_HEIGHT;
+    obj->obj.area.height += KEYBOARD_KEY_HEIGHT;
   }
 
   if (computePosition) {
@@ -830,10 +830,10 @@ static void draw_keyboard(nbgl_keyboard_t* obj, nbgl_obj_t *prevObj, bool comput
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_keyboard(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_keyboard(), x0 = %d, y0 = %d\n", obj->obj.area.x0, obj->obj.area.y0);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
 #ifdef NBGL_KEYBOARD
   nbgl_objDrawKeyboard(obj);
@@ -849,8 +849,8 @@ static void draw_keyboard(nbgl_keyboard_t* obj, nbgl_obj_t *prevObj, bool comput
  * @param computePosition if TRUE, force to compute the object position
  */
 static void draw_keypad(nbgl_keypad_t* obj, nbgl_obj_t *prevObj, bool computePosition) {
-  obj->area.width = SCREEN_WIDTH;
-  obj->area.height = 4*KEYPAD_KEY_HEIGHT;
+  obj->obj.area.width = SCREEN_WIDTH;
+  obj->obj.area.height = 4*KEYPAD_KEY_HEIGHT;
 
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
@@ -858,10 +858,10 @@ static void draw_keypad(nbgl_keypad_t* obj, nbgl_obj_t *prevObj, bool computePos
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_keypad(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_keypad(), x0 = %d, y0 = %d\n", obj->obj.area.x0, obj->obj.area.y0);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
 
 #ifdef NBGL_KEYPAD
   nbgl_objDrawKeypad(obj);
@@ -880,8 +880,8 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
   nbgl_area_t rectArea;
   color_t foreColor;
 
-  obj->area.width = 60;
-  obj->area.height = 44;
+  obj->obj.area.width = 60;
+  obj->obj.area.height = 44;
 
   if (computePosition) {
     compute_position((nbgl_obj_t *)obj,prevObj);
@@ -889,51 +889,51 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
   if (objDrawingDisabled) {
     return;
   }
-  LOG_DEBUG(OBJ_LOGGER,"draw_spinner(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_spinner(), x0 = %d, y0 = %d\n", obj->obj.area.x0, obj->obj.area.y0);
 
   // inherit background from parent
-  obj->area.backgroundColor = obj->parent->area.backgroundColor;
+  obj->obj.area.backgroundColor = obj->obj.parent->area.backgroundColor;
   // foreground color is the opposite of background one
-  foreColor = (obj->area.backgroundColor == WHITE) ? BLACK : WHITE;
+  foreColor = (obj->obj.area.backgroundColor == WHITE) ? BLACK : WHITE;
 
   rectArea.bpp = NBGL_BPP_1;
-  rectArea.backgroundColor = obj->area.backgroundColor;
+  rectArea.backgroundColor = obj->obj.area.backgroundColor;
   // if position is OxFF, it means "fixed" so draw 4 corners
   if (obj->position == 0xFF) {
     // draw horizontal segments
-    rectArea.x0 = obj->area.x0;
-    rectArea.y0 = obj->area.y0;
+    rectArea.x0 = obj->obj.area.x0;
+    rectArea.y0 = obj->obj.area.y0;
     rectArea.width = 20;
     rectArea.height = 4;
     nbgl_frontDrawHorizontalLine(&rectArea, 0x7, foreColor); // top left
-    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+    rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
     nbgl_frontDrawHorizontalLine(&rectArea,0x7, foreColor); // top right
-    rectArea.y0 = obj->area.y0+obj->area.height-4;
+    rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-4;
     nbgl_frontDrawHorizontalLine(&rectArea,0xE, foreColor); //bottom right
-    rectArea.x0 = obj->area.x0;
+    rectArea.x0 = obj->obj.area.x0;
     nbgl_frontDrawHorizontalLine(&rectArea,0xE, foreColor); // bottom left
     // draw vertical segments
-    rectArea.x0 = obj->area.x0;
-    rectArea.y0 = obj->area.y0;
+    rectArea.x0 = obj->obj.area.x0;
+    rectArea.y0 = obj->obj.area.y0;
     rectArea.width = 3;
     rectArea.height = 12;
     rectArea.backgroundColor = foreColor;
     nbgl_frontDrawRect(&rectArea); // top left
-    rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
+    rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
     nbgl_frontDrawRect(&rectArea); // top right
-    rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height;
+    rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-rectArea.height;
     nbgl_frontDrawRect(&rectArea); //bottom right
-    rectArea.x0 = obj->area.x0;
+    rectArea.x0 = obj->obj.area.x0;
     nbgl_frontDrawRect(&rectArea); // bottom left
   }
   else {
     uint8_t mask;
     // clean up full rectangle
-    rectArea.x0 = obj->area.x0;
-    rectArea.y0 = obj->area.y0;
-    rectArea.width = obj->area.width;
-    rectArea.height = obj->area.height;
-    rectArea.backgroundColor = obj->area.backgroundColor;
+    rectArea.x0 = obj->obj.area.x0;
+    rectArea.y0 = obj->obj.area.y0;
+    rectArea.width = obj->obj.area.width;
+    rectArea.height = obj->obj.area.height;
+    rectArea.backgroundColor = obj->obj.area.backgroundColor;
     nbgl_frontDrawRect(&rectArea); // top left
 
     // draw horizontal segment in foreColor
@@ -941,23 +941,23 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
     rectArea.height = 4;
     switch (obj->position) {
     case 0: // top left corner
-      rectArea.x0 = obj->area.x0;
-      rectArea.y0 = obj->area.y0;
+      rectArea.x0 = obj->obj.area.x0;
+      rectArea.y0 = obj->obj.area.y0;
       mask = 0x7;
       break;
     case 1: // top right
-      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
-      rectArea.y0 = obj->area.y0;
+      rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
+      rectArea.y0 = obj->obj.area.y0;
       mask = 0x7;
       break;
     case 2: //bottom right
-      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
-      rectArea.y0 = obj->area.y0+obj->area.height-4;
+      rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
+      rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-4;
       mask = 0xE;
       break;
     case 3: // bottom left
-      rectArea.x0 = obj->area.x0;
-      rectArea.y0 = obj->area.y0+obj->area.height-4;
+      rectArea.x0 = obj->obj.area.x0;
+      rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-4;
       mask = 0xE;
       break;
     default:
@@ -971,20 +971,20 @@ static void draw_spinner(nbgl_spinner_t* obj, nbgl_obj_t *prevObj, bool computeP
     rectArea.backgroundColor = foreColor;
     switch (obj->position) {
     case 0:// top left corner
-      rectArea.x0 = obj->area.x0;
-      rectArea.y0 = obj->area.y0;
+      rectArea.x0 = obj->obj.area.x0;
+      rectArea.y0 = obj->obj.area.y0;
       break;
     case 1:// top right corner
-      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
-      rectArea.y0 = obj->area.y0;
+      rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
+      rectArea.y0 = obj->obj.area.y0;
       break;
     case 2:// bottom right corner
-      rectArea.x0 = obj->area.x0+obj->area.width-rectArea.width;
-      rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height;
+      rectArea.x0 = obj->obj.area.x0+obj->obj.area.width-rectArea.width;
+      rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-rectArea.height;
       break;
     case 3:// bottom left corner
-      rectArea.x0 = obj->area.x0;
-      rectArea.y0 = obj->area.y0+obj->area.height-rectArea.height;
+      rectArea.x0 = obj->obj.area.x0;
+      rectArea.y0 = obj->obj.area.y0+obj->obj.area.height-rectArea.height;
       break;
     default:
       return;
@@ -1011,7 +1011,7 @@ static void draw_image_file(nbgl_image_file_t* obj, nbgl_obj_t *prevObj, bool co
     return;
   }
 
-  LOG_DEBUG(OBJ_LOGGER,"draw_image_file(), x0 = %d, y0 = %d\n", obj->area.x0, obj->area.y0);
+  LOG_DEBUG(OBJ_LOGGER,"draw_image_file(), x0 = %d, y0 = %d\n", obj->obj.area.x0, obj->obj.area.y0);
   nbgl_frontDrawImageFile((nbgl_area_t *)obj, (uint8_t*)obj->buffer, 0, ramBuffer);
 }
 

--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -133,18 +133,18 @@ static void keyboardDrawCommonLines(nbgl_keyboard_t *keyboard) {
   nbgl_area_t rectArea;
 
   // clean full area
-  rectArea.backgroundColor = keyboard->area.backgroundColor;
-  rectArea.x0 = keyboard->area.x0;
-  rectArea.y0 = keyboard->area.y0;
-  rectArea.width = keyboard->area.width;
-  rectArea.height = keyboard->area.height;
+  rectArea.backgroundColor = keyboard->obj.area.backgroundColor;
+  rectArea.x0 = keyboard->obj.area.x0;
+  rectArea.y0 = keyboard->obj.area.y0;
+  rectArea.width = keyboard->obj.area.width;
+  rectArea.height = keyboard->obj.area.height;
   nbgl_frontDrawRect(&rectArea);
 
   /// draw horizontal lines
-  rectArea.backgroundColor = keyboard->area.backgroundColor;
-  rectArea.x0 = keyboard->area.x0;
-  rectArea.y0 = keyboard->area.y0;
-  rectArea.width = keyboard->area.width;
+  rectArea.backgroundColor = keyboard->obj.area.backgroundColor;
+  rectArea.x0 = keyboard->obj.area.x0;
+  rectArea.y0 = keyboard->obj.area.y0;
+  rectArea.width = keyboard->obj.area.width;
   rectArea.height = 4;
   nbgl_frontDrawHorizontalLine(&rectArea, 0x1, keyboard->borderColor); // 1st line (top)
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
@@ -159,8 +159,8 @@ static void keyboardDrawCommonLines(nbgl_keyboard_t *keyboard) {
   }
   /// then draw vertical lines
   rectArea.backgroundColor = keyboard->borderColor;
-  rectArea.x0 = keyboard->area.x0;
-  rectArea.y0 = keyboard->area.y0;
+  rectArea.x0 = keyboard->obj.area.x0;
+  rectArea.y0 = keyboard->obj.area.y0;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT*3;
   if (!keyboard->lettersOnly)
@@ -179,8 +179,8 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
 
   // then all vertical lines separating keys
   rectArea.backgroundColor = keyboard->borderColor;
-  rectArea.x0 = keyboard->area.x0;
-  rectArea.y0 = keyboard->area.y0;
+  rectArea.x0 = keyboard->obj.area.x0;
+  rectArea.y0 = keyboard->obj.area.y0;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT;
   // First row of keys: 10 letters (qwertyuiop)
@@ -190,7 +190,7 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
   }
 
   // Second row: 9 letters (asdfghjkl)
-  rectArea.x0 = keyboard->area.x0+SECOND_LINE_OFFSET;
+  rectArea.x0 = keyboard->obj.area.x0+SECOND_LINE_OFFSET;
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   nbgl_frontDrawRect(&rectArea);
   for (i=10;i<19;i++) {
@@ -201,7 +201,7 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
   // Third row: 7 letters (zxcvbnm) and backspace in letters only mode
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   if (!keyboard->lettersOnly) {
-    rectArea.x0 = keyboard->area.x0+SHIFT_KEY_WIDTH;
+    rectArea.x0 = keyboard->obj.area.x0+SHIFT_KEY_WIDTH;
   }
   else {
     rectArea.x0 = NORMAL_KEY_WIDTH;
@@ -219,7 +219,7 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
   // 4th row, only in Full mode
   if (!keyboard->lettersOnly) {
     rectArea.y0 += KEYBOARD_KEY_HEIGHT;
-    rectArea.x0 = keyboard->area.x0+SWITCH_KEY_WIDTH;
+    rectArea.x0 = keyboard->obj.area.x0+SWITCH_KEY_WIDTH;
     nbgl_frontDrawRect(&rectArea);
   }
 }
@@ -234,8 +234,8 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
 
   // then all vertical lines separating keys
   rectArea.backgroundColor = keyboard->borderColor;
-  rectArea.x0 = keyboard->area.x0;
-  rectArea.y0 = keyboard->area.y0;
+  rectArea.x0 = keyboard->obj.area.x0;
+  rectArea.y0 = keyboard->obj.area.y0;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT;
   // First row of keys: 10 keys so 9 separations
@@ -245,7 +245,7 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
   }
 
   // Second row: 9 keys
-  rectArea.x0 = keyboard->area.x0+SECOND_LINE_OFFSET;
+  rectArea.x0 = keyboard->obj.area.x0+SECOND_LINE_OFFSET;
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   nbgl_frontDrawRect(&rectArea);
   for (i=10;i<19;i++) {
@@ -253,7 +253,7 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
     nbgl_frontDrawRect(&rectArea);
   }
   // Third row: Special char key, 5 keys and backspace
-  rectArea.x0 = keyboard->area.x0+SPECIAL_CHARS_KEY_WIDTH;
+  rectArea.x0 = keyboard->obj.area.x0+SPECIAL_CHARS_KEY_WIDTH;
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   nbgl_frontDrawRect(&rectArea);
   for (i=0;i<5;i++) {
@@ -263,7 +263,7 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
 
   // 4th row, switch to letters and space
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
-  rectArea.x0 = keyboard->area.x0+SWITCH_KEY_WIDTH;
+  rectArea.x0 = keyboard->obj.area.x0+SWITCH_KEY_WIDTH;
   nbgl_frontDrawRect(&rectArea);
 }
 
@@ -278,15 +278,15 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   else
     keys = kbd_chars;
 
-  rectArea.backgroundColor = keyboard->area.backgroundColor;
-  rectArea.y0 = keyboard->area.y0 + LETTER_OFFSET_Y;
+  rectArea.backgroundColor = keyboard->obj.area.backgroundColor;
+  rectArea.y0 = keyboard->obj.area.y0 + LETTER_OFFSET_Y;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT*3;
-  rectArea.x0 = keyboard->area.x0;
+  rectArea.x0 = keyboard->obj.area.x0;
 
   // First row of keys: 10 letters (qwertyuiop)
   for (i=0;i<10;i++) {
-    rectArea.x0 = keyboard->area.x0 + i*NORMAL_KEY_WIDTH;
+    rectArea.x0 = keyboard->obj.area.x0 + i*NORMAL_KEY_WIDTH;
 
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i],
@@ -296,7 +296,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   // Second row: 9 letters (asdfghjkl)
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   for (i=10;i<19;i++) {
-    rectArea.x0 = keyboard->area.x0 + SECOND_LINE_OFFSET + (i-10)*NORMAL_KEY_WIDTH;
+    rectArea.x0 = keyboard->obj.area.x0 + SECOND_LINE_OFFSET + (i-10)*NORMAL_KEY_WIDTH;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i],
                   1, BAGL_FONT_INTER_REGULAR_24px_1bpp,
@@ -310,7 +310,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
     rectArea.width = SHIFT_KEY_WIDTH-1;
     rectArea.height = KEYBOARD_KEY_HEIGHT;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2;
+    rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2;
     rectArea.x0 = 1;
     rectArea.backgroundColor = (keyboard->casing != LOWER_CASE)?BLACK:WHITE;
     nbgl_frontDrawRect(&rectArea);
@@ -318,14 +318,14 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
     rectArea.width = SHIFT_KEY_WIDTH-1;
     rectArea.height = 4;
     rectArea.x0 = 1;
-    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2;
+    rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2;
     rectArea.backgroundColor = (keyboard->casing != LOWER_CASE)?BLACK:WHITE;
     nbgl_frontDrawHorizontalLine(&rectArea, 0x1, keyboard->borderColor);
     // draw Shift key
     rectArea.width = C_shift32px.width;
     rectArea.height = C_shift32px.height;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.y0 = (keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
+    rectArea.y0 = (keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
     rectArea.x0 = (SHIFT_KEY_WIDTH-rectArea.width)/2;
     rectArea.backgroundColor = (keyboard->casing != LOWER_CASE)?BLACK:WHITE;
     nbgl_frontDrawImage(&rectArea,
@@ -333,12 +333,12 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
                         NO_TRANSFORMATION,
                         (keyboard->casing != LOWER_CASE)?WHITE:BLACK);
     rectArea.backgroundColor = WHITE;
-    offsetX = keyboard->area.x0 + SHIFT_KEY_WIDTH;
+    offsetX = keyboard->obj.area.x0 + SHIFT_KEY_WIDTH;
   }
   else {
     offsetX = 0;
   }
-  rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
+  rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
   for (i=19;i<26;i++) {
     rectArea.x0 = offsetX + (i-19)*NORMAL_KEY_WIDTH;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
@@ -351,7 +351,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   rectArea.height = C_backspace32px.height;
   rectArea.bpp = NBGL_BPP_1;
   rectArea.x0 = offsetX + 7*NORMAL_KEY_WIDTH;
-  rectArea.y0 = (keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
+  rectArea.y0 = (keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
   if (!keyboard->lettersOnly) {
     rectArea.x0 += (BACKSPACE_KEY_WIDTH_FULL-rectArea.width)/2;
   }
@@ -363,7 +363,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   // 4th row, only in Full mode
   if (!keyboard->lettersOnly) {
     rectArea.x0 = (SWITCH_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,".?123"))/2;
-    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
+    rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
     nbgl_drawText(&rectArea, ".?123", 5, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
 
     rectArea.x0 = SWITCH_KEY_WIDTH+(SPACE_KEY_WIDTH-C_space32px.width)/2;
@@ -383,22 +383,22 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard) {
   else
     keys = kbd_specials;
 
-  rectArea.backgroundColor = keyboard->area.backgroundColor;
-  rectArea.y0 = keyboard->area.y0 + LETTER_OFFSET_Y;
+  rectArea.backgroundColor = keyboard->obj.area.backgroundColor;
+  rectArea.y0 = keyboard->obj.area.y0 + LETTER_OFFSET_Y;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT*3;
-  rectArea.x0 = keyboard->area.x0;
+  rectArea.x0 = keyboard->obj.area.x0;
 
   // First row of keys: 10 digits (1234567890)
   for (i=0;i<10;i++) {
-    rectArea.x0 = keyboard->area.x0 + i*NORMAL_KEY_WIDTH;
+    rectArea.x0 = keyboard->obj.area.x0 + i*NORMAL_KEY_WIDTH;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i], 1, BAGL_FONT_INTER_REGULAR_24px_1bpp, (keyboard->keyMask&(1<<i))? WHITE:BLACK);
   }
   // Second row: 9 keys ()
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   for (i=10;i<19;i++) {
-    rectArea.x0 = keyboard->area.x0 + (i-10)*NORMAL_KEY_WIDTH + SECOND_LINE_OFFSET;
+    rectArea.x0 = keyboard->obj.area.x0 + (i-10)*NORMAL_KEY_WIDTH + SECOND_LINE_OFFSET;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i], 1, BAGL_FONT_INTER_REGULAR_24px_1bpp, (keyboard->keyMask&(1<<i))? WHITE:BLACK);
   }
@@ -407,12 +407,12 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard) {
   // draw "#+=" key
   if (keyboard->mode == MODE_DIGITS) {
     rectArea.x0 = (SPECIAL_CHARS_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,"#+="))/2;
-    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
+    rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
     nbgl_drawText(&rectArea, "#+=", 3, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
   }
   else {
     rectArea.x0 = (SPECIAL_CHARS_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,"123"))/2;
-    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
+    rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
     nbgl_drawText(&rectArea, "123", 3, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
   }
 
@@ -426,13 +426,13 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard) {
   rectArea.height = C_backspace32px.height;
   rectArea.bpp = NBGL_BPP_1;
   rectArea.x0 = SPECIAL_CHARS_KEY_WIDTH + 5*NORMAL_KEY_WIDTH;
-  rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2;
+  rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2;
   rectArea.x0 += (BACKSPACE_KEY_WIDTH_DIGITS-rectArea.width)/2;
   nbgl_frontDrawImage(&rectArea,(uint8_t*)C_backspace32px.bitmap,NO_TRANSFORMATION,BLACK);
 
   // 4th row
   rectArea.x0 = (SWITCH_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,"ABC"))/2;
-  rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
+  rectArea.y0 = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
   nbgl_drawText(&rectArea, "ABC", 3, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
 
   rectArea.x0 = SWITCH_KEY_WIDTH+(SPACE_KEY_WIDTH-C_space32px.width)/2;
@@ -573,7 +573,7 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
  * @param kbd the object to be drawned
  */
 void nbgl_objDrawKeyboard(nbgl_keyboard_t *kbd) {
-  kbd->touchMask = (1 << TOUCHED);
+  kbd->obj.touchMask = (1 << TOUCHED);
   kbd->needsRefresh = false;
 
   keyboardDraw(kbd);

--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -133,18 +133,18 @@ static void keyboardDrawCommonLines(nbgl_keyboard_t *keyboard) {
   nbgl_area_t rectArea;
 
   // clean full area
-  rectArea.backgroundColor = keyboard->backgroundColor;
-  rectArea.x0 = keyboard->x0;
-  rectArea.y0 = keyboard->y0;
-  rectArea.width = keyboard->width;
-  rectArea.height = keyboard->height;
+  rectArea.backgroundColor = keyboard->area.backgroundColor;
+  rectArea.x0 = keyboard->area.x0;
+  rectArea.y0 = keyboard->area.y0;
+  rectArea.width = keyboard->area.width;
+  rectArea.height = keyboard->area.height;
   nbgl_frontDrawRect(&rectArea);
 
   /// draw horizontal lines
-  rectArea.backgroundColor = keyboard->backgroundColor;
-  rectArea.x0 = keyboard->x0;
-  rectArea.y0 = keyboard->y0;
-  rectArea.width = keyboard->width;
+  rectArea.backgroundColor = keyboard->area.backgroundColor;
+  rectArea.x0 = keyboard->area.x0;
+  rectArea.y0 = keyboard->area.y0;
+  rectArea.width = keyboard->area.width;
   rectArea.height = 4;
   nbgl_frontDrawHorizontalLine(&rectArea, 0x1, keyboard->borderColor); // 1st line (top)
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
@@ -159,8 +159,8 @@ static void keyboardDrawCommonLines(nbgl_keyboard_t *keyboard) {
   }
   /// then draw vertical lines
   rectArea.backgroundColor = keyboard->borderColor;
-  rectArea.x0 = keyboard->x0;
-  rectArea.y0 = keyboard->y0;
+  rectArea.x0 = keyboard->area.x0;
+  rectArea.y0 = keyboard->area.y0;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT*3;
   if (!keyboard->lettersOnly)
@@ -179,8 +179,8 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
 
   // then all vertical lines separating keys
   rectArea.backgroundColor = keyboard->borderColor;
-  rectArea.x0 = keyboard->x0;
-  rectArea.y0 = keyboard->y0;
+  rectArea.x0 = keyboard->area.x0;
+  rectArea.y0 = keyboard->area.y0;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT;
   // First row of keys: 10 letters (qwertyuiop)
@@ -190,7 +190,7 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
   }
 
   // Second row: 9 letters (asdfghjkl)
-  rectArea.x0 = keyboard->x0+SECOND_LINE_OFFSET;
+  rectArea.x0 = keyboard->area.x0+SECOND_LINE_OFFSET;
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   nbgl_frontDrawRect(&rectArea);
   for (i=10;i<19;i++) {
@@ -201,7 +201,7 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
   // Third row: 7 letters (zxcvbnm) and backspace in letters only mode
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   if (!keyboard->lettersOnly) {
-    rectArea.x0 = keyboard->x0+SHIFT_KEY_WIDTH;
+    rectArea.x0 = keyboard->area.x0+SHIFT_KEY_WIDTH;
   }
   else {
     rectArea.x0 = NORMAL_KEY_WIDTH;
@@ -219,7 +219,7 @@ static void keyboardDrawLetterGrid(nbgl_keyboard_t *keyboard) {
   // 4th row, only in Full mode
   if (!keyboard->lettersOnly) {
     rectArea.y0 += KEYBOARD_KEY_HEIGHT;
-    rectArea.x0 = keyboard->x0+SWITCH_KEY_WIDTH;
+    rectArea.x0 = keyboard->area.x0+SWITCH_KEY_WIDTH;
     nbgl_frontDrawRect(&rectArea);
   }
 }
@@ -234,8 +234,8 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
 
   // then all vertical lines separating keys
   rectArea.backgroundColor = keyboard->borderColor;
-  rectArea.x0 = keyboard->x0;
-  rectArea.y0 = keyboard->y0;
+  rectArea.x0 = keyboard->area.x0;
+  rectArea.y0 = keyboard->area.y0;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT;
   // First row of keys: 10 keys so 9 separations
@@ -245,7 +245,7 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
   }
 
   // Second row: 9 keys
-  rectArea.x0 = keyboard->x0+SECOND_LINE_OFFSET;
+  rectArea.x0 = keyboard->area.x0+SECOND_LINE_OFFSET;
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   nbgl_frontDrawRect(&rectArea);
   for (i=10;i<19;i++) {
@@ -253,7 +253,7 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
     nbgl_frontDrawRect(&rectArea);
   }
   // Third row: Special char key, 5 keys and backspace
-  rectArea.x0 = keyboard->x0+SPECIAL_CHARS_KEY_WIDTH;
+  rectArea.x0 = keyboard->area.x0+SPECIAL_CHARS_KEY_WIDTH;
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   nbgl_frontDrawRect(&rectArea);
   for (i=0;i<5;i++) {
@@ -263,7 +263,7 @@ static void keyboardDrawDigitsGrid(nbgl_keyboard_t *keyboard) {
 
   // 4th row, switch to letters and space
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
-  rectArea.x0 = keyboard->x0+SWITCH_KEY_WIDTH;
+  rectArea.x0 = keyboard->area.x0+SWITCH_KEY_WIDTH;
   nbgl_frontDrawRect(&rectArea);
 }
 
@@ -278,15 +278,15 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   else
     keys = kbd_chars;
 
-  rectArea.backgroundColor = keyboard->backgroundColor;
-  rectArea.y0 = keyboard->y0 + LETTER_OFFSET_Y;
+  rectArea.backgroundColor = keyboard->area.backgroundColor;
+  rectArea.y0 = keyboard->area.y0 + LETTER_OFFSET_Y;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT*3;
-  rectArea.x0 = keyboard->x0;
+  rectArea.x0 = keyboard->area.x0;
 
   // First row of keys: 10 letters (qwertyuiop)
   for (i=0;i<10;i++) {
-    rectArea.x0 = keyboard->x0 + i*NORMAL_KEY_WIDTH;
+    rectArea.x0 = keyboard->area.x0 + i*NORMAL_KEY_WIDTH;
 
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i],
@@ -296,7 +296,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   // Second row: 9 letters (asdfghjkl)
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   for (i=10;i<19;i++) {
-    rectArea.x0 = keyboard->x0 + SECOND_LINE_OFFSET + (i-10)*NORMAL_KEY_WIDTH;
+    rectArea.x0 = keyboard->area.x0 + SECOND_LINE_OFFSET + (i-10)*NORMAL_KEY_WIDTH;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i],
                   1, BAGL_FONT_INTER_REGULAR_24px_1bpp,
@@ -310,7 +310,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
     rectArea.width = SHIFT_KEY_WIDTH-1;
     rectArea.height = KEYBOARD_KEY_HEIGHT;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2;
+    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2;
     rectArea.x0 = 1;
     rectArea.backgroundColor = (keyboard->casing != LOWER_CASE)?BLACK:WHITE;
     nbgl_frontDrawRect(&rectArea);
@@ -318,14 +318,14 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
     rectArea.width = SHIFT_KEY_WIDTH-1;
     rectArea.height = 4;
     rectArea.x0 = 1;
-    rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2;
+    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2;
     rectArea.backgroundColor = (keyboard->casing != LOWER_CASE)?BLACK:WHITE;
     nbgl_frontDrawHorizontalLine(&rectArea, 0x1, keyboard->borderColor);
     // draw Shift key
     rectArea.width = C_shift32px.width;
     rectArea.height = C_shift32px.height;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.y0 = (keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
+    rectArea.y0 = (keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
     rectArea.x0 = (SHIFT_KEY_WIDTH-rectArea.width)/2;
     rectArea.backgroundColor = (keyboard->casing != LOWER_CASE)?BLACK:WHITE;
     nbgl_frontDrawImage(&rectArea,
@@ -333,12 +333,12 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
                         NO_TRANSFORMATION,
                         (keyboard->casing != LOWER_CASE)?WHITE:BLACK);
     rectArea.backgroundColor = WHITE;
-    offsetX = keyboard->x0 + SHIFT_KEY_WIDTH;
+    offsetX = keyboard->area.x0 + SHIFT_KEY_WIDTH;
   }
   else {
     offsetX = 0;
   }
-  rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
+  rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
   for (i=19;i<26;i++) {
     rectArea.x0 = offsetX + (i-19)*NORMAL_KEY_WIDTH;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
@@ -351,7 +351,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   rectArea.height = C_backspace32px.height;
   rectArea.bpp = NBGL_BPP_1;
   rectArea.x0 = offsetX + 7*NORMAL_KEY_WIDTH;
-  rectArea.y0 = (keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
+  rectArea.y0 = (keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2) & 0xFFC;
   if (!keyboard->lettersOnly) {
     rectArea.x0 += (BACKSPACE_KEY_WIDTH_FULL-rectArea.width)/2;
   }
@@ -363,7 +363,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard) {
   // 4th row, only in Full mode
   if (!keyboard->lettersOnly) {
     rectArea.x0 = (SWITCH_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,".?123"))/2;
-    rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
+    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
     nbgl_drawText(&rectArea, ".?123", 5, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
 
     rectArea.x0 = SWITCH_KEY_WIDTH+(SPACE_KEY_WIDTH-C_space32px.width)/2;
@@ -383,22 +383,22 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard) {
   else
     keys = kbd_specials;
 
-  rectArea.backgroundColor = keyboard->backgroundColor;
-  rectArea.y0 = keyboard->y0 + LETTER_OFFSET_Y;
+  rectArea.backgroundColor = keyboard->area.backgroundColor;
+  rectArea.y0 = keyboard->area.y0 + LETTER_OFFSET_Y;
   rectArea.width = 1;
   rectArea.height = KEYBOARD_KEY_HEIGHT*3;
-  rectArea.x0 = keyboard->x0;
+  rectArea.x0 = keyboard->area.x0;
 
   // First row of keys: 10 digits (1234567890)
   for (i=0;i<10;i++) {
-    rectArea.x0 = keyboard->x0 + i*NORMAL_KEY_WIDTH;
+    rectArea.x0 = keyboard->area.x0 + i*NORMAL_KEY_WIDTH;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i], 1, BAGL_FONT_INTER_REGULAR_24px_1bpp, (keyboard->keyMask&(1<<i))? WHITE:BLACK);
   }
   // Second row: 9 keys ()
   rectArea.y0 += KEYBOARD_KEY_HEIGHT;
   for (i=10;i<19;i++) {
-    rectArea.x0 = keyboard->x0 + (i-10)*NORMAL_KEY_WIDTH + SECOND_LINE_OFFSET;
+    rectArea.x0 = keyboard->area.x0 + (i-10)*NORMAL_KEY_WIDTH + SECOND_LINE_OFFSET;
     rectArea.x0 += (NORMAL_KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,&keys[i]))/2;
     nbgl_drawText(&rectArea, &keys[i], 1, BAGL_FONT_INTER_REGULAR_24px_1bpp, (keyboard->keyMask&(1<<i))? WHITE:BLACK);
   }
@@ -407,12 +407,12 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard) {
   // draw "#+=" key
   if (keyboard->mode == MODE_DIGITS) {
     rectArea.x0 = (SPECIAL_CHARS_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,"#+="))/2;
-    rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
+    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
     nbgl_drawText(&rectArea, "#+=", 3, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
   }
   else {
     rectArea.x0 = (SPECIAL_CHARS_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,"123"))/2;
-    rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
+    rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + LETTER_OFFSET_Y;
     nbgl_drawText(&rectArea, "123", 3, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
   }
 
@@ -426,13 +426,13 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard) {
   rectArea.height = C_backspace32px.height;
   rectArea.bpp = NBGL_BPP_1;
   rectArea.x0 = SPECIAL_CHARS_KEY_WIDTH + 5*NORMAL_KEY_WIDTH;
-  rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2;
+  rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*2 + (KEYBOARD_KEY_HEIGHT-rectArea.height)/2;
   rectArea.x0 += (BACKSPACE_KEY_WIDTH_DIGITS-rectArea.width)/2;
   nbgl_frontDrawImage(&rectArea,(uint8_t*)C_backspace32px.bitmap,NO_TRANSFORMATION,BLACK);
 
   // 4th row
   rectArea.x0 = (SWITCH_KEY_WIDTH-nbgl_getTextWidth(BAGL_FONT_INTER_REGULAR_24px_1bpp,"ABC"))/2;
-  rectArea.y0 = keyboard->y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
+  rectArea.y0 = keyboard->area.y0 + KEYBOARD_KEY_HEIGHT*3 + LETTER_OFFSET_Y;
   nbgl_drawText(&rectArea, "ABC", 3, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
 
   rectArea.x0 = SWITCH_KEY_WIDTH+(SPACE_KEY_WIDTH-C_space32px.width)/2;
@@ -480,10 +480,10 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
     return;
   }
   // modify positions with keyboard position
-  firstPosition->x -= obj->x0;
-  firstPosition->y -= obj->y0;
-  lastPosition->x -= obj->x0;
-  lastPosition->y -= obj->y0;
+  firstPosition->x -= obj->area.x0;
+  firstPosition->y -= obj->area.y0;
+  lastPosition->x -= obj->area.x0;
+  lastPosition->y -= obj->area.y0;
 
   firstIndex = getKeyboardIndex(keyboard,firstPosition);
   if (firstIndex > SPECIAL_KEYS_INDEX)

--- a/lib_nbgl/src/nbgl_obj_keypad.c
+++ b/lib_nbgl/src/nbgl_obj_keypad.c
@@ -83,18 +83,18 @@ static void keypadDrawGrid(nbgl_keypad_t *keypad) {
   nbgl_area_t rectArea;
 
   // clean full area
-  rectArea.backgroundColor = keypad->backgroundColor;
-  rectArea.x0 = keypad->x0;
-  rectArea.y0 = keypad->y0;
-  rectArea.width = keypad->width;
-  rectArea.height = keypad->height;
+  rectArea.backgroundColor = keypad->area.backgroundColor;
+  rectArea.x0 = keypad->area.x0;
+  rectArea.y0 = keypad->area.y0;
+  rectArea.width = keypad->area.width;
+  rectArea.height = keypad->area.height;
   nbgl_frontDrawRect(&rectArea);
 
   /// draw horizontal lines
-  rectArea.backgroundColor = keypad->backgroundColor;
-  rectArea.x0 = keypad->x0;
-  rectArea.y0 = keypad->y0;
-  rectArea.width = keypad->width;
+  rectArea.backgroundColor = keypad->area.backgroundColor;
+  rectArea.x0 = keypad->area.x0;
+  rectArea.y0 = keypad->area.y0;
+  rectArea.width = keypad->area.width;
   rectArea.height = 4;
   nbgl_frontDrawHorizontalLine(&rectArea, 0x1, keypad->borderColor); // 1st line (top)
   rectArea.y0 += KEYPAD_KEY_HEIGHT;
@@ -106,8 +106,8 @@ static void keypadDrawGrid(nbgl_keypad_t *keypad) {
 
   /// then draw 3 vertical lines
   rectArea.backgroundColor = keypad->borderColor;
-  rectArea.x0 = keypad->x0;
-  rectArea.y0 = keypad->y0;
+  rectArea.x0 = keypad->area.x0;
+  rectArea.y0 = keypad->area.y0;
   rectArea.width = 1;
   rectArea.height = KEYPAD_KEY_HEIGHT*4;
   nbgl_frontDrawRect(&rectArea); // 1st full line, on the left
@@ -123,14 +123,14 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   nbgl_area_t rectArea;
   char key_value;
 
-  rectArea.backgroundColor = keypad->backgroundColor;
-  rectArea.y0 = keypad->y0 + DIGIT_OFFSET_Y;
+  rectArea.backgroundColor = keypad->area.backgroundColor;
+  rectArea.y0 = keypad->area.y0 + DIGIT_OFFSET_Y;
 
   // First row of keys: 1 2 3
   for (i=0;i<3;i++) {
     key_value = GET_DIGIT_INDEX(keypad,(i+1)) + 0x30;
 
-    rectArea.x0 = keypad->x0 + i*KEY_WIDTH;
+    rectArea.x0 = keypad->area.x0 + i*KEY_WIDTH;
     rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
     nbgl_drawText(&rectArea, &key_value,
                   1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
@@ -140,7 +140,7 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   rectArea.y0 += KEYPAD_KEY_HEIGHT;
   for (;i<6;i++) {
     key_value = GET_DIGIT_INDEX(keypad,(i+1)) + 0x30;
-    rectArea.x0 = keypad->x0 + (i-3)*KEY_WIDTH;
+    rectArea.x0 = keypad->area.x0 + (i-3)*KEY_WIDTH;
     rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
     nbgl_drawText(&rectArea, &key_value,
                   1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
@@ -150,7 +150,7 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   rectArea.y0 += KEYPAD_KEY_HEIGHT;
   for (;i<9;i++) {
     key_value = GET_DIGIT_INDEX(keypad,(i+1)) + 0x30;
-    rectArea.x0 = keypad->x0 + (i-6)*KEY_WIDTH;
+    rectArea.x0 = keypad->area.x0 + (i-6)*KEY_WIDTH;
     rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
     nbgl_drawText(&rectArea, &key_value,
                   1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
@@ -161,15 +161,15 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   rectArea.width = C_backspace32px.width;
   rectArea.height = C_backspace32px.height;
   rectArea.bpp = NBGL_BPP_1;
-  rectArea.x0 = keypad->x0 + (KEY_WIDTH-rectArea.width)/2;
-  rectArea.y0 = keypad->y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
+  rectArea.x0 = keypad->area.x0 + (KEY_WIDTH-rectArea.width)/2;
+  rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
   nbgl_frontDrawImage(&rectArea,(uint8_t*)C_backspace32px.bitmap,NO_TRANSFORMATION, keypad->enableBackspace?BLACK:WHITE);
 
   // draw 0
   key_value = GET_DIGIT_INDEX(keypad,0)+0x30;
-  rectArea.x0 = keypad->x0 + KEY_WIDTH;
+  rectArea.x0 = keypad->area.x0 + KEY_WIDTH;
   rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
-  rectArea.y0 = keypad->y0 + KEYPAD_KEY_HEIGHT*3 + DIGIT_OFFSET_Y;
+  rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + DIGIT_OFFSET_Y;
   nbgl_drawText(&rectArea, &key_value,
                 1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
                 keypad->enableDigits ? BLACK :  WHITE);
@@ -179,24 +179,24 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
     rectArea.width = C_check32px.width;
     rectArea.height = C_check32px.height;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.x0 = keypad->x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
-    rectArea.y0 = keypad->y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
+    rectArea.x0 = keypad->area.x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
+    rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
     rectArea.backgroundColor = WHITE;
     nbgl_frontDrawRect(&rectArea);
   }
   else {
     // if enabled, draw icon in white on a black background
     rectArea.backgroundColor = BLACK;
-    rectArea.x0 = keypad->x0 + 2*KEY_WIDTH;
-    rectArea.y0 = keypad->y0 + KEYPAD_KEY_HEIGHT*3;
+    rectArea.x0 = keypad->area.x0 + 2*KEY_WIDTH;
+    rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3;
     rectArea.width = KEY_WIDTH;
     rectArea.height = KEYPAD_KEY_HEIGHT;
     nbgl_frontDrawRect(&rectArea);
     rectArea.width = C_check32px.width;
     rectArea.height = C_check32px.height;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.x0 = keypad->x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
-    rectArea.y0 = keypad->y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
+    rectArea.x0 = keypad->area.x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
+    rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
     nbgl_frontDrawImage(&rectArea,(uint8_t*)C_check32px.bitmap,NO_TRANSFORMATION, WHITE);
   }
 }
@@ -234,10 +234,10 @@ void nbgl_keypadTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
   }
 
   // use positions relative to keypad position
-  firstIndex = getKeypadIndex(firstPosition->x - obj->x0, firstPosition->y - obj->y0);
+  firstIndex = getKeypadIndex(firstPosition->x - obj->area.x0, firstPosition->y - obj->area.y0);
   if (firstIndex > VALIDATE_KEY_INDEX)
     return;
-  lastIndex = getKeypadIndex(lastPosition->x - obj->x0, lastPosition->y - obj->y0);
+  lastIndex = getKeypadIndex(lastPosition->x - obj->area.x0, lastPosition->y - obj->area.y0);
   if (lastIndex > VALIDATE_KEY_INDEX)
     return;
 

--- a/lib_nbgl/src/nbgl_obj_keypad.c
+++ b/lib_nbgl/src/nbgl_obj_keypad.c
@@ -83,18 +83,18 @@ static void keypadDrawGrid(nbgl_keypad_t *keypad) {
   nbgl_area_t rectArea;
 
   // clean full area
-  rectArea.backgroundColor = keypad->area.backgroundColor;
-  rectArea.x0 = keypad->area.x0;
-  rectArea.y0 = keypad->area.y0;
-  rectArea.width = keypad->area.width;
-  rectArea.height = keypad->area.height;
+  rectArea.backgroundColor = keypad->obj.area.backgroundColor;
+  rectArea.x0 = keypad->obj.area.x0;
+  rectArea.y0 = keypad->obj.area.y0;
+  rectArea.width = keypad->obj.area.width;
+  rectArea.height = keypad->obj.area.height;
   nbgl_frontDrawRect(&rectArea);
 
   /// draw horizontal lines
-  rectArea.backgroundColor = keypad->area.backgroundColor;
-  rectArea.x0 = keypad->area.x0;
-  rectArea.y0 = keypad->area.y0;
-  rectArea.width = keypad->area.width;
+  rectArea.backgroundColor = keypad->obj.area.backgroundColor;
+  rectArea.x0 = keypad->obj.area.x0;
+  rectArea.y0 = keypad->obj.area.y0;
+  rectArea.width = keypad->obj.area.width;
   rectArea.height = 4;
   nbgl_frontDrawHorizontalLine(&rectArea, 0x1, keypad->borderColor); // 1st line (top)
   rectArea.y0 += KEYPAD_KEY_HEIGHT;
@@ -106,8 +106,8 @@ static void keypadDrawGrid(nbgl_keypad_t *keypad) {
 
   /// then draw 3 vertical lines
   rectArea.backgroundColor = keypad->borderColor;
-  rectArea.x0 = keypad->area.x0;
-  rectArea.y0 = keypad->area.y0;
+  rectArea.x0 = keypad->obj.area.x0;
+  rectArea.y0 = keypad->obj.area.y0;
   rectArea.width = 1;
   rectArea.height = KEYPAD_KEY_HEIGHT*4;
   nbgl_frontDrawRect(&rectArea); // 1st full line, on the left
@@ -123,14 +123,14 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   nbgl_area_t rectArea;
   char key_value;
 
-  rectArea.backgroundColor = keypad->area.backgroundColor;
-  rectArea.y0 = keypad->area.y0 + DIGIT_OFFSET_Y;
+  rectArea.backgroundColor = keypad->obj.area.backgroundColor;
+  rectArea.y0 = keypad->obj.area.y0 + DIGIT_OFFSET_Y;
 
   // First row of keys: 1 2 3
   for (i=0;i<3;i++) {
     key_value = GET_DIGIT_INDEX(keypad,(i+1)) + 0x30;
 
-    rectArea.x0 = keypad->area.x0 + i*KEY_WIDTH;
+    rectArea.x0 = keypad->obj.area.x0 + i*KEY_WIDTH;
     rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
     nbgl_drawText(&rectArea, &key_value,
                   1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
@@ -140,7 +140,7 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   rectArea.y0 += KEYPAD_KEY_HEIGHT;
   for (;i<6;i++) {
     key_value = GET_DIGIT_INDEX(keypad,(i+1)) + 0x30;
-    rectArea.x0 = keypad->area.x0 + (i-3)*KEY_WIDTH;
+    rectArea.x0 = keypad->obj.area.x0 + (i-3)*KEY_WIDTH;
     rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
     nbgl_drawText(&rectArea, &key_value,
                   1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
@@ -150,7 +150,7 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   rectArea.y0 += KEYPAD_KEY_HEIGHT;
   for (;i<9;i++) {
     key_value = GET_DIGIT_INDEX(keypad,(i+1)) + 0x30;
-    rectArea.x0 = keypad->area.x0 + (i-6)*KEY_WIDTH;
+    rectArea.x0 = keypad->obj.area.x0 + (i-6)*KEY_WIDTH;
     rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
     nbgl_drawText(&rectArea, &key_value,
                   1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
@@ -161,15 +161,15 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
   rectArea.width = C_backspace32px.width;
   rectArea.height = C_backspace32px.height;
   rectArea.bpp = NBGL_BPP_1;
-  rectArea.x0 = keypad->area.x0 + (KEY_WIDTH-rectArea.width)/2;
-  rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
+  rectArea.x0 = keypad->obj.area.x0 + (KEY_WIDTH-rectArea.width)/2;
+  rectArea.y0 = keypad->obj.area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
   nbgl_frontDrawImage(&rectArea,(uint8_t*)C_backspace32px.bitmap,NO_TRANSFORMATION, keypad->enableBackspace?BLACK:WHITE);
 
   // draw 0
   key_value = GET_DIGIT_INDEX(keypad,0)+0x30;
-  rectArea.x0 = keypad->area.x0 + KEY_WIDTH;
+  rectArea.x0 = keypad->obj.area.x0 + KEY_WIDTH;
   rectArea.x0 += (KEY_WIDTH-nbgl_getCharWidth(BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,&key_value))/2;
-  rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + DIGIT_OFFSET_Y;
+  rectArea.y0 = keypad->obj.area.y0 + KEYPAD_KEY_HEIGHT*3 + DIGIT_OFFSET_Y;
   nbgl_drawText(&rectArea, &key_value,
                 1, BAGL_FONT_HM_ALPHA_MONO_MEDIUM_32px,
                 keypad->enableDigits ? BLACK :  WHITE);
@@ -179,24 +179,24 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad) {
     rectArea.width = C_check32px.width;
     rectArea.height = C_check32px.height;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.x0 = keypad->area.x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
-    rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
+    rectArea.x0 = keypad->obj.area.x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
+    rectArea.y0 = keypad->obj.area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
     rectArea.backgroundColor = WHITE;
     nbgl_frontDrawRect(&rectArea);
   }
   else {
     // if enabled, draw icon in white on a black background
     rectArea.backgroundColor = BLACK;
-    rectArea.x0 = keypad->area.x0 + 2*KEY_WIDTH;
-    rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3;
+    rectArea.x0 = keypad->obj.area.x0 + 2*KEY_WIDTH;
+    rectArea.y0 = keypad->obj.area.y0 + KEYPAD_KEY_HEIGHT*3;
     rectArea.width = KEY_WIDTH;
     rectArea.height = KEYPAD_KEY_HEIGHT;
     nbgl_frontDrawRect(&rectArea);
     rectArea.width = C_check32px.width;
     rectArea.height = C_check32px.height;
     rectArea.bpp = NBGL_BPP_1;
-    rectArea.x0 = keypad->area.x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
-    rectArea.y0 = keypad->area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
+    rectArea.x0 = keypad->obj.area.x0 + 2*KEY_WIDTH + (KEY_WIDTH-rectArea.width)/2;
+    rectArea.y0 = keypad->obj.area.y0 + KEYPAD_KEY_HEIGHT*3 + (KEYPAD_KEY_HEIGHT-rectArea.height)/2;
     nbgl_frontDrawImage(&rectArea,(uint8_t*)C_check32px.bitmap,NO_TRANSFORMATION, WHITE);
   }
 }
@@ -273,7 +273,7 @@ void nbgl_keypadTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
  * @return the keypad keypad object
  */
 void nbgl_objDrawKeypad(nbgl_keypad_t *kpd) {
-  kpd->touchMask = (1 << TOUCHED) | (1 << TOUCH_PRESSED);
+  kpd->obj.touchMask = (1 << TOUCHED) | (1 << TOUCH_PRESSED);
 
   // if the object has not been already used, prepare indexes of digits
   if (kpd->digitIndexes[0] == 0) {

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -118,11 +118,11 @@ static int nbgl_screenSetAt(uint8_t screenIndex, nbgl_obj_t*** children, uint8_t
   }
   *children = nbgl_containerPoolGet(nbChildren,screenIndex);
   screenStack[screenIndex].type = SCREEN;
-  screenStack[screenIndex].backgroundColor = WHITE;
-  screenStack[screenIndex].height = SCREEN_HEIGHT;
-  screenStack[screenIndex].width = SCREEN_WIDTH;
-  screenStack[screenIndex].x0 = 0;
-  screenStack[screenIndex].y0 = 0;
+  screenStack[screenIndex].area.backgroundColor = WHITE;
+  screenStack[screenIndex].area.height = SCREEN_HEIGHT;
+  screenStack[screenIndex].area.width = SCREEN_WIDTH;
+  screenStack[screenIndex].area.x0 = 0;
+  screenStack[screenIndex].area.y0 = 0;
   screenStack[screenIndex].rel_x0 = 0;
   screenStack[screenIndex].rel_y0 = 0;
   screenStack[screenIndex].layout = VERTICAL;
@@ -188,7 +188,7 @@ int nbgl_screenUpdateNbElements(uint8_t screenIndex, uint8_t nbElements) {
  * @return >= 0 if OK
  */
 int nbgl_screenUpdateBackgroundColor(uint8_t screenIndex, color_t color) {
-  screenStack[screenIndex].backgroundColor = color;
+  screenStack[screenIndex].area.backgroundColor = color;
   return 0;
 }
 

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -91,7 +91,7 @@ nbgl_obj_t *nbgl_screenGetTop(void) {
  * @return the number of used screens on stack
  */
 uint8_t nbgl_screenGetCurrentStackSize(void) {
-  if ((nbScreensOnStack == 1) && (screenStack[0].nbChildren == 0))
+  if ((nbScreensOnStack == 1) && (screenStack[0].container.nbChildren == 0))
     return 0;
   return nbScreensOnStack;
 }
@@ -117,25 +117,25 @@ static int nbgl_screenSetAt(uint8_t screenIndex, nbgl_obj_t*** children, uint8_t
     return -1;
   }
   *children = nbgl_containerPoolGet(nbChildren,screenIndex);
-  screenStack[screenIndex].type = SCREEN;
-  screenStack[screenIndex].area.backgroundColor = WHITE;
-  screenStack[screenIndex].area.height = SCREEN_HEIGHT;
-  screenStack[screenIndex].area.width = SCREEN_WIDTH;
-  screenStack[screenIndex].area.x0 = 0;
-  screenStack[screenIndex].area.y0 = 0;
-  screenStack[screenIndex].rel_x0 = 0;
-  screenStack[screenIndex].rel_y0 = 0;
-  screenStack[screenIndex].layout = VERTICAL;
-  screenStack[screenIndex].children = *children;
-  screenStack[screenIndex].nbChildren = nbChildren;
+  screenStack[screenIndex].container.obj.type = SCREEN;
+  screenStack[screenIndex].container.obj.area.backgroundColor = WHITE;
+  screenStack[screenIndex].container.obj.area.height = SCREEN_HEIGHT;
+  screenStack[screenIndex].container.obj.area.width = SCREEN_WIDTH;
+  screenStack[screenIndex].container.obj.area.x0 = 0;
+  screenStack[screenIndex].container.obj.area.y0 = 0;
+  screenStack[screenIndex].container.obj.rel_x0 = 0;
+  screenStack[screenIndex].container.obj.rel_y0 = 0;
+  screenStack[screenIndex].container.layout = VERTICAL;
+  screenStack[screenIndex].container.children = *children;
+  screenStack[screenIndex].container.nbChildren = nbChildren;
   screenStack[screenIndex].touchCallback = callback;
   if (ticker != NULL) {
-    screenStack[screenIndex].tickerCallback = (nbgl_tickerCallback_t)PIC(ticker->tickerCallback);
-    screenStack[screenIndex].tickerIntervale = ticker->tickerIntervale;
-    screenStack[screenIndex].tickerValue = ticker->tickerValue;
+    screenStack[screenIndex].ticker.tickerCallback = (nbgl_tickerCallback_t)PIC(ticker->tickerCallback);
+    screenStack[screenIndex].ticker.tickerIntervale = ticker->tickerIntervale;
+    screenStack[screenIndex].ticker.tickerValue = ticker->tickerValue;
   }
   else {
-    screenStack[screenIndex].tickerCallback = NULL;
+    screenStack[screenIndex].ticker.tickerCallback = NULL;
   }
   return 0;
 }
@@ -175,7 +175,7 @@ int nbgl_screenSet(nbgl_obj_t*** elements, uint8_t nbElements,
  * @return >= 0 if OK
  */
 int nbgl_screenUpdateNbElements(uint8_t screenIndex, uint8_t nbElements) {
-  screenStack[screenIndex].nbChildren = nbElements;
+  screenStack[screenIndex].container.nbChildren = nbElements;
   return 0;
 }
 
@@ -188,7 +188,7 @@ int nbgl_screenUpdateNbElements(uint8_t screenIndex, uint8_t nbElements) {
  * @return >= 0 if OK
  */
 int nbgl_screenUpdateBackgroundColor(uint8_t screenIndex, color_t color) {
-  screenStack[screenIndex].area.backgroundColor = color;
+  screenStack[screenIndex].container.obj.area.backgroundColor = color;
   return 0;
 }
 
@@ -202,12 +202,12 @@ int nbgl_screenUpdateBackgroundColor(uint8_t screenIndex, color_t color) {
  */
 int nbgl_screenUpdateTicker(uint8_t screenIndex, const nbgl_screenTickerConfiguration_t *ticker) {
   if (ticker != NULL) {
-    screenStack[screenIndex].tickerCallback = (nbgl_tickerCallback_t)PIC(ticker->tickerCallback);
-    screenStack[screenIndex].tickerIntervale = ticker->tickerIntervale;
-    screenStack[screenIndex].tickerValue = ticker->tickerValue;
+    screenStack[screenIndex].ticker.tickerCallback = (nbgl_tickerCallback_t)PIC(ticker->tickerCallback);
+    screenStack[screenIndex].ticker.tickerIntervale = ticker->tickerIntervale;
+    screenStack[screenIndex].ticker.tickerValue = ticker->tickerValue;
   }
   else {
-    screenStack[screenIndex].tickerCallback = NULL;
+    screenStack[screenIndex].ticker.tickerCallback = NULL;
   }
   return 0;
 }
@@ -221,7 +221,7 @@ int nbgl_screenUpdateTicker(uint8_t screenIndex, const nbgl_screenTickerConfigur
  * @return array of elements (children) of the screen
  */
 nbgl_obj_t** nbgl_screenGetElements(uint8_t screenIndex) {
-  return screenStack[screenIndex].children;
+  return screenStack[screenIndex].container.children;
 }
 
 /**
@@ -252,7 +252,7 @@ int nbgl_screenPush(nbgl_obj_t*** elements, uint8_t nbElements,
     // link top of stack to background (even if empty)
     topOfStack->previous = &screenStack[0];
     screenStack[0].next = topOfStack;
-    screenStack[0].nbChildren = 0;
+    screenStack[0].container.nbChildren = 0;
     // count empty background as an active screen
     nbScreensOnStack++;
   }
@@ -321,8 +321,8 @@ int nbgl_screenPop(uint8_t screenIndex) {
   // free slot
   screenStack[screenIndex].previous = NULL;
   screenStack[screenIndex].next = NULL;
-  screenStack[screenIndex].nbChildren = 0;
-  screenStack[screenIndex].children = NULL;
+  screenStack[screenIndex].container.nbChildren = 0;
+  screenStack[screenIndex].container.children = NULL;
   // release used objects and containers
   nbgl_objPoolRelease(screenIndex);
   nbgl_containerPoolRelease(screenIndex);
@@ -359,13 +359,13 @@ void nbgl_screenHandler(uint32_t intervaleMs) {
   if (nbScreensOnStack == 0)
     return;
   // call ticker callback of top of stack if active and not expired yet (for a non periodic)
-  if ((topOfStack->tickerCallback != NULL) &&
-      (topOfStack->tickerValue != 0)) {
-    topOfStack->tickerValue -= MIN(topOfStack->tickerValue, intervaleMs);
-    if (topOfStack->tickerValue == 0) {
+  if ((topOfStack->ticker.tickerCallback != NULL) &&
+      (topOfStack->ticker.tickerValue != 0)) {
+    topOfStack->ticker.tickerValue -= MIN(topOfStack->ticker.tickerValue, intervaleMs);
+    if (topOfStack->ticker.tickerValue == 0) {
       // rearm if intervale is not null, and call the registered function
-      topOfStack->tickerValue = topOfStack->tickerIntervale;
-      topOfStack->tickerCallback();
+      topOfStack->ticker.tickerValue = topOfStack->ticker.tickerIntervale;
+      topOfStack->ticker.tickerCallback();
     }
   }
 }

--- a/lib_nbgl/src/nbgl_touch.c
+++ b/lib_nbgl/src/nbgl_touch.c
@@ -92,8 +92,8 @@ static nbgl_obj_t * getTouchedObject(nbgl_obj_t *obj, nbgl_touchStatePosition_t 
   /* check coordinates
      no need to go further if the touched point is not within the object
      And because the children are also within the object, no need to check them either */
-  if ((event->x < obj->x0) || (event->x > (obj->x0+obj->width)) ||
-      (event->y < obj->y0) || (event->y > (obj->y0+obj->height))) {
+  if ((event->x < obj->area.x0) || (event->x > (obj->area.x0+obj->area.width)) ||
+      (event->y < obj->area.y0) || (event->y > (obj->area.y0+obj->area.height))) {
     return NULL;
   }
   if ((obj->type == SCREEN) ||


### PR DESCRIPTION
## Description

The goal is to get rid of anonymous structure used as members of other structures in NBGL objects, to simulate inheritance.
This mechanism is not full C-compatible.
The chosen solution is to name this sub-structure.

Note: -fms-extensions and -Wno-microsoft-anon-tag build options can then be removed.


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [*] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Some objet fields need to be addressed by this field names now
