### PR TITLE
standard_app: allow URL to be defined in app makefile

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -99,7 +99,10 @@ ifneq ($(DISABLE_STANDARD_USB), 1)
 endif
 
 ifneq ($(DISABLE_STANDARD_WEBUSB), 1)
-    DEFINES += HAVE_WEBUSB WEBUSB_URL_SIZE_B=0 WEBUSB_URL=""
+    APP_WEBUSB_URL ?= ""
+    WEBUSB_URL_SIZE_B = $(shell echo -n $(APP_WEBUSB_URL) | wc -c)
+    WEBUSB_URL=$(shell echo -n $(APP_WEBUSB_URL) | sed -e "s/./\\\'\0\\\',/g")
+    DEFINES += HAVE_WEBUSB WEBUSB_URL_SIZE_B=$(WEBUSB_URL_SIZE_B) WEBUSB_URL=$(WEBUSB_URL)
 endif
 
 ifneq ($(DISABLE_STANDARD_BAGL_UX_FLOW), 1)


### PR DESCRIPTION
## Description

Allow app to define only the URL in its makefile

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
