### PR TITLE
Fix icon2glyph script

### DIFF
--- a/lib_nbgl/tools/icon2glyph.py
+++ b/lib_nbgl/tools/icon2glyph.py
@@ -113,13 +113,14 @@ def image_to_packed_buffer(img, bpp: int):
 # Compressions functions
 
 
-def rle_compress(im: Image, bpp) -> bytes:
+def rle_compress(im: Image, bpp) -> Optional[bytes]:
     """
     Run RLE compression on input image
     """
     if bpp == 1:
         return Rle1bpp.rle_1bpp(im)[1]
     elif bpp == 2:
+        # No compression supports BPP2
         return None
     elif bpp == 4:
         return Rle4bpp.rle_4bpp(im)[1]
@@ -167,6 +168,9 @@ def compress(im: Image, bpp) -> Tuple[NbglFileCompression, bytes]:
     min_comp = NbglFileCompression.NoCompression
 
     for compression, buffer in compressed_bufs.items():
+        if buffer is None:
+            continue
+
         final_length = len(buffer)
         if compression != NbglFileCompression.NoCompression:
             final_length += NBGL_IMAGE_FILE_HEADER_SIZE
@@ -341,7 +345,7 @@ def main():
 
         except Exception as e:
             sys.stderr.write(
-                "Exception while processing {} {}\n".format(file), e)
+                    "Exception while processing {}: {}\n".format(file, e))
             try:
                 traceback.print_tb()
             except:

--- a/lib_nbgl/tools/nbgl_rle.py
+++ b/lib_nbgl/tools/nbgl_rle.py
@@ -147,7 +147,7 @@ class Rle4bpp():
         return result
 
     @classmethod
-    def rle_4bpp(cls, img) -> bytes:
+    def rle_4bpp(cls, img) -> Tuple[int, bytes]:
         bpp = 4
         pixels = cls.image_to_pixels(img, bpp)
         occurrences = cls.pixels_to_occurrences(pixels)
@@ -314,7 +314,7 @@ class Rle1bpp():
 
     # -------------------------------------------------------------------------
     @classmethod
-    def rle_1bpp(cls, img) -> bytes:
+    def rle_1bpp(cls, img) -> Tuple[int, bytes]:
         """
         Input: image to compress
         - convert the picture to an array of pixels


### PR DESCRIPTION
icon2glyph.py crashed when encountering a 2BPP image

## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

