### PR TITLE
Fix CX warning in OS update context

### DIFF
--- a/lib_cxng/include/lcx_cipher.h
+++ b/lib_cxng/include/lcx_cipher.h
@@ -66,10 +66,14 @@ typedef struct {
 
 /** Cipher information */
 typedef struct {
-    uint32_t                key_bitlen;  ///< Key size
-    uint32_t                iv_size;     ///< Initialization vector size
-    uint32_t                block_size;  ///< Block size
-    const cx_cipher_base_t *base;        /// Structure for base cipher
+    uint32_t key_bitlen;  ///< Key size
+    uint32_t iv_size;     ///< Initialization vector size
+    uint32_t block_size;  ///< Block size
+#if !defined(BOLOS_OS_UPGRADER_APP)
+    const cx_cipher_base_t *base;  /// Structure for base cipher
+#else
+    cx_cipher_base_t *base;  /// Structure for base cipher
+#endif
 
 } cx_cipher_info_t;
 


### PR DESCRIPTION
## Description

Remove const qualifier for a CX field - in the context of an OS upgrade app.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

