### PR TITLE
Update the way ELF metadata sections are added.

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -43,10 +43,17 @@ endif
 ifeq ($(SDK_HASH),)
 SDK_HASH := "None"
 endif
-# Expose API_LEVEL, SDK_VERSION and SDK_HASH to the app.
+
+# APPNAME exposed to the app as a CFLAG because it might contain spaces
+CFLAGS += -DAPPNAME=\"$(APPNAME)\"
+
+# API_LEVEL exposed to the app as an integer
 DEFINES += API_LEVEL=$(API_LEVEL)
-DEFINES += SDK_VERSION=\"$(SDK_VERSION)\"
-DEFINES += SDK_HASH=\"$(SDK_HASH)\"
+
+# Define list of other items to be exposed to the app as strings
+# TARGET_ID is not in this list : it is already defined in bolos_target.h.
+APP_METADATA_LIST := TARGET TARGET_NAME APPVERSION SDK_NAME SDK_VERSION SDK_HASH
+DEFINES += $(foreach item,$(APP_METADATA_LIST), $(item)=\"$($(item))\")
 
 # extra load parameters for loadApp script
 ifneq ($(SCP_PRIVKEY),)

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -111,15 +111,6 @@ $(BIN_DIR)/app.elf: $(LINK_DEPENDENCIES)
 	$(L)$(call link_cmdline,$(OBJECT_FILES) $(LDLIBS),$(BIN_DIR)/app.elf)
 	$(L)$(GCCPATH)arm-none-eabi-objcopy -O ihex -S $(BIN_DIR)/app.elf $(BIN_DIR)/app.hex
 	$(L)$(GCCPATH)arm-none-eabi-objdump -S -d $(BIN_DIR)/app.elf > $(DBG_DIR)/app.asm
-	$(L)$(call objcopy_add_section_cmdline,$(TARGET), ledger.target)
-	$(L)$(call objcopy_add_section_cmdline,$(TARGET_NAME), ledger.target_name)
-	$(L)$(call objcopy_add_section_cmdline,$(TARGET_ID), ledger.target_id)
-	$(L)$(call objcopy_add_section_cmdline,$(APPNAME), ledger.app_name)
-	$(L)$(call objcopy_add_section_cmdline,$(APPVERSION), ledger.app_version)
-	$(L)$(call objcopy_add_section_cmdline,$(API_LEVEL), ledger.api_level)
-	$(L)$(call objcopy_add_section_cmdline,$(SDK_NAME), ledger.sdk_name)
-	$(L)$(call objcopy_add_section_cmdline,$(SDK_VERSION), ledger.sdk_version)
-	$(L)$(call objcopy_add_section_cmdline,$(SDK_HASH), ledger.sdk_hash)
 
 # This targets are generated along $(OBJ_DIR)/app.elf but we can't make them co-target
 # otherwise building with `make -j` fails due to multiple threads running simultaneously
@@ -159,14 +150,6 @@ endif
 cc_cmdline = $(CC) -c $(CFLAGS) -MMD -MT $(OBJ_DIR)/$(basename $(notdir $(4))).o -MF $(DEP_DIR)/$(basename $(notdir $(4))).d $(addprefix -D,$(2)) $(addprefix -I,$(1)) -o $(4) $(3)
 
 as_cmdline = $(AS) -c $(AFLAGS) $(addprefix -D,$(2)) $(addprefix -I,$(1)) -o $(4) $(3)
-
-# objcopy_add_section_cmdline(data,section_name)
-TMPFILE := $(shell mktemp)
-objcopy_add_section_cmdline = echo $(1) > $(TMPFILE) && \
-    $(GCCPATH)arm-none-eabi-objcopy --add-section $(2)="$(TMPFILE)" \
-	--set-section-flags $(2)=noload,readonly \
-	$(BIN_DIR)/app.elf $(BIN_DIR)/app.elf && \
-	rm $(TMPFILE)
 
 ### END GCC COMPILER RULES
 

--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -75,9 +75,6 @@ endif
 #                          STANDARD DEFINES                         #
 #####################################################################
 DEFINES += $(DEFINES_LIB)
-# Added directly as a CFLAG because it might contain spaces
-CFLAGS += -DAPPNAME=\"$(APPNAME)\"
-DEFINES += APPVERSION=\"$(APPVERSION)\"
 DEFINES += MAJOR_VERSION=$(APPVERSION_M) MINOR_VERSION=$(APPVERSION_N) PATCH_VERSION=$(APPVERSION_P)
 DEFINES += IO_HID_EP_LENGTH=64
 

--- a/src/app_metadata.c
+++ b/src/app_metadata.c
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *   Ledger - Secure firmware
+ *   (c) 2023 Ledger
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#if !defined(HAVE_BOLOS)
+
+#include <stdint.h>
+
+#if !defined(RUST_APP)
+#include "bolos_target.h"
+#endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
+#define STR_IMPL_(x) #x
+#define STRINGIFY(x) STR_IMPL_(x)
+
+#define CREATE_METADATA_STRING_ITEM(ITEM_NAME, section_name) \
+    __attribute__((section(".ledger." #section_name))) const char section_name[] = ITEM_NAME;
+
+#define CREATE_METADATA_STRING_ITEM_FROM_INT(ITEM_NAME, section_name)            \
+    __attribute__((section(".ledger." #section_name))) const char section_name[] \
+        = STRINGIFY(ITEM_NAME);
+
+#if defined(TARGET)
+CREATE_METADATA_STRING_ITEM(TARGET, target)
+#endif
+
+#if defined(TARGET_NAME)
+CREATE_METADATA_STRING_ITEM(TARGET_NAME, target_name)
+#endif
+
+#if defined(TARGET_ID)
+CREATE_METADATA_STRING_ITEM_FROM_INT(TARGET_ID, target_id)
+#endif
+
+#if defined(APPNAME)
+CREATE_METADATA_STRING_ITEM(APPNAME, app_name)
+#endif
+
+#if defined(APPVERSION)
+CREATE_METADATA_STRING_ITEM(APPVERSION, app_version)
+#endif
+
+#if defined(API_LEVEL)
+CREATE_METADATA_STRING_ITEM_FROM_INT(API_LEVEL, api_level)
+#endif
+
+#if defined(SDK_NAME)
+CREATE_METADATA_STRING_ITEM(SDK_NAME, sdk_name)
+#endif
+
+#if defined(SDK_VERSION)
+CREATE_METADATA_STRING_ITEM(SDK_VERSION, sdk_version)
+#endif
+
+#if defined(SDK_HASH)
+CREATE_METADATA_STRING_ITEM(SDK_HASH, sdk_hash)
+#endif
+
+#pragma GCC diagnostic pop
+
+#endif

--- a/target/nanos/script.ld
+++ b/target/nanos/script.ld
@@ -192,6 +192,18 @@ SECTIONS
   .debug_funcnames 0 : { *(.debug_funcnames) }
   .debug_typenames 0 : { *(.debug_typenames) }
   .debug_varnames  0 : { *(.debug_varnames) }
+
+  .ARM.attributes : { *(.ARM.attributes) }
+
+  .ledger.target (INFO): { KEEP(*(.ledger.target)) }
+  .ledger.target_name (INFO): { KEEP(*(.ledger.target_name)) }
+  .ledger.target_id (INFO): { KEEP(*(.ledger.target_id)) }
+  .ledger.app_name (INFO): { KEEP(*(.ledger.app_name)) }
+  .ledger.app_version (INFO): { KEEP(*(.ledger.app_version)) }
+  .ledger.api_level (INFO): { KEEP(*(.ledger.api_level)) }
+  .ledger.sdk_name (INFO): { KEEP(*(.ledger.sdk_name)) }
+  .ledger.sdk_version (INFO): { KEEP(*(.ledger.sdk_version)) }
+  .ledger.sdk_hash (INFO): { KEEP(*(.ledger.sdk_hash)) }
 }
 
 PROVIDE(_nvram = ABSOLUTE(_nvram_start));

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -168,6 +168,18 @@ SECTIONS
   .debug_funcnames 0 : { *(.debug_funcnames) }
   .debug_typenames 0 : { *(.debug_typenames) }
   .debug_varnames  0 : { *(.debug_varnames) }
+
+  .ARM.attributes : { *(.ARM.attributes) }
+
+  .ledger.target (INFO): { KEEP(*(.ledger.target)) }
+  .ledger.target_name (INFO): { KEEP(*(.ledger.target_name)) }
+  .ledger.target_id (INFO): { KEEP(*(.ledger.target_id)) }
+  .ledger.app_name (INFO): { KEEP(*(.ledger.app_name)) }
+  .ledger.app_version (INFO): { KEEP(*(.ledger.app_version)) }
+  .ledger.api_level (INFO): { KEEP(*(.ledger.api_level)) }
+  .ledger.sdk_name (INFO): { KEEP(*(.ledger.sdk_name)) }
+  .ledger.sdk_version (INFO): { KEEP(*(.ledger.sdk_version)) }
+  .ledger.sdk_hash (INFO): { KEEP(*(.ledger.sdk_hash)) }
 }
 
 PROVIDE(_nvram = ABSOLUTE(_nvram_start));

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -179,6 +179,18 @@ SECTIONS
   .debug_funcnames 0 : { *(.debug_funcnames) }
   .debug_typenames 0 : { *(.debug_typenames) }
   .debug_varnames  0 : { *(.debug_varnames) }
+
+  .ARM.attributes : { *(.ARM.attributes) }
+
+  .ledger.target (INFO): { KEEP(*(.ledger.target)) }
+  .ledger.target_name (INFO): { KEEP(*(.ledger.target_name)) }
+  .ledger.target_id (INFO): { KEEP(*(.ledger.target_id)) }
+  .ledger.app_name (INFO): { KEEP(*(.ledger.app_name)) }
+  .ledger.app_version (INFO): { KEEP(*(.ledger.app_version)) }
+  .ledger.api_level (INFO): { KEEP(*(.ledger.api_level)) }
+  .ledger.sdk_name (INFO): { KEEP(*(.ledger.sdk_name)) }
+  .ledger.sdk_version (INFO): { KEEP(*(.ledger.sdk_version)) }
+  .ledger.sdk_hash (INFO): { KEEP(*(.ledger.sdk_hash)) }
 }
 
 PROVIDE(_nvram = ABSOLUTE(_nvram_start));

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -169,6 +169,18 @@ SECTIONS
   .debug_funcnames 0 : { *(.debug_funcnames) }
   .debug_typenames 0 : { *(.debug_typenames) }
   .debug_varnames  0 : { *(.debug_varnames) }
+
+  .ARM.attributes : { *(.ARM.attributes) }
+
+  .ledger.target (INFO): { KEEP(*(.ledger.target)) }
+  .ledger.target_name (INFO): { KEEP(*(.ledger.target_name)) }
+  .ledger.target_id (INFO): { KEEP(*(.ledger.target_id)) }
+  .ledger.app_name (INFO): { KEEP(*(.ledger.app_name)) }
+  .ledger.app_version (INFO): { KEEP(*(.ledger.app_version)) }
+  .ledger.api_level (INFO): { KEEP(*(.ledger.api_level)) }
+  .ledger.sdk_name (INFO): { KEEP(*(.ledger.sdk_name)) }
+  .ledger.sdk_version (INFO): { KEEP(*(.ledger.sdk_version)) }
+  .ledger.sdk_hash (INFO): { KEEP(*(.ledger.sdk_hash)) }
 }
 
 PROVIDE(_nvram = ABSOLUTE(_nvram_start));


### PR DESCRIPTION
## Description

Update the way elf metadata sections are created. Currently we use `objcopy` to add section to an existing file, after compilation / linking.

The proposed way uses a source file that puts variables at the required sections. We don't need an external tool anymore and we could use this file for rust apps as well (as long as there are proper defines for the items).

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)
