### PR TITLE
Fix APPNAME handling in standard app Makefile

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -75,7 +75,8 @@ endif
 #                          STANDARD DEFINES                         #
 #####################################################################
 DEFINES += $(DEFINES_LIB)
-DEFINES += APPNAME=\"$(APPNAME)\"
+# Added directly as a CFLAG because it might contain spaces
+CFLAGS += -DAPPNAME=\"$(APPNAME)\"
 DEFINES += APPVERSION=\"$(APPVERSION)\"
 DEFINES += MAJOR_VERSION=$(APPVERSION_M) MINOR_VERSION=$(APPVERSION_N) PATCH_VERSION=$(APPVERSION_P)
 DEFINES += IO_HID_EP_LENGTH=64


### PR DESCRIPTION
## Description

Spaces would not be handled properly in the CFLAGS given to the compiler when added with `DEFINES`, it would be visibly wrong when seen on the Stax app home screen.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)