### PR TITLE
Avoid unwanted pin lock during io reset

### DIFF
--- a/include/os_ux.h
+++ b/include/os_ux.h
@@ -27,6 +27,7 @@ typedef enum bolos_ux_e {
     BOLOS_UX_ASYNCHMODAL_PAIRING_REQUEST,  // ask the ux to display a modal to accept/reject the
                                            // current pairing request
     BOLOS_UX_ASYNCHMODAL_PAIRING_CANCEL,
+    BOLOS_UX_IO_RESET,
     BOLOS_UX_LAST_ID,
 } bolos_ux_t;
 

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -430,6 +430,13 @@ void io_seproxyhal_init(void)
     app_stack_canary = APP_STACK_CANARY_MAGIC;
 #endif  // HAVE_BOLOS_APP_STACK_CANARY
 
+#if !defined(HAVE_BOLOS) && !defined(BOLOS_OS_UPGRADER_APP)
+    // Warn UX layer of io reset to avoid unwanted pin lock
+    memset(&G_ux_params, 0, sizeof(G_ux_params));
+    G_ux_params.ux_id = BOLOS_UX_IO_RESET;
+    os_ux(&G_ux_params);
+#endif
+
     // wipe the io structure before it's used
 #ifdef HAVE_BLE
     unsigned int plane = G_io_app.plane_mode;


### PR DESCRIPTION


## Description

Introduces usage of BOLOS_UX_IO_RESET event for apps: 
Warns the UX layer that an IO reset will happen. 
It allows UX layer to anticipate jitter in USB values and avoid undesired pin locks.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

The addition of this new event shifts the values of multiple UX event values.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
