### PR TITLE
NBGL: fix syscall signature that generates a warning in the OSU

### DIFF
--- a/lib_nbgl/include/nbgl_screen.h
+++ b/lib_nbgl/include/nbgl_screen.h
@@ -69,7 +69,7 @@ typedef struct PACKED__ nbgl_screen_s {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-unsigned int nbgl_screen_reinit(void);
+void nbgl_screen_reinit(void);
 
 #ifdef HAVE_DISPLAY_FAST_MODE
 void nbgl_screen_update_temperature(uint8_t temp_degrees);

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -176,11 +176,11 @@ const nbgl_font_t *nbgl_font_getFont(unsigned int fontId)
     return (const nbgl_font_t *) SVC_Call(SYSCALL_nbgl_get_font_ID, parameters);
 }
 
-unsigned int nbgl_screen_reinit(void)
+void nbgl_screen_reinit(void)
 {
     unsigned int parameters[1];
     parameters[0] = 0;
-    return SVC_Call(SYSCALL_nbgl_screen_reinit_ID, parameters);
+    SVC_Call(SYSCALL_nbgl_screen_reinit_ID, parameters);
 }
 
 #ifdef HAVE_DISPLAY_FAST_MODE

--- a/unit-tests/lib_nbgl/test_nbgl_obj.c
+++ b/unit-tests/lib_nbgl/test_nbgl_obj.c
@@ -184,9 +184,9 @@ uint8_t touch_exclude_borders(uint8_t excluded_borders)
     return excluded_borders;
 }
 
-unsigned int nbgl_screen_reinit(void)
+void nbgl_screen_reinit(void)
 {
-    return 0;
+    return;
 }
 
 #ifdef HAVE_SE_TOUCH

--- a/unit-tests/lib_nbgl/test_nbgl_screen.c
+++ b/unit-tests/lib_nbgl/test_nbgl_screen.c
@@ -25,9 +25,9 @@ uint8_t touch_exclude_borders(uint8_t excluded_borders)
     return excluded_borders;
 }
 
-unsigned int nbgl_screen_reinit(void)
+void nbgl_screen_reinit(void)
 {
-    return 0;
+    return;
 }
 
 void nbgl_redrawObject(nbgl_obj_t *obj, nbgl_obj_t *prevObj, bool computePosition)


### PR DESCRIPTION
## Description

Update a NBGL syscall signature that generates a warning in the OSU.
The implementation of this syscall do not return anything so update the signature.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
