### PR TITLE
lib_nbgl: Constify nbgl_layoutTagValueList_t pairs element

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -155,7 +155,7 @@ typedef nbgl_layoutTagValue_t *(*nbgl_tagValueCallback_t)(uint8_t pairIndex);
  * @brief This structure contains a list of [tag,value] pairs
  */
 typedef struct {
-    nbgl_layoutTagValue_t
+    const nbgl_layoutTagValue_t
         *pairs;  ///< array of [tag,value] pairs (nbPairs items). If NULL, callback is used instead
     nbgl_tagValueCallback_t callback;  ///< function to call to retrieve a given pair
     uint8_t nbPairs;  ///< number of pairs in pairs array (or max number of pairs to retrieve with

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1597,8 +1597,8 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
     }
 
     for (i = 0; i < list->nbPairs; i++) {
-        nbgl_layoutTagValue_t *pair;
-        uint16_t               fullHeight = 0, usableWidth;
+        const nbgl_layoutTagValue_t *pair;
+        uint16_t                     fullHeight = 0, usableWidth;
 
         if (list->pairs != NULL) {
             pair = &list->pairs[i];

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -214,7 +214,7 @@ static void pageCallback(int token, uint8_t index)
         }
     }
     else if (token == DETAILS_BUTTON_TOKEN) {
-        nbgl_layoutTagValue_t *pair;
+        const nbgl_layoutTagValue_t *pair;
         if (staticReviewContext.tagValueList.pairs != NULL) {
             pair = &staticReviewContext.tagValueList.pairs[staticReviewContext.currentPairIndex];
         }


### PR DESCRIPTION
## Description

lib_nbgl: Constify nbgl_layoutTagValueList_t pairs element
this allow to use const pairs, and therefore pairs from flash without having to drop the `const` qualifier.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
