### PR TITLE
Deprecate cx_ecdsa_verify

### DIFF
--- a/lib_cxng/include/lcx_ecdsa.h
+++ b/lib_cxng/include/lcx_ecdsa.h
@@ -136,35 +136,16 @@ bool cx_ecdsa_verify_no_throw(const cx_ecfp_public_key_t *pukey,
                               size_t                      sig_len);
 
 /**
- * @brief   Verifies an ECDSA signature according to ECDSA specification.
- *
- * @param[in] pukey    Public key initialized with #cx_ecfp_init_public_key_no_throw.
- *
- * @param[in] mode     ECDSA mode. This parameter is not used.
- *
- * @param[in] hashID   Message digest algorithm identifier.
- *                     This parameter is not used.
- *
- * @param[in] hash     Digest of the message to be verified.
- *                     The length of *hash* must be smaller than the group order size.
- *                     Otherwise it is truncated.
- *
- * @param[in] hash_len Length of the digest in octets.
- *
- * @param[in] sig      Pointer to the signature encoded in TLV: **30 || L || 02 || Lr || r || 02 ||
- * Ls || s**
- *
- * @param[in] sig_len  Length of the signature in octets.
- *
- * @return             1 if the signature is verified, 0 otherwise.
+ * @deprecated
+ * See #cx_ecdsa_verify_no_throw
  */
-static inline bool cx_ecdsa_verify(const cx_ecfp_public_key_t *pukey,
-                                   int                         mode,
-                                   cx_md_t                     hashID,
-                                   const unsigned char        *hash,
-                                   unsigned int                hash_len,
-                                   const unsigned char        *sig,
-                                   unsigned int                sig_len)
+DEPRECATED static inline bool cx_ecdsa_verify(const cx_ecfp_public_key_t *pukey,
+                                              int                         mode,
+                                              cx_md_t                     hashID,
+                                              const unsigned char        *hash,
+                                              unsigned int                hash_len,
+                                              const unsigned char        *sig,
+                                              unsigned int                sig_len)
 {
     UNUSED(mode);
     UNUSED(hashID);


### PR DESCRIPTION
## Description

Deprecate `cx_ecdsa_verify`, as `cx_ecdsa_verify_no_throw` exists

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [X] Other (for changes that might not fit in any category)

