### PR TITLE
Fix unexpected behaviors in stax UI

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -116,7 +116,7 @@ static uint8_t getKeyboardIndex(nbgl_keyboard_t *keyboard, nbgl_touchStatePositi
       }
     }
   }
-  else if (position->y < (4*KEYBOARD_KEY_HEIGHT)) {
+  else if (!keyboard->lettersOnly && (position->y < (4*KEYBOARD_KEY_HEIGHT))) {
     // 4th row
     if (position->x<SWITCH_KEY_WIDTH) {
       i = DIGITS_SWITCH_KEY_INDEX;
@@ -494,7 +494,6 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType) {
   // if position of finger has moved durinng press to another "key", drop it
   if (lastIndex != firstIndex)
     return;
-
 
   if (keyboard->mode == MODE_LETTERS) {
     keyboardCase_t cur_casing = keyboard->casing;

--- a/lib_nbgl/src/nbgl_touch.c
+++ b/lib_nbgl/src/nbgl_touch.c
@@ -92,8 +92,8 @@ static nbgl_obj_t * getTouchedObject(nbgl_obj_t *obj, nbgl_touchStatePosition_t 
   /* check coordinates
      no need to go further if the touched point is not within the object
      And because the children are also within the object, no need to check them either */
-  if ((event->x < obj->area.x0) || (event->x > (obj->area.x0+obj->area.width)) ||
-      (event->y < obj->area.y0) || (event->y > (obj->area.y0+obj->area.height))) {
+  if ((event->x < obj->area.x0) || (event->x >= (obj->area.x0+obj->area.width)) ||
+      (event->y < obj->area.y0) || (event->y >= (obj->area.y0+obj->area.height))) {
     return NULL;
   }
   if ((obj->type == SCREEN) ||

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -1414,7 +1414,7 @@ reply_apdu:
 
       // An apdu has been received asynchronously.
       if (G_io_app.apdu_state != APDU_IDLE && G_io_app.apdu_length > 0) {
-        if (os_perso_isonboarded() == BOLOS_TRUE && os_global_pin_is_validated() != BOLOS_TRUE) {
+        if (os_perso_is_pin_set() == BOLOS_TRUE && os_global_pin_is_validated() != BOLOS_TRUE) {
           tx_len = 0;
           G_io_apdu_buffer[(tx_len)++] = (SWO_SEC_PIN_15 >> 8) & 0xFF;
           G_io_apdu_buffer[(tx_len)++] = (SWO_SEC_PIN_15) & 0xFF;


### PR DESCRIPTION
## Description

Fixes:

- https://ledgerhq.atlassian.net/browse/FWEO-950 : by returning 0x5515 error code to any APDU in “locked” state as soon as PIN is set, instead of as soon as device is onboarded.

- https://ledgerhq.atlassian.net/browse/FWEO-954 : by better handling of the touched objet limits and protection in letter-only mode


## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)