### PR TITLE
[fix] Unused arguments in lib_stusb_impl/usbd_impl.c:USBD_HID_DataOut_impl when HAVE_USB_HIDKBD macro is set

### DIFF
--- a/lib_stusb_impl/usbd_impl.c
+++ b/lib_stusb_impl/usbd_impl.c
@@ -1018,8 +1018,14 @@ uint8_t USBD_HID_DataIn_impl(USBD_HandleTypeDef *pdev, uint8_t epnum)
 
 uint8_t USBD_HID_DataOut_impl(USBD_HandleTypeDef *pdev,
                               uint8_t             epnum,
-                              uint8_t            *buffer,
-                              apdu_buffer_t      *apdu_buf)
+#ifndef HAVE_USB_HIDKBD
+                              uint8_t       *buffer,
+                              apdu_buffer_t *apdu_buf
+#else
+                              __attribute__((unused)) uint8_t       *buffer,
+                              __attribute__((unused)) apdu_buffer_t *apdu_buf
+#endif  // HAVE_USB_HIDKBD
+)
 {
     // only the data hid endpoint will receive data
     switch (epnum) {


### PR DESCRIPTION
## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
