### PR TITLE
Xch/crypto helpers

### DIFF
--- a/lib_standard_app/crypto_helpers.c
+++ b/lib_standard_app/crypto_helpers.c
@@ -55,12 +55,12 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_init_privkey_256(
     CX_CHECK(cx_ecfp_init_private_key_no_throw(curve, raw_privkey, length, privkey));
 
 end:
-    explicit_bzero(&raw_privkey, sizeof(raw_privkey));
+    explicit_bzero(raw_privkey, sizeof(raw_privkey));
 
     if (error != CX_OK) {
         // Make sure the caller doesn't use uninitialized data in case
         // the return code is not checked.
-        explicit_bzero(&privkey, sizeof(privkey));
+        explicit_bzero(privkey, sizeof(cx_ecfp_256_private_key_t));
     }
     return error;
 }


### PR DESCRIPTION
## Description

lib_standard_app/crypto_helpers.c: Fix bad cleanup of private key
lib_standard_app/crypto_helpers.c: Add API for 64bytes private key

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

