### PR TITLE
cx aes: fix some warnings for the OSU

### DIFF
--- a/lib_cxng/src/cx_aes.c
+++ b/lib_cxng/src/cx_aes.c
@@ -165,10 +165,13 @@ static const cx_cipher_base_t aes_base = {
     (cx_err_t(*)(void)) cx_aes_reset_hw,
 };
 
-const cx_cipher_info_t cx_aes_128_info = {128, 16, CX_AES_BLOCK_SIZE, &aes_base};
+const cx_cipher_info_t cx_aes_128_info
+    = {128, 16, CX_AES_BLOCK_SIZE, (cx_cipher_base_t *) &aes_base};
 
-const cx_cipher_info_t cx_aes_192_info = {192, 16, CX_AES_BLOCK_SIZE, &aes_base};
+const cx_cipher_info_t cx_aes_192_info
+    = {192, 16, CX_AES_BLOCK_SIZE, (cx_cipher_base_t *) &aes_base};
 
-const cx_cipher_info_t cx_aes_256_info = {256, 16, CX_AES_BLOCK_SIZE, &aes_base};
+const cx_cipher_info_t cx_aes_256_info
+    = {256, 16, CX_AES_BLOCK_SIZE, (cx_cipher_base_t *) &aes_base};
 
 #endif  // HAVE_AES


### PR DESCRIPTION
## Description

Fix some warnings needed for OSU build

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

