### PR TITLE
Ensure no os perso is pin set in apps

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -1414,7 +1414,13 @@ reply_apdu:
 
       // An apdu has been received asynchronously.
       if (G_io_app.apdu_state != APDU_IDLE && G_io_app.apdu_length > 0) {
+#ifdef HAVE_BOLOS
+        // for Bolos UX, answer SWO_SEC_PIN_15 as soon as PIN has been set and PIN is not validated
         if (os_perso_is_pin_set() == BOLOS_TRUE && os_global_pin_is_validated() != BOLOS_TRUE) {
+#else // ! HAVE_BOLOS
+        // for Apps, answer SWO_SEC_PIN_15 as soon as device is onboarded and PIN is not validated
+        if (os_perso_isonboarded() == BOLOS_TRUE && os_global_pin_is_validated() != BOLOS_TRUE) {
+#endif // ! HAVE_BOLOS
           tx_len = 0;
           G_io_apdu_buffer[(tx_len)++] = (SWO_SEC_PIN_15 >> 8) & 0xFF;
           G_io_apdu_buffer[(tx_len)++] = (SWO_SEC_PIN_15) & 0xFF;


### PR DESCRIPTION
## Description

Folliwing fix of FWEO-950, a regression has been introduced, making Apps use the os_perso_is_pin_set() syscall, not available except for UX

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)