### PR TITLE
fix: improper use of bzero

### DIFF
--- a/include/os_seed.h
+++ b/include/os_seed.h
@@ -188,7 +188,7 @@ WARN_UNUSED_RESULT static inline cx_err_t os_derive_bip32_with_seed_no_throw(
 
             // Make sure the caller doesn't use uninitialized data in case
             // the return code is not checked.
-            explicit_bzero(&raw_privkey, 64);
+            explicit_bzero(raw_privkey, 64);
         }
         FINALLY {
         }
@@ -277,7 +277,7 @@ WARN_UNUSED_RESULT static inline cx_err_t os_derive_eip2333_no_throw(
 
             // Make sure the caller doesn't use uninitialized data in case
             // the return code is not checked.
-            explicit_bzero(&raw_privkey, 64);
+            explicit_bzero(raw_privkey, 64);
         }
         FINALLY {
         }


### PR DESCRIPTION
## Description

`scan-build -enable-checker alpha.unix.cstring.OutOfBounds` showed a few `explicit_bzeroes` were clearing the pointer (and part of the stack...) instead of the intended array.
These were in a `CATCH` clause so could not be seen on the happy path.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
