### PR TITLE
script.ld/Makefile: Use the maximum ram size available for the stack

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -151,7 +151,14 @@ debug/app.map debug/app.asm: debug/app.%: $(DBG_DIR)/app.%
 # link_cmdline(objects,dest)		Macro that is used to format arguments for the linker
 link_cmdline = $(LD) $(LDFLAGS) -o $(2) $(1)
 ifneq ($(APP_STACK_SIZE),)
-link_cmdline += -Wl,--defsym=stack_size=$(APP_STACK_SIZE)
+ifneq ($(ENABLE_SDK_WERROR),0)
+$(error Deprecated APP_STACK_SIZE define, use APP_STACK_MIN_SIZE if really needed)
+else
+$(warning Deprecated APP_STACK_SIZE define, use APP_STACK_MIN_SIZE if really needed)
+endif
+endif
+ifneq ($(APP_STACK_MIN_SIZE),)
+link_cmdline += -Wl,--defsym=stack_min_size=$(APP_STACK_MIN_SIZE)
 endif
 
 # cc_cmdline(include,defines,src,dest)	Macro that is used to format arguments for the compiler

--- a/target/nanos/script.ld
+++ b/target/nanos/script.ld
@@ -29,7 +29,7 @@ MEMORY
 }
 
 PAGE_SIZE  = 64;
-STACK_SIZE = DEFINED(stack_size) ? stack_size : 1024;
+STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1024;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
 /*
@@ -125,15 +125,14 @@ SECTIONS
     app_stack_canary = .;
     PROVIDE(app_stack_canary = .);
     . += 4;
-    _stack_validation = .;
-    . = _stack_validation + STACK_SIZE;
-    _stack = ABSOLUTE(END_STACK) - STACK_SIZE;
-    PROVIDE( _stack = ABSOLUTE(END_STACK) - STACK_SIZE);
+    _stack = .;
+    PROVIDE( _stack = .);
     _estack = ABSOLUTE(END_STACK);
     PROVIDE( _estack = ABSOLUTE(END_STACK) );
 
   } > SRAM = 0x00
 
+  ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 
 
   /****************************************************************/

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -30,7 +30,7 @@ MEMORY
 }
 
 PAGE_SIZE  = 512;
-STACK_SIZE = 1500;
+STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
 ENTRY(main);
@@ -113,14 +113,14 @@ SECTIONS
     app_stack_canary = .;
     PROVIDE(app_stack_canary = .);
     . += 4;
-    _stack_validation = .;
-    . = _stack_validation + STACK_SIZE;
-    _stack = ABSOLUTE(END_STACK) - STACK_SIZE;
-    PROVIDE( _stack = ABSOLUTE(END_STACK) - STACK_SIZE);
+    _stack = .;
+    PROVIDE( _stack = .);
     _estack = ABSOLUTE(END_STACK);
     PROVIDE( _estack = ABSOLUTE(END_STACK) );
 
   } > SRAM = 0x00
+
+  ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -30,7 +30,7 @@ MEMORY
 }
 
 PAGE_SIZE  = 256;
-STACK_SIZE = 1500;
+STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
 ENTRY(main);
@@ -124,14 +124,14 @@ SECTIONS
     app_stack_canary = .;
     PROVIDE(app_stack_canary = .);
     . += 4;
-    _stack_validation = .;
-    . = _stack_validation + STACK_SIZE;
-    _stack = ABSOLUTE(END_STACK) - STACK_SIZE;
-    PROVIDE( _stack = ABSOLUTE(END_STACK) - STACK_SIZE);
+    _stack = .;
+    PROVIDE( _stack = .);
     _estack = ABSOLUTE(END_STACK);
     PROVIDE( _estack = ABSOLUTE(END_STACK) );
 
   } > SRAM
+
+  ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -30,7 +30,7 @@ MEMORY
 }
 
 PAGE_SIZE  = 512;
-STACK_SIZE = 1500;
+STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
 ENTRY(main);
@@ -114,14 +114,14 @@ SECTIONS
     app_stack_canary = .;
     PROVIDE(app_stack_canary = .);
     . += 4;
-    _stack_validation = .;
-    . = _stack_validation + STACK_SIZE;
-    _stack = ABSOLUTE(END_STACK) - STACK_SIZE;
-    PROVIDE( _stack = ABSOLUTE(END_STACK) - STACK_SIZE);
+    _stack = .;
+    PROVIDE( _stack = .);
     _estack = ABSOLUTE(END_STACK);
     PROVIDE( _estack = ABSOLUTE(END_STACK) );
 
   } > SRAM = 0x00
+
+  ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 
   /****************************************************************/
   /* DEBUG                                                        */


### PR DESCRIPTION
## Description

script.ld/Makefile: Use the maximum ram size available for the stack
APP_STACK_SIZE is now ignored, and replaced by APP_STACK_MIN_SIZE.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

