### PR TITLE
Fat: Add anti-bleeding syscalls

### DIFF
--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -299,7 +299,12 @@
 #define SYSCALL_nbgl_front_draw_img_rle_ID                               0x05fa0010
 #ifdef HAVE_DISPLAY_FAST_MODE
 #define SYSCALL_nbgl_screen_update_temperature_ID                        0x01fa0011
-#endif
+#endif // HAVE_DISPLAY_FAST_MODE
+
+#ifdef HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#define SYSCALL_nbgl_screen_config_fast_mode_ID                          0x00fa0012
+#endif // HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#endif // HAVE_NBGL
 
 #ifdef HAVE_BACKGROUND_IMG
 #define SYSCALL_fetch_background_img  	                                 0x01fa0009

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -297,6 +297,8 @@
 #define SYSCALL_nbgl_get_font_ID                                         0x01fa000c
 #define SYSCALL_nbgl_screen_reinit_ID                                    0x00fa000d
 #define SYSCALL_nbgl_front_draw_img_rle_ID                               0x05fa0010
+#ifdef HAVE_DISPLAY_FAST_MODE
+#define SYSCALL_nbgl_screen_update_temperature_ID                        0x01fa0011
 #endif
 
 #ifdef HAVE_BACKGROUND_IMG

--- a/lib_nbgl/include/nbgl_screen.h
+++ b/lib_nbgl/include/nbgl_screen.h
@@ -58,7 +58,10 @@ typedef struct PACKED__ nbgl_screen_s {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
 unsigned int nbgl_screen_reinit(void);
+void nbgl_screen_update_temperature(uint8_t temp_degrees);
+
 void nbgl_screenRedraw(void);
 nbgl_obj_t *nbgl_screenGetTop(void);
 uint8_t nbgl_screenGetCurrentStackSize(void);

--- a/lib_nbgl/include/nbgl_screen.h
+++ b/lib_nbgl/include/nbgl_screen.h
@@ -60,7 +60,14 @@ typedef struct PACKED__ nbgl_screen_s {
  **********************/
 
 unsigned int nbgl_screen_reinit(void);
+
+#ifdef HAVE_DISPLAY_FAST_MODE
 void nbgl_screen_update_temperature(uint8_t temp_degrees);
+#endif // HAVE_DISPLAY_FAST_MODE
+
+#ifdef HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+void nbgl_screen_config_fast_mode(uint8_t fast_mode_setting);
+#endif // HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
 
 void nbgl_screenRedraw(void);
 nbgl_obj_t *nbgl_screenGetTop(void);

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -166,6 +166,17 @@ unsigned int nbgl_screen_reinit(void)
   parameters[0] = 0;
   return SVC_Call(SYSCALL_nbgl_screen_reinit_ID, parameters);
 }
+
+#ifdef HAVE_DISPLAY_FAST_MODE
+void nbgl_screen_update_temperature(uint8_t temp_degrees)
+{
+  unsigned int parameters[1];
+  parameters[0] = (unsigned int) temp_degrees;
+  SVC_Call(SYSCALL_nbgl_screen_update_temperature_ID, parameters);
+  return;
+}
+#endif // HAVE_DISPLAY_FAST_MODE
+
 #endif
 
 void nvm_write ( void * dst_adr, void * src_adr, unsigned int src_len ) {

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -177,6 +177,15 @@ void nbgl_screen_update_temperature(uint8_t temp_degrees)
 }
 #endif // HAVE_DISPLAY_FAST_MODE
 
+#ifdef HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+void nbgl_screen_config_fast_mode(uint8_t fast_mode_setting)
+{
+  unsigned int parameters[1];
+  parameters[0] = (unsigned int) fast_mode_setting;
+  SVC_Call(SYSCALL_nbgl_screen_config_fast_mode_ID, parameters);
+}
+#endif // HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+
 #endif
 
 void nvm_write ( void * dst_adr, void * src_adr, unsigned int src_len ) {


### PR DESCRIPTION
## Description

Add two syscalls to reduce risks of Stax display bleeding.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

