### PR TITLE
Force enable seproxyhal in case of a debug build in the standard app …

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -91,11 +91,12 @@ ifneq ($(DISABLE_STANDARD_SNPRINTF), 1)
     DEFINES += HAVE_SPRINTF HAVE_SNPRINTF_FORMAT_U
 endif
 
-ifneq ($(TARGET_NAME),TARGET_NANOS)
+ifneq ($(DEBUG), 0)
     # Since the PRINTF implementation uses the USB code
-    ifneq ($(DEBUG), 0)
+    ifneq ($(TARGET_NAME),TARGET_NANOS)
         DISABLE_STANDARD_USB = 0
     endif
+    DISABLE_SEPROXYHAL = 0
 endif
 
 ifneq ($(DISABLE_STANDARD_USB), 1)


### PR DESCRIPTION
## Description

Would prevent the compilation of debug builds of apps with DISABLE_SEPROXYHAL=1.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)