### PR TITLE
lib_ux/include/ux.h: Fix LNX and LNSP version of UX_WAIT_DISPLAYED()

### DIFF
--- a/lib_ux/include/ux.h
+++ b/lib_ux/include/ux.h
@@ -580,6 +580,12 @@ extern bolos_ux_params_t G_ux_params;
  * Macro to process sequentially display a screen. The call finishes when the UX is completely
  * displayed, and the state of the MCU <-> SE exchanges is the same as before this macro call.
  */
+#ifdef HAVE_SE_SCREEN
+#define UX_WAIT_DISPLAYED()        \
+    while (!UX_DISPLAYED()) {      \
+        UX_DISPLAY_NEXT_ELEMENT(); \
+    }
+#else
 #define UX_WAIT_DISPLAYED()                                                                        \
     while (!UX_DISPLAYED()) {                                                                      \
         /* We wait for the MCU event (should indicate display processed for a bagl element) */     \
@@ -594,6 +600,7 @@ extern bolos_ux_params_t G_ux_params;
     io_seproxyhal_general_status();                                                                \
     /* We wait for an ack of the MCU. */                                                           \
     io_seproxyhal_spi_recv(G_io_seproxyhal_spi_buffer, sizeof(G_io_seproxyhal_spi_buffer), 0);
+#endif
 
 /**
  * Process button push events. Application's button event handler is called only if the ux app does


### PR DESCRIPTION
## Description

On devices where the SE drives the screen, there is no need for seph exchanges to control the screen.
The previous version was assuming UX_DISPLAY_NEXT_ELEMENT() was changing the state of the MCU <-> SE exchanges, which is false, this was leading to a deadlock on Speculos.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
