### PR TITLE
Fix nbgl_getTextMaxLenInNbLines() computing wrong len for non wrappable text

### DIFF
--- a/lib_nbgl/src/nbgl_fonts.c
+++ b/lib_nbgl/src/nbgl_fonts.c
@@ -585,6 +585,7 @@ bool nbgl_getTextMaxLenInNbLines(nbgl_font_id_e fontId,
                 textLen       = lenAtLastDelimiter;
             }
             else {
+                textLen += text - previousText;
                 text = previousText;
             }
             width = 0;


### PR DESCRIPTION
## Description

The goal of this PR is to fix nbgl_getTextMaxLenInNbLines() computing wrong len for non wrappable text

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
