### PR TITLE
Enable os_perso_is_pin_set for non-privileged applications

### DIFF
--- a/include/os_pin.h
+++ b/include/os_pin.h
@@ -34,7 +34,7 @@ SYSCALL PERMISSION(APPLICATION_FLAG_GLOBAL_PIN) unsigned int os_global_pin_retri
  * @return BOLOS_TRUE if the CRC of N_secure_element_nvram_user_sensitive_data
  * is correct and if a PIN value has been written
  */
-SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX)
+SYSCALL
 bolos_bool_t   os_perso_is_pin_set(void);
 
 

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -1414,13 +1414,8 @@ reply_apdu:
 
       // An apdu has been received asynchronously.
       if (G_io_app.apdu_state != APDU_IDLE && G_io_app.apdu_length > 0) {
-#ifdef HAVE_BOLOS
-        // for Bolos UX, answer SWO_SEC_PIN_15 as soon as PIN has been set and PIN is not validated
+        // for Bolos UX and apps, answer SWO_SEC_PIN_15 as soon as PIN has been set and PIN is not validated
         if (os_perso_is_pin_set() == BOLOS_TRUE && os_global_pin_is_validated() != BOLOS_TRUE) {
-#else // ! HAVE_BOLOS
-        // for Apps, answer SWO_SEC_PIN_15 as soon as device is onboarded and PIN is not validated
-        if (os_perso_isonboarded() == BOLOS_TRUE && os_global_pin_is_validated() != BOLOS_TRUE) {
-#endif // ! HAVE_BOLOS
           tx_len = 0;
           G_io_apdu_buffer[(tx_len)++] = (SWO_SEC_PIN_15 >> 8) & 0xFF;
           G_io_apdu_buffer[(tx_len)++] = (SWO_SEC_PIN_15) & 0xFF;


### PR DESCRIPTION
## Description

Make os_perso_is_pin_set available to regular applications when processing default apdu.

## Changes include

- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Breaking changes

Change the syscall's privilege.

