### PR TITLE
Make bagl_hal_draw_bitmap_within_rect to return errors instead of throwing

### DIFF
--- a/include/os_screen.h
+++ b/include/os_screen.h
@@ -2,6 +2,7 @@
 
 #include "bolos_target.h"
 #include "decorators.h"
+#include "os_types.h"
 
 #ifdef HAVE_BAGL
 #ifdef HAVE_SE_SCREEN
@@ -34,16 +35,16 @@ SYSCALL void screen_set_keepout(unsigned int x,
  * Draw the given bitmap, with the given colors and position into the screen buffer. Don't update
  * the screen driver.
  */
-SYSCALL void bagl_hal_draw_bitmap_within_rect(int                        x,
-                                              int                        y,
-                                              unsigned int               width,
-                                              unsigned int               height,
-                                              unsigned int               color_count,
-                                              const unsigned int *colors PLENGTH(color_count * 4),
-                                              unsigned int               bit_per_pixel,
-                                              const unsigned char *bitmap
-                                                           PLENGTH(1 + bitmap_length_bits / 8),
-                                              unsigned int bitmap_length_bits);
+SYSCALL bolos_err_t
+bagl_hal_draw_bitmap_within_rect(int                         x,
+                                 int                         y,
+                                 unsigned int                width,
+                                 unsigned int                height,
+                                 unsigned int                color_count,
+                                 const unsigned int *colors  PLENGTH(color_count * 4),
+                                 unsigned int                bit_per_pixel,
+                                 const unsigned char *bitmap PLENGTH(1 + bitmap_length_bits / 8),
+                                 unsigned int                bitmap_length_bits);
 /**
  * Fill a rectangle with a given color in the screen buffer, but don't update the screen driver.
  */

--- a/include/os_types.h
+++ b/include/os_types.h
@@ -5,6 +5,8 @@
 
 typedef uint8_t bolos_bool_t;
 
+typedef uint32_t bolos_err_t;
+
 #define BOLOS_TRUE  0xaa
 #define BOLOS_FALSE 0x55
 

--- a/lib_bagl/include/bagl.h
+++ b/lib_bagl/include/bagl.h
@@ -20,6 +20,9 @@
 #ifndef BAGL_H_
 #define BAGL_H_
 
+#include "decorators.h"
+#include "os_types.h"
+
 #define BAGL_NOFILL  0
 #define BAGL_FILL    1
 #define BAGL_OUTLINE 2
@@ -338,15 +341,15 @@ void bagl_set_glyph_array(const bagl_glyph_array_entry_t *array, unsigned int co
 
 // --------------------------------------------------------------------------------------
 // start drawing a bitmap in the given area
-void bagl_hal_draw_bitmap_within_rect(int                  x,
-                                      int                  y,
-                                      unsigned int         width,
-                                      unsigned int         height,
-                                      unsigned int         color_count,
-                                      const unsigned int  *colors,
-                                      unsigned int         bit_per_pixel,
-                                      const unsigned char *bitmap,
-                                      unsigned int         bitmap_length_bits);
+WARN_UNUSED_RESULT bolos_err_t bagl_hal_draw_bitmap_within_rect(int                  x,
+                                                                int                  y,
+                                                                unsigned int         width,
+                                                                unsigned int         height,
+                                                                unsigned int         color_count,
+                                                                const unsigned int  *colors,
+                                                                unsigned int         bit_per_pixel,
+                                                                const unsigned char *bitmap,
+                                                                unsigned int bitmap_length_bits);
 // continue drawing the bitmap in the previously setup area, take care to use the same bpp
 void bagl_hal_draw_bitmap_continue(unsigned int         bit_per_pixel,
                                    const unsigned char *bitmap,

--- a/lib_bagl/src/bagl.c
+++ b/lib_bagl/src/bagl.c
@@ -553,15 +553,20 @@ int bagl_draw_string(unsigned short font_id,
 
             // chars are storred LSB to MSB in each char, packed chars. horizontal scan
             if (ch_bitmap) {
-                bagl_hal_draw_bitmap_within_rect(xx + ch_offset_x,
-                                                 ch_y + ch_offset_y,
-                                                 ch_width,
-                                                 ch_height,
-                                                 (1 << bpp),
-                                                 colors,
-                                                 bpp,
-                                                 ch_bitmap,
-                                                 ch_bits);
+                bolos_err_t ret = bagl_hal_draw_bitmap_within_rect(xx + ch_offset_x,
+                                                                   ch_y + ch_offset_y,
+                                                                   ch_width,
+                                                                   ch_height,
+                                                                   (1 << bpp),
+                                                                   colors,
+                                                                   bpp,
+                                                                   ch_bitmap,
+                                                                   ch_bits);
+                if (SWO_SUCCESS != ret) {
+                    // Exiting as early as error is detected can permit to see
+                    // on screen that there is an issue drawing some text
+                    return xx;
+                }
             }
             else {
                 bagl_hal_draw_rect(bgcolor, xx, ch_y, ch_width, ch_height);
@@ -1126,7 +1131,7 @@ void bagl_draw_with_context(const bagl_component_t *component,
 
                 // center glyph in rect
                 // draw the glyph from the bitmap using the context for colors
-                bagl_hal_draw_bitmap_within_rect(
+                bolos_err_t ret = bagl_hal_draw_bitmap_within_rect(
                     component->x + (component->width / 2 - glyph->width / 2),
                     component->y + (component->height / 2 - glyph->height / 2),
                     glyph->width,
@@ -1136,6 +1141,9 @@ void bagl_draw_with_context(const bagl_component_t *component,
                     glyph->bits_per_pixel,
                     glyph->bitmap,
                     glyph->bits_per_pixel * (glyph->width * glyph->height));
+                if (SWO_SUCCESS != ret) {
+                    return;
+                }
             }
             else {
                 // context: <bitperpixel> [color_count*4 bytes (LE encoding)] <icon bitmap (raw
@@ -1153,15 +1161,19 @@ void bagl_draw_with_context(const bagl_component_t *component,
                 }
 
                 // draw the glyph from the bitmap using the context for colors
-                bagl_hal_draw_bitmap_within_rect(component->x,
-                                                 component->y,
-                                                 component->width,
-                                                 component->height,
-                                                 1 << bpp,
-                                                 colors,
-                                                 bpp,
-                                                 ((unsigned char *) context) + 1 + (1 << bpp) * 4,
-                                                 bpp * (component->width * component->height));
+                bolos_err_t ret = bagl_hal_draw_bitmap_within_rect(
+                    component->x,
+                    component->y,
+                    component->width,
+                    component->height,
+                    1 << bpp,
+                    colors,
+                    bpp,
+                    ((unsigned char *) context) + 1 + (1 << bpp) * 4,
+                    bpp * (component->width * component->height));
+                if (SWO_SUCCESS != ret) {
+                    return;
+                }
             }
             break;
 #endif  // HAVE_BAGL_GLYPH_ARRAY
@@ -1202,7 +1214,7 @@ void bagl_draw_glyph(const bagl_component_t *component, const bagl_icon_details_
     */
 
     // draw the glyph from the bitmap using the context for colors
-    bagl_hal_draw_bitmap_within_rect(
+    bolos_err_t ret = bagl_hal_draw_bitmap_within_rect(
         component->x,
         component->y,
         icon_details->width,
@@ -1220,6 +1232,9 @@ void bagl_draw_glyph(const bagl_component_t *component, const bagl_icon_details_
         (unsigned char *) PIC((unsigned int) icon_details->bitmap),
 #endif  // DISPLAY_FLOWS
         icon_details->bpp * (icon_details->width * icon_details->height));
+    if (SWO_SUCCESS != ret) {
+        return;
+    }
 }
 
 // --------------------------------------------------------------------------------------

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1914,15 +1914,15 @@ void screen_set_keepout(unsigned int x, unsigned int y, unsigned int width, unsi
     return;
 }
 
-void bagl_hal_draw_bitmap_within_rect(int                  x,
-                                      int                  y,
-                                      unsigned int         width,
-                                      unsigned int         height,
-                                      unsigned int         color_count,
-                                      const unsigned int  *colors,
-                                      unsigned int         bit_per_pixel,
-                                      const unsigned char *bitmap,
-                                      unsigned int         bitmap_length_bits)
+bolos_err_t bagl_hal_draw_bitmap_within_rect(int                  x,
+                                             int                  y,
+                                             unsigned int         width,
+                                             unsigned int         height,
+                                             unsigned int         color_count,
+                                             const unsigned int  *colors,
+                                             unsigned int         bit_per_pixel,
+                                             const unsigned char *bitmap,
+                                             unsigned int         bitmap_length_bits)
 {
     unsigned int parameters[9];
     parameters[0] = (unsigned int) x;
@@ -1934,8 +1934,7 @@ void bagl_hal_draw_bitmap_within_rect(int                  x,
     parameters[6] = (unsigned int) bit_per_pixel;
     parameters[7] = (unsigned int) bitmap;
     parameters[8] = (unsigned int) bitmap_length_bits;
-    SVC_Call(SYSCALL_bagl_hal_draw_bitmap_within_rect_ID, parameters);
-    return;
+    return SVC_Call(SYSCALL_bagl_hal_draw_bitmap_within_rect_ID, parameters);
 }
 
 void bagl_hal_draw_rect(unsigned int color, int x, int y, unsigned int width, unsigned int height)


### PR DESCRIPTION
## Description

Update syscall signature to return an error instead of throwing.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
