### PR TITLE
Mask backspace in keyboard when disabled in keyMask

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -384,7 +384,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard)
     else {
         rectArea.x0 += (BACKSPACE_KEY_WIDTH_LETTERS_ONLY - rectArea.width) / 2;
     }
-    nbgl_drawIcon(&rectArea, BLACK, &C_backspace32px);
+    nbgl_drawIcon(&rectArea, (keyboard->keyMask & (1 << 26)) ? WHITE : BLACK, &C_backspace32px);
 
     // 4th row, only in Full mode
     if (!keyboard->lettersOnly) {


### PR DESCRIPTION
## Description

The goal is to be able to hide/disable backspace in keyboard when disabled in keyMask

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
