### PR TITLE
Add UX specific syscall to share time with OS

### DIFF
--- a/include/os_time.h
+++ b/include/os_time.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "decorators.h"
+
+// UX specific syscall to share time with dashboard task
+SYSCALL void os_set_ux_time_ms(unsigned int ux_ms);

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -189,6 +189,7 @@
 #define SYSCALL_os_deny_protected_flash_ID                   0x00000091
 #define SYSCALL_os_allow_protected_ram_ID                    0x00000092
 #define SYSCALL_os_deny_protected_ram_ID                     0x00000093
+#define SYSCALL_os_set_ux_time_ms_ID                         0x010000a2
 
 #ifdef HAVE_CUSTOM_CA_DETAILS_IN_SETTINGS
 #define SYSCALL_os_bolos_custom_ca_get_info_ID 0x01000CA0

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1281,6 +1281,14 @@ void os_perso_set_onboarding_status(unsigned int state, unsigned int count, unsi
     return;
 }
 
+void os_set_ux_time_ms(unsigned int ux_ms)
+{
+    unsigned int parameters[1];
+    parameters[0] = (unsigned int) ux_ms;
+    SVC_Call(SYSCALL_os_set_ux_time_ms_ID, parameters);
+    return;
+}
+
 void os_perso_derive_node_bip32(cx_curve_t          curve,
                                 const unsigned int *path,
                                 unsigned int        pathLength,


### PR DESCRIPTION
## Description

Add `os_set_ux_time_ms` syscall dedicated to the UX app.
The goal is to share time to the OS layer, in order to implement actions based on time.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

