### PR TITLE
Increase NBGL serialization buffer size to 200 bytes

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -1036,7 +1036,7 @@ void io_seproxyhal_se_reset(void)
 
 #ifdef HAVE_SERIALIZED_NBGL
 
-#define SERIALIZED_NBGL_MAX_LEN 120
+#define SERIALIZED_NBGL_MAX_LEN 200
 
 static uint8_t nbgl_serialize_buffer[SERIALIZED_NBGL_MAX_LEN];
 


### PR DESCRIPTION
## Description

The goal is to be able to serialize bigger NBGL objects for Stax/Nano Testing

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
