### PR TITLE
Delete `os_ux_result` syscall

### DIFF
--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -153,7 +153,6 @@
 #define SYSCALL_os_registry_count_ID                               0x0000005f
 #define SYSCALL_os_registry_get_ID                                 0x02000122
 #define SYSCALL_os_ux_ID                                           0x01000064
-#define SYSCALL_os_ux_result_ID                                    0x01000065
 #define SYSCALL_os_lib_call_ID                                     0x01000067
 #define SYSCALL_os_lib_end_ID                                      0x00000068
 #define SYSCALL_os_flags_ID                                        0x0000006a

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1252,14 +1252,6 @@ unsigned int os_ux ( bolos_ux_params_t * params ) {
   parameters[1] = 0;
   return (unsigned int) SVC_Call(SYSCALL_os_ux_ID, parameters);
 }
-
-void os_ux_result ( bolos_ux_params_t * params ) {
-  unsigned int parameters[2];
-  parameters[0] = (unsigned int)params;
-  parameters[1] = 0;
-  SVC_Call(SYSCALL_os_ux_result_ID, parameters);
-  return;
-}
 #endif // !defined(APP_UX)
 
 void os_lib_call ( unsigned int * call_parameters ) {


### PR DESCRIPTION
## Description

Delete `os_ux_result` syscall.
From @apaillier-ledger tests, no official app is impacted by this change.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

The `os_ux_result` syscall is not available anymore.
