### PR TITLE
stax: script.ld: Fix SRAM length

### DIFF
--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -26,7 +26,7 @@ MEMORY
 
   FLASH   (rx)  : ORIGIN = 0xc0de0000, LENGTH = 400K
   DATA    (r)   : ORIGIN = 0xc0de0000, LENGTH = 400K
-  SRAM    (rwx) : ORIGIN = 0xda7a0000, LENGTH = 30K
+  SRAM    (rwx) : ORIGIN = 0xda7a0000, LENGTH = 44K
 }
 
 PAGE_SIZE  = 512;


### PR DESCRIPTION
## Description

Fix stax Linker script SRAM length value

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
