### PR TITLE
FIX osu build - always declare function os_setting_update()

### DIFF
--- a/include/os_settings.h
+++ b/include/os_settings.h
@@ -138,10 +138,10 @@ SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_SETTINGS) void os_setting_set(unsigned
                                                                             PLENGTH(length),
                                                                         unsigned int length);
 
-#ifdef HAVE_LANGUAGE_PACK
 // Shift preferences settings (could be needed after an update)
 void os_setting_update(void);
 
+#ifdef HAVE_LANGUAGE_PACK
 // Prototypes for language helper functions
 unsigned int os_setting_get_language(void);
 void         os_setting_set_language(unsigned int language);


### PR DESCRIPTION
## Description

Depending on the target or the on compiler version used, osu build can fail on an implicit declaration of `os_setting_update()`. That's because this function is declared behind `HAVE_LANGUAGE_PACK` flag.

This PR moves the function declaration to fix this issue

## Changes include

- [ *] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

