### PR TITLE
Fix CI failure (scan-build) on API_LEVEL_5

### DIFF
--- a/src/checks.c
+++ b/src/checks.c
@@ -151,7 +151,6 @@ void ui_audited_deinit(void) {}
 void check_audited_app(void) {
   unsigned char     data = BOLOS_FALSE;
   unsigned char*    buffer = &data;
-  unsigned int      slot;
   unsigned int      length = os_parse_bertlv((unsigned char*)(&_install_parameters),
                                              CHECK_NOT_AUDITED_MAX_LEN,
                                              NULL,


### PR DESCRIPTION
## Description

CIs using the guidelines_enforcer are failing on recent builds with Nano X updated to API_LEVEL_5 because of an unused variable, which was fixed on master already. (ex. https://github.com/ton-blockchain/ledger-app-ton/actions/runs/5403907636/jobs/9817380906#step:4:39)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)


