### PR TITLE
Add `io_seproxyhal_enable_io()` function

### DIFF
--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -291,6 +291,7 @@ void io_seproxyhal_setup_ticker(unsigned int interval_ms);
 void io_seproxyhal_power_off(bool criticalBattery);
 void io_seproxyhal_se_reset(void);
 void io_seproxyhal_disable_io(void);
+void io_seproxyhal_enable_io(void);
 
 #ifdef HAVE_PIEZO_SOUND
 typedef enum tune_index_e {

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -1111,10 +1111,24 @@ static const unsigned char seph_io_usb_disconnect[] = {
     1,
     SEPROXYHAL_TAG_USB_CONFIG_DISCONNECT,
 };
+
 void io_seproxyhal_disable_io(void)
 {
     // usb off
     io_seproxyhal_spi_send(seph_io_usb_disconnect, sizeof(seph_io_usb_disconnect));
+}
+
+static const unsigned char seph_io_usb_connect[] = {
+    SEPROXYHAL_TAG_USB_CONFIG,
+    0,
+    1,
+    SEPROXYHAL_TAG_USB_CONFIG_CONNECT,
+};
+
+void io_seproxyhal_enable_io(void)
+{
+    // usb on
+    io_seproxyhal_spi_send(seph_io_usb_connect, sizeof(seph_io_usb_connect));
 }
 
 void io_seproxyhal_backlight(unsigned int flags, unsigned int backlight_percentage)


### PR DESCRIPTION
`io_seproxyhal_enable_io()` and `io_seproxyhal_disable_io()` allow to turn on and off USB connection.

## Description

Add a function needed by BOLOS.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

