### PR TITLE
fix undefined behaviour

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -289,7 +289,7 @@ static void displaySettingsPage(uint8_t page, bool forceFullRefresh) {
 
 // function used to display the current page in review
 static void displayReviewPage(uint8_t page, bool forceFullRefresh) {
-  nbgl_pageContent_t content;
+  nbgl_pageContent_t content = {0};
 
   // ensure the page is valid
   if ((navInfo.nbPages != 0) && (page >= (navInfo.nbPages))) {


### PR DESCRIPTION
## Description


When calling `nbgl_useCaseRegularReview` and setting a `TAG_VALUE_LIST`, the first screen appears as intented (with the full value displayed ), yet when going backwards the values appeared cropped with "...".
This happened because the `tagValueList.nbMaxLinesForValue` had a value of 1 instead of 0 the second time, due to the structure not being initialized.
The NBGL should initialize the structure.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)



