### PR TITLE
remove BAGL-gating on screen syscalls declaration

### DIFF
--- a/include/os_screen.h
+++ b/include/os_screen.h
@@ -18,10 +18,13 @@ SYSCALL void screen_clear(void);
  */
 SYSCALL void screen_update(void);
 
+#ifdef HAVE_BRIGHTNESS_SYSCALL
 /**
  * Set screen brightness
  */
 SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX) void screen_set_brightness(unsigned int percent);
+#endif // HAVE_BRIGHTNESS_SYSCALL
+
 /**
  * Require a specific zone not to be cleared/drawn by any graphic HAL to implement screen overlay
  */

--- a/include/os_screen.h
+++ b/include/os_screen.h
@@ -3,7 +3,6 @@
 #include "bolos_target.h"
 #include "decorators.h"
 
-#ifdef HAVE_BAGL
 #ifdef HAVE_SE_SCREEN
 //SYSCALL void screen_write_frame(unsigned char* framebuffer PLENGTH(BAGL_WIDTH*BAGL_HEIGHT/8));
 /**
@@ -36,4 +35,3 @@ SYSCALL void bagl_hal_draw_bitmap_within_rect(int x, int y, unsigned int width, 
  */
 SYSCALL void bagl_hal_draw_rect(unsigned int color, int x, int y, unsigned int width, unsigned int height);
 #endif // HAVE_SE_SCREEN
-#endif // HAVE_BAGL


### PR DESCRIPTION
## Description

Screen drawing syscalls like `bagl_hal_draw_bitmap_within_rect`, ... were gated by `HAVE_BAGL` and `HAVE_SE_SCREEN` in `os_screen.h` whereas the syscalls implementation in `syscalls.c` only use `HAVE_SE_SCREEN`.
`HAVE_BAGL` was removed as the syscalls are there whether we use this define or not, and also the `set_brightness` syscall was gated to match `syscalls.c`.

## Changes include

- [x] Other (for changes that might not fit in any category)

