### PR TITLE
B2CA-969: Activate pinpad and fix CCID SC_Secure

### DIFF
--- a/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/sc_itf.h
+++ b/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/sc_itf.h
@@ -64,7 +64,7 @@ uint8_t SC_ExecuteEscape (uint8_t* escapePtr, uint32_t escapeLen,
                           uint8_t* responseBuff,
                           uint16_t* responseLen);
 uint8_t SC_SetClock (uint8_t bClockCommand);
-uint8_t SC_XferBlock (uint8_t* ptrBlock, uint32_t blockLen, uint16_t* expectedLen);
+uint8_t SC_XferBlock (uint8_t* ptrBlock, uint32_t blockLen);
 uint8_t SC_Request_GetClockFrequencies(uint8_t* pbuf, uint16_t* len);
 uint8_t SC_Request_GetDataRates(uint8_t* pbuf, uint16_t* len);
 uint8_t SC_T0Apdu(uint8_t bmChanges, uint8_t bClassGetResponse, 
@@ -72,8 +72,7 @@ uint8_t SC_T0Apdu(uint8_t bmChanges, uint8_t bClassGetResponse,
 uint8_t SC_Mechanical(uint8_t bFunction);
 uint8_t SC_SetDataRateAndClockFrequency(uint32_t dwClockFrequency, 
                                         uint32_t dwDataRate); 
-uint8_t SC_Secure(uint32_t dwLength, uint8_t bBWI, uint16_t wLevelParameter, 
-                    uint8_t* pbuf, uint32_t* returnLen );
+uint8_t SC_Secure(uint8_t* pbuf, uint32_t* returnLen);
 
 #endif // HAVE_USB_CLASS_CCID
 

--- a/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_if.h
+++ b/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_if.h
@@ -58,6 +58,14 @@
 #define VOLTAGE_SELECTION_5V  0x01
 #define VOLTAGE_SELECTION_1V8 0x03
 
+/* PC_to_RDR_Secure PIN operations */
+#define PIN_OPR_VERIFICATION   0x00
+#define PIN_OPR_MODIFICATION   0x01
+#define PIN_OPR_TRANSFER       0x02
+#define PIN_OPR_WAIT_ICC_RESP  0x03
+#define PIN_OPR_CANCEL         0x04
+#define PIN_OPR_APDU_CLA       0xEF
+
 #define		PC_TO_RDR_ICCPOWERON		0x62
 #define		PC_TO_RDR_ICCPOWEROFF		0x63
 #define		PC_TO_RDR_GETSLOTSTATUS		0x65

--- a/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_if.h
+++ b/lib_stusb/STM32_USB_Device_Library/Class/CCID/inc/usbd_ccid_if.h
@@ -223,6 +223,8 @@ void Set_CSW (uint8_t CSW_Status, uint8_t Send_Permission);
 
 void io_usb_ccid_set_card_inserted(unsigned int inserted);
 
+void io_usb_ccid_configure_pinpad(uint8_t enabled);
+
 #endif // HAVE_USB_CLASS_CCID
 
 #endif /* __USBD_CCID_IF_H */

--- a/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.c
+++ b/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.c
@@ -247,10 +247,7 @@ uint8_t  PC_to_RDR_XfrBlock(void)
 
   G_io_ccid.bulk_header.bulkin.dwLength = (uint16_t)expectedLength;  
 
-
-  error = SC_XferBlock(&G_io_ccid_data_buffer[0], 
-                   reqlen, 
-                   &expectedLength); 
+  error = SC_XferBlock(&G_io_ccid_data_buffer[0], reqlen); 
 
   if (error != SLOT_NO_ERROR)
   {
@@ -693,7 +690,6 @@ uint8_t  PC_TO_RDR_SetDataRateAndClockFrequency(void)
 uint8_t  PC_TO_RDR_Secure(void)
 {
   uint8_t error;
-  uint8_t bBWI;
   uint16_t wLevelParameter;
   uint32_t responseLen; 
   
@@ -707,14 +703,13 @@ uint8_t  PC_TO_RDR_Secure(void)
     return error;
   }
   
-  bBWI = G_io_ccid.bulk_header.bulkout.bSpecific_0;
   wLevelParameter = (G_io_ccid.bulk_header.bulkout.bSpecific_1 + ((uint16_t)G_io_ccid.bulk_header.bulkout.bSpecific_2<<8));
   
   if ((EXCHANGE_LEVEL_FEATURE == TPDU_EXCHANGE) || 
     (EXCHANGE_LEVEL_FEATURE == SHORT_APDU_EXCHANGE))
   {
     /* TPDU level & short APDU level, wLevelParameter is RFU, = 0000h */
-    if (wLevelParameter != 0 )
+    if (wLevelParameter != 0)
     {
       G_io_ccid.bulk_header.bulkin.dwLength = 0;
       CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
@@ -723,8 +718,7 @@ uint8_t  PC_TO_RDR_Secure(void)
     }
   }
 
-  error = SC_Secure(G_io_ccid.bulk_header.bulkout.dwLength - CCID_HEADER_SIZE, bBWI, wLevelParameter, 
-                    &G_io_ccid_data_buffer[0], &responseLen);
+  error = SC_Secure(&G_io_ccid_data_buffer[0], &responseLen);
 
   G_io_ccid.bulk_header.bulkin.dwLength = responseLen;
   

--- a/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.c
+++ b/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.c
@@ -231,28 +231,28 @@ uint8_t  PC_to_RDR_XfrBlock(void)
   if (error != 0) 
     return error;
     
-    if (G_io_ccid.bulk_header.bulkout.dwLength > IO_CCID_DATA_BUFFER_SIZE)
-    { /* Check amount of Data Sent by Host is > than memory allocated ? */
+  if (G_io_ccid.bulk_header.bulkout.dwLength > IO_CCID_DATA_BUFFER_SIZE)
+  { /* Check amount of Data Sent by Host is > than memory allocated ? */
      
-      return SLOTERROR_BAD_DWLENGTH;
-    }
+    return SLOTERROR_BAD_DWLENGTH;
+  }
 
 
-    /* wLevelParameter = Size of expected data to be returned by the 
-                          bulk-IN endpoint */
-    expectedLength = (G_io_ccid.bulk_header.bulkout.bSpecific_2 << 8) | 
-                      G_io_ccid.bulk_header.bulkout.bSpecific_1;   
+  /* wLevelParameter = Size of expected data to be returned by the 
+                        bulk-IN endpoint */
+  expectedLength = (G_io_ccid.bulk_header.bulkout.bSpecific_2 << 8) | 
+                    G_io_ccid.bulk_header.bulkout.bSpecific_1;   
 
-    reqlen = G_io_ccid.bulk_header.bulkout.dwLength;
-    
-    G_io_ccid.bulk_header.bulkin.dwLength = (uint16_t)expectedLength;  
+  reqlen = G_io_ccid.bulk_header.bulkout.dwLength;
+
+  G_io_ccid.bulk_header.bulkin.dwLength = (uint16_t)expectedLength;  
 
 
-    error = SC_XferBlock(&G_io_ccid_data_buffer[0], 
-                     reqlen, 
-                     &expectedLength); 
+  error = SC_XferBlock(&G_io_ccid_data_buffer[0], 
+                   reqlen, 
+                   &expectedLength); 
 
-   if (error != SLOT_NO_ERROR)
+  if (error != SLOT_NO_ERROR)
   {
     CCID_UpdateCommandStatus(BM_COMMAND_STATUS_FAILED, BM_ICC_PRESENT_ACTIVE);
   }
@@ -639,7 +639,6 @@ uint8_t  PC_TO_RDR_SetDataRateAndClockFrequency(void)
   uint8_t error;
   uint32_t clockFrequency;
   uint32_t dataRate;
-  uint32_t temp =0;
   
   error = CCID_CheckCommandParams(CHK_PARAM_SLOT |\
     CHK_PARAM_CARD_PRESENT |\

--- a/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.c
+++ b/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.c
@@ -615,11 +615,10 @@ void io_usb_ccid_set_card_inserted(unsigned int inserted) {
 #endif // HAVE_CCID_INTERRUPT
 }
 
-
-
-
-
-
+void io_usb_ccid_configure_pinpad(uint8_t enabled) {
+    const volatile uint8_t *cfgDesc = USBD_GetPinPadOffset();
+    nvm_write((void *)cfgDesc, &enabled, 1);
+}
 
 #endif // HAVE_USB_CLASS_CCID
 

--- a/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.c
+++ b/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.c
@@ -206,6 +206,7 @@ void CCID_BulkMessage_Out (USBD_HandleTypeDef  *pdev,
       G_io_ccid.Ccid_BulkState = CCID_STATE_IDLE;
       // no break is intentional
 
+    __attribute__((fallthrough));
     case CCID_STATE_IDLE:
       // prepare to receive another packet later on (to avoid troubles with timeout due to other hid command timeouting the ccid endpoint reply)
       USBD_LL_PrepareReceive(pdev, CCID_BULK_OUT_EP, CCID_BULK_EPOUT_SIZE);

--- a/lib_stusb/usbd_conf.h
+++ b/lib_stusb/usbd_conf.h
@@ -167,6 +167,7 @@ typedef unsigned short uint16_t;
 void *USBD_static_malloc(uint32_t size);
 void USBD_static_free(void *p);
 
+const volatile uint8_t *USBD_GetPinPadOffset(void);
 
 void USB_power(unsigned char enabled);
 


### PR DESCRIPTION
## Description

This PR
- Adds a pinpad activation, allowing to set the password (usefull for Apps like OpenPGP).
- Fixes the `SC_Secure` function because the data parsing was not aligned with CCID spec, and the returned payload caused the app crashing
- In addition, few fix for compilation warnings about code formatting.

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
