### PR TITLE
Remove unnecessary includes in os_printf

### DIFF
--- a/src/os_printf.c
+++ b/src/os_printf.c
@@ -67,8 +67,6 @@ static const char g_pcHex_cap[] = {
 
 #ifdef HAVE_PRINTF
 #include "os_io_seproxyhal.h"
-#include "usbd_def.h"
-#include "usbd_core.h"
 
 void screen_printf(const char *format, ...) __attribute__((weak, alias("mcu_usb_printf")));
 


### PR DESCRIPTION
## Description

Brings it more in line with other API levels. Required for plugins compilation with all their disablers.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)