### PR TITLE
nbgl: ensure state set to correct values in certain `use_case` flows

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1458,6 +1458,7 @@ void nbgl_useCaseAddressConfirmationExt(const char                      *address
     navInfo.navWithTap.backButton    = (tagValueList != NULL);
     navInfo.navWithTap.quitText      = "Cancel";
     navInfo.navWithTap.nextPageToken = ADDR_NEXT_TOKEN;
+    navInfo.navWithTap.nextPageText  = NULL;
     navInfo.navWithTap.backToken     = ADDR_BACK_TOKEN;
     navInfo.navWithTap.skipText      = NULL;
     navInfo.quitToken                = REJECT_TOKEN;

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1241,6 +1241,7 @@ void nbgl_useCaseForwardOnlyReview(const char                *rejectText,
     navInfo.navWithTap.backToken     = BACK_TOKEN;
     navInfo.navWithTap.skipText      = "Skip >>";
     navInfo.navWithTap.skipToken     = SKIP_TOKEN;
+    navInfo.navWithTap.backButton    = false;
     navInfo.progressIndicator        = true;
     navInfo.tuneId                   = TUNE_TAP_CASUAL;
 
@@ -1281,6 +1282,7 @@ void nbgl_useCaseForwardOnlyReviewNoSkip(const char                *rejectText,
     navInfo.navWithTap.nextPageToken = NEXT_TOKEN;
     navInfo.navWithTap.quitText      = rejectText;
     navInfo.navWithTap.backToken     = BACK_TOKEN;
+    navInfo.navWithTap.backButton    = false;
     navInfo.navWithTap.skipText      = NULL;
     navInfo.progressIndicator        = true;
     navInfo.tuneId                   = TUNE_TAP_CASUAL;


### PR DESCRIPTION
## Description

Ensure state properly reset when entering `ForwardOnlyReview`, `AddressConfirmation` use cases.
Fixes https://github.com/trilitech/ledger-app-tezos-wallet/issues/63

### Background

When displaying `AddressConfirmation` page, if a `useCaseReview` was rejected previously, the `Continue` button is partially overriden with a `Tap to Continue` text.

When using `ForwardOnlyReview`, if the user previously entered `Settings`, where settings has more than one page, then during the review, the `BackButton` is visible, despite `ForwardOnlyReview` being used.

## Changes include

- Set the `nextPageText` to `NULL` when entering `AddressConfirmation`
- Explicitly set the backButton to `false` when entering `ForwardOnlyReview*` use cases.

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
