### PR TITLE
Fat: Fix backspace and space drawing in keyboard

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -482,7 +482,7 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard)
     rectArea.y0     = keyboard->obj.area.y0 + KEYBOARD_KEY_HEIGHT * 2
                   + (KEYBOARD_KEY_HEIGHT - rectArea.height) / 2;
     rectArea.x0 += (BACKSPACE_KEY_WIDTH_DIGITS - rectArea.width) / 2;
-    nbgl_frontDrawImage(&rectArea, (uint8_t *) C_backspace32px.bitmap, NO_TRANSFORMATION, BLACK);
+    nbgl_drawIcon(&rectArea, BLACK, &C_backspace32px);
 
     // 4th row
     rectArea.x0
@@ -491,10 +491,8 @@ static void keyboardDrawDigits(nbgl_keyboard_t *keyboard)
     nbgl_drawText(&rectArea, "ABC", 3, BAGL_FONT_INTER_REGULAR_24px_1bpp, BLACK);
 
     rectArea.x0 = SWITCH_KEY_WIDTH + (SPACE_KEY_WIDTH - C_space32px.width) / 2;
-    nbgl_frontDrawImage(&rectArea,
-                        (uint8_t *) C_space32px.bitmap,
-                        NO_TRANSFORMATION,
-                        (keyboard->keyMask & (1 << SPACE_KEY_INDEX)) ? WHITE : BLACK);
+    nbgl_drawIcon(
+        &rectArea, (keyboard->keyMask & (1 << SPACE_KEY_INDEX)) ? WHITE : BLACK, &C_space32px);
 }
 
 static void keyboardDraw(nbgl_keyboard_t *keyboard)


### PR DESCRIPTION
Fix cases where RLE encoded glyphs were rendered with the direct drawing functions, leading to glitches.

## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
