### PR TITLE
LEDGER_ASSERT improvments and CX_ASSERT addition

### DIFF
--- a/include/cx_errors.h
+++ b/include/cx_errors.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "ledger_assert.h"
 
 /**
  * Checks the error code of a function.
@@ -30,6 +31,15 @@
         if (error && error != CX_CARRY) { \
             goto end;                     \
         }                                 \
+    } while (0)
+
+/**
+ * Checks the error code of a function and assert in case of error.
+ */
+#define CX_ASSERT(call)                                                   \
+    do {                                                                  \
+        cx_err_t _assert_err = call;                                      \
+        LEDGER_ASSERT(!_assert_err, "err 0x%X <%s>", _assert_err, #call); \
     } while (0)
 
 /** Success. */

--- a/include/ledger_assert.h
+++ b/include/ledger_assert.h
@@ -1,160 +1,95 @@
 #pragma once
 
-#include <stdbool.h>
+#include "ledger_assert_internals.h"
 
-#ifdef HAVE_PRINTF
-void assert_print_failed(void);
-#endif
+/*****************
+ * LEDGER_ASSERT *
+ ****************/
 
-#ifdef LEDGER_ASSERT_CONFIG_FILE_INFO
-#define LEDGER_ASSERT_CONFIG_MESSAGE_INFO   1
-#define LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO 1
-#endif
-
-#ifdef LEDGER_ASSERT_CONFIG_MESSAGE_INFO
-#define LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO 1
-#endif
-
-#if defined(LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO) && defined(HAVE_LEDGER_ASSERT_DISPLAY)
-#define LR_AND_PC_SIZE 30
-void assert_display_lr_and_pc(int lr, int pc);
-#define ASSERT_DISPLAY_LR_AND_PC(lr, pc) assert_display_lr_and_pc(lr, pc)
-#else
-#define LR_AND_PC_SIZE 0
-#define ASSERT_DISPLAY_LR_AND_PC(lr, pc) \
-    do {                                 \
+/**
+ * LEDGER_ASSERT - exit the app if assertion is false.
+ *
+ * Description:
+ * This is a C macro that can be used similarly of the libc `assert` macro.
+ * Therefore, it can help programmers find bugs in their programs, or handle
+ * exceptional cases via a crash that will produce limited debugging output.
+ *
+ *
+ * Important note:
+ * Note that contrary to the libc `assert`, the `LEDGER_ASSERT` macro will
+ * still end the app execution even if build with DEBUG=0 or NDEBUG.
+ * However, there are configurations explained below that shall be used to
+ * reduce the code size impact of the `LEDGER_ASSERT` macro to the bare minimum.
+ *
+ *
+ * Examples of usage:
+ *
+ * 1/ Simple example always raising with simple message:
+ * - `LEDGER_ASSERT(false, "Always assert");`
+ *
+ * 2/ More complex examples:
+ * - `LEDGER_ASSERT(len <= sizeof(buf), "Len too long");`
+ * - `LEDGER_ASSERT(check_value(value) == 0, "check_value failed");`
+ *
+ * 3/ Examples showcasing advance message format:
+ * - `LEDGER_ASSERT(len <= sizeof(buf), "Len too long %d <= %d", len, sizeof(buf));`
+ * - `int err = check_value(value); LEDGER_ASSERT(err == 0, "check_value failed (%d)", err);`
+ *
+ *
+ * Configuration:
+ *
+ * I/ Type of info to expose in PRINTF and screen if enabled.
+ *
+ * There are 4 types of information that can be displayed:
+ *
+ * 1/ A simple info displaying "LEDGER_ASSERT FAILED"
+ *    => This is always enabled
+ *
+ * 2/ An info containing the PC and LR of the instruction that failed.
+ *    This can be used to locate the failing code and flow using the following
+ *    command: `arm-none-eabi-addr2line --exe bin/app.elf -pf 0xC0DE586B`
+ *    => This is enabled when `LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO` is defined.
+ *
+ * 3/ An info displaying the `LEDGER_ASSERT` message passed as parameter.
+ *    => This is enabled when `LEDGER_ASSERT_CONFIG_MESSAGE_INFO` is defined.
+ *
+ * 4/ An info displaying the file and line position of the failing
+ *    `LEDGER_ASSERT`.
+ *    => This is enabled when `LEDGER_ASSERT_CONFIG_FILE_INFO` is defined.
+ *
+ * By default, when an info level X is enabled, all info level below are enabled.
+ *
+ * When using `Makefile.standard_app` and building with `DEBUG=1` all info are
+ * enabled.
+ *
+ * Note that enabling these info increase the app code size and is only
+ * recommended to ease the debugging.
+ *
+ *
+ * II/ Display info on device screen.
+ *
+ * Control whether or not a specific screen displaying assert info is shown
+ * to the app user before exiting the app due to an assert failure.
+ *
+ * To enable it, add `DEFINES+=HAVE_LEDGER_ASSERT_DISPLAY` in your app Makefile.
+ *
+ * This is enabled by default when using `Makefile.standard_app` and building
+ * with `DEBUG=1`. It can still be disabled with using
+ * `DISABLE_DEBUG_LEDGER_ASSERT=1`.
+ *
+ * Note that this is increasing the app code size and exposes a non-user
+ * friendly screen in case of assert. therefore this should not be enabled in
+ * app release build but only kept for debug purposes.
+ *
+ */
+#define LEDGER_ASSERT(test, format, ...)                  \
+    do {                                                  \
+        if (!(test)) {                                    \
+            LEDGER_ASSERT_LR_AND_PC_PREAMBLE();           \
+            PRINTF("LEDGER_ASSERT FAILED\n");             \
+            LEDGER_ASSERT_MESSAGE(format, ##__VA_ARGS__); \
+            LEDGER_ASSERT_FILE_INFO();                    \
+            LEDGER_ASSERT_LR_AND_PC();                    \
+            LEDGER_ASSERT_EXIT();                         \
+        }                                                 \
     } while (0)
-#endif
-
-#if defined(LEDGER_ASSERT_CONFIG_MESSAGE_INFO) && defined(HAVE_LEDGER_ASSERT_DISPLAY)
-#define MESSAGE_SIZE 20
-void assert_display_message(const char *message);
-#define ASSERT_DISPLAY_MESSAGE(message) assert_display_message(message)
-#else
-#define MESSAGE_SIZE 0
-#define ASSERT_DISPLAY_MESSAGE(message) \
-    do {                                \
-    } while (0)
-#endif
-
-#if defined(LEDGER_ASSERT_CONFIG_FILE_INFO) && defined(HAVE_LEDGER_ASSERT_DISPLAY)
-#define FILE_SIZE 50
-void assert_display_file_info(const char *file, unsigned int line);
-#define ASSERT_DISPLAY_FILE_INFO(file, line) assert_display_file_info(file, line)
-#else
-#define FILE_SIZE 0
-#define ASSERT_DISPLAY_FILE_INFO(file, line) \
-    do {                                     \
-    } while (0)
-#endif
-
-#ifdef HAVE_LEDGER_ASSERT_DISPLAY
-#define ASSERT_BUFFER_LEN LR_AND_PC_SIZE + MESSAGE_SIZE + FILE_SIZE
-void __attribute__((noreturn)) assert_display_exit(void);
-
-#define LEDGER_ASSERT_EXIT() assert_display_exit()
-#else
-void assert_exit(bool confirm);
-#define LEDGER_ASSERT_EXIT() assert_exit(true)
-#endif
-
-#if defined(LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO) && defined(HAVE_PRINTF)
-void assert_print_lr_and_pc(int lr, int pc);
-#define ASSERT_PRINT_LR_AND_PC(lr, pc) assert_print_lr_and_pc(lr, pc)
-#else
-#define ASSERT_PRINT_LR_AND_PC(lr, pc) \
-    do {                               \
-    } while (0)
-#endif
-
-#if defined(LEDGER_ASSERT_CONFIG_MESSAGE_INFO) && defined(HAVE_PRINTF)
-void assert_print_message(const char *message);
-#define ASSERT_PRINT_MESSAGE(message) assert_print_message(message)
-#else
-#define ASSERT_PRINT_MESSAGE(message) \
-    do {                              \
-    } while (0)
-#endif
-
-#if defined(LEDGER_ASSERT_CONFIG_FILE_INFO) && defined(HAVE_PRINTF)
-void assert_print_file_info(const char *file, int line);
-#define ASSERT_PRINT_FILE_INFO(file, line) assert_print_file_info(file, line)
-#else
-#define ASSERT_PRINT_FILE_INFO(file, line) \
-    do {                                   \
-    } while (0)
-#endif
-
-#ifdef LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO
-#define LEDGER_ASSERT_LR_AND_PC()                           \
-    do {                                                    \
-        int _lr_address = 0;                                \
-        int _pc_address = 0;                                \
-                                                            \
-        __asm volatile("mov %0, lr" : "=r"(_lr_address));   \
-        __asm volatile("mov %0, pc" : "=r"(_pc_address));   \
-        ASSERT_PRINT_LR_AND_PC(_lr_address, _pc_address);   \
-        ASSERT_DISPLAY_LR_AND_PC(_lr_address, _pc_address); \
-    } while (0)
-#elif defined(HAVE_PRINTF)
-#define LEDGER_ASSERT_LR_AND_PC() assert_print_failed()
-#else
-#define LEDGER_ASSERT_LR_AND_PC() \
-    do {                          \
-    } while (0)
-#endif
-
-#ifdef LEDGER_ASSERT_CONFIG_MESSAGE_INFO
-#define LEDGER_ASSERT_MESSAGE(message)   \
-    do {                                 \
-        ASSERT_PRINT_MESSAGE(message);   \
-        ASSERT_DISPLAY_MESSAGE(message); \
-    } while (0)
-#else
-#define LEDGER_ASSERT_MESSAGE(message) \
-    do {                               \
-    } while (0)
-#endif
-
-#ifdef LEDGER_ASSERT_CONFIG_FILE_INFO
-#define LEDGER_ASSERT_FILE_INFO()                     \
-    do {                                              \
-        ASSERT_PRINT_FILE_INFO(__FILE__, __LINE__);   \
-        ASSERT_DISPLAY_FILE_INFO(__FILE__, __LINE__); \
-    } while (0)
-#else
-#define LEDGER_ASSERT_FILE_INFO() \
-    do {                          \
-    } while (0)
-#endif
-
-#define LEDGER_ASSERT(test, message)        \
-    do {                                    \
-        if (!(test)) {                      \
-            LEDGER_ASSERT_LR_AND_PC();      \
-            LEDGER_ASSERT_MESSAGE(message); \
-            LEDGER_ASSERT_FILE_INFO();      \
-            LEDGER_ASSERT_EXIT();           \
-        }                                   \
-    } while (0)
-
-#if defined(HAVE_DEBUG_THROWS) && defined(HAVE_PRINTF)
-void throw_print_lr(int e, int lr);
-#define THROW_PRINT_LR(e, lr_val) throw_print_lr(e, lr_val)
-#else
-#define THROW_PRINT_LR(e, lr_val) \
-    do {                          \
-    } while (0)
-#endif
-
-#if defined(HAVE_DEBUG_THROWS)
-void __attribute__((noreturn)) assert_display_exit(void);
-void throw_display_lr(int e, int lr);
-#define DEBUG_THROW(e)                               \
-    do {                                             \
-        unsigned int lr_val;                         \
-        __asm volatile("mov %0, lr" : "=r"(lr_val)); \
-        throw_display_lr(e, lr_val);                 \
-        THROW_PRINT_LR(e, lr_val);                   \
-    } while (0)
-#endif

--- a/include/ledger_assert_internals.h
+++ b/include/ledger_assert_internals.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include "os_print.h"
+
+/*******************************
+ * Default configuration level *
+ ******************************/
+#ifdef LEDGER_ASSERT_CONFIG_FILE_INFO
+#define LEDGER_ASSERT_CONFIG_MESSAGE_INFO   1
+#define LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO 1
+#endif
+
+#ifdef LEDGER_ASSERT_CONFIG_MESSAGE_INFO
+#define LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO 1
+#endif
+
+/*********************************************************************
+ * Compute needed buffer length to display the assert info on screen *
+ ********************************************************************/
+#ifdef HAVE_LEDGER_ASSERT_DISPLAY
+
+#ifdef LEDGER_ASSERT_CONFIG_MESSAGE_INFO
+#if defined(TARGET_NANOS)
+// Spare RAM on NANOS
+#define MESSAGE_SIZE 20
+#else
+#define MESSAGE_SIZE 50
+#endif
+#else
+#define MESSAGE_SIZE 0
+#endif
+
+#ifdef LEDGER_ASSERT_CONFIG_FILE_INFO
+#define FILE_SIZE 50
+#else
+#define FILE_SIZE 0
+#endif
+
+#ifdef LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO
+#define LR_AND_PC_SIZE 30
+#else
+#define LR_AND_PC_SIZE 0
+#endif
+
+#define ASSERT_BUFFER_LEN LR_AND_PC_SIZE + MESSAGE_SIZE + FILE_SIZE
+extern char assert_buffer[ASSERT_BUFFER_LEN];
+
+#endif  // HAVE_LEDGER_ASSERT_DISPLAY
+
+/************************************************************
+ * Define behavior when LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO *
+ ***********************************************************/
+#ifdef LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO
+
+#ifdef HAVE_PRINTF
+void assert_print_lr_and_pc(int lr, int pc);
+#define ASSERT_PRINT_LR_AND_PC(lr, pc) assert_print_lr_and_pc(lr, pc)
+#else
+#define ASSERT_PRINT_LR_AND_PC(lr, pc) \
+    do {                               \
+    } while (0)
+#endif
+
+#ifdef HAVE_LEDGER_ASSERT_DISPLAY
+void assert_display_lr_and_pc(int lr, int pc);
+#define ASSERT_DISPLAY_LR_AND_PC(lr, pc) assert_display_lr_and_pc(lr, pc)
+#else
+#define ASSERT_DISPLAY_LR_AND_PC(lr, pc) \
+    do {                                 \
+    } while (0)
+#endif
+
+#define LEDGER_ASSERT_LR_AND_PC_PREAMBLE()            \
+    int _lr_address = 0;                              \
+    int _pc_address = 0;                              \
+                                                      \
+    __asm volatile("mov %0, lr" : "=r"(_lr_address)); \
+    __asm volatile("mov %0, pc" : "=r"(_pc_address))
+
+#define LEDGER_ASSERT_LR_AND_PC()                           \
+    do {                                                    \
+        ASSERT_PRINT_LR_AND_PC(_lr_address, _pc_address);   \
+        ASSERT_DISPLAY_LR_AND_PC(_lr_address, _pc_address); \
+    } while (0)
+
+#else  // LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO
+
+#define LEDGER_ASSERT_LR_AND_PC_PREAMBLE() \
+    do {                                   \
+    } while (0)
+
+#define LEDGER_ASSERT_LR_AND_PC() \
+    do {                          \
+    } while (0)
+
+#endif  // LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO
+
+/**********************************************************
+ * Define behavior when LEDGER_ASSERT_CONFIG_MESSAGE_INFO *
+ *********************************************************/
+#ifdef LEDGER_ASSERT_CONFIG_MESSAGE_INFO
+
+#ifdef HAVE_PRINTF
+#define ASSERT_PRINT_MESSAGE(format, ...) \
+    do {                                  \
+        PRINTF(format, ##__VA_ARGS__);    \
+        PRINTF("\n");                     \
+    } while (0)
+#else
+#define ASSERT_PRINT_MESSAGE(...) \
+    do {                          \
+    } while (0)
+#endif
+
+#ifdef HAVE_LEDGER_ASSERT_DISPLAY
+// Immediately call snprintf here (no function wrapping it cleanly in ledger_assert.c).
+// This is because we don't have an vsnprintf implementation which would be needed if
+// we were to pass the va_args to an intermediate function.
+// See https://stackoverflow.com/a/150578
+#define ASSERT_DISPLAY_MESSAGE(format, ...)                           \
+    do {                                                              \
+        snprintf(assert_buffer, MESSAGE_SIZE, format, ##__VA_ARGS__); \
+        strncat(assert_buffer, "\n", MESSAGE_SIZE);                   \
+    } while (0)
+#else
+#define ASSERT_DISPLAY_MESSAGE(format, ...) \
+    do {                                    \
+    } while (0)
+#endif
+
+#define LEDGER_ASSERT_MESSAGE(format, ...)                 \
+    do {                                                   \
+        if (format != NULL) {                              \
+            ASSERT_PRINT_MESSAGE(format, ##__VA_ARGS__);   \
+            ASSERT_DISPLAY_MESSAGE(format, ##__VA_ARGS__); \
+        }                                                  \
+    } while (0)
+
+#else  // LEDGER_ASSERT_CONFIG_MESSAGE_INFO
+
+#define LEDGER_ASSERT_MESSAGE(...) \
+    do {                           \
+    } while (0)
+
+#endif  // LEDGER_ASSERT_CONFIG_MESSAGE_INFO
+
+/*******************************************************
+ * Define behavior when LEDGER_ASSERT_CONFIG_FILE_INFO *
+ ******************************************************/
+#ifdef LEDGER_ASSERT_CONFIG_FILE_INFO
+
+#ifdef HAVE_PRINTF
+void assert_print_file_info(const char *file, int line);
+#define ASSERT_PRINT_FILE_INFO(file, line) assert_print_file_info(file, line)
+#else
+#define ASSERT_PRINT_FILE_INFO(file, line) \
+    do {                                   \
+    } while (0)
+#endif
+
+#ifdef HAVE_LEDGER_ASSERT_DISPLAY
+void assert_display_file_info(const char *file, unsigned int line);
+#define ASSERT_DISPLAY_FILE_INFO(file, line) assert_display_file_info(file, line)
+#else
+#define ASSERT_DISPLAY_FILE_INFO(file, line) \
+    do {                                     \
+    } while (0)
+#endif
+
+#define LEDGER_ASSERT_FILE_INFO()                     \
+    do {                                              \
+        ASSERT_PRINT_FILE_INFO(__FILE__, __LINE__);   \
+        ASSERT_DISPLAY_FILE_INFO(__FILE__, __LINE__); \
+    } while (0)
+
+#else  // LEDGER_ASSERT_CONFIG_FILE_INFO
+
+#define LEDGER_ASSERT_FILE_INFO() \
+    do {                          \
+    } while (0)
+
+#endif  // LEDGER_ASSERT_CONFIG_FILE_INFO
+
+/********************************************************
+ * Define exit behavior when HAVE_LEDGER_ASSERT_DISPLAY *
+ *******************************************************/
+#ifdef HAVE_LEDGER_ASSERT_DISPLAY
+void __attribute__((noreturn)) assert_display_exit(void);
+#define LEDGER_ASSERT_EXIT() assert_display_exit()
+
+#else  // HAVE_LEDGER_ASSERT_DISPLAY
+
+void assert_exit(bool confirm);
+#define LEDGER_ASSERT_EXIT() assert_exit(true)
+
+#endif  // HAVE_LEDGER_ASSERT_DISPLAY
+
+/*************************************
+ * Specific mechanism to debug THROW *
+ ************************************/
+#ifdef HAVE_DEBUG_THROWS
+
+#ifdef HAVE_PRINTF
+void throw_print_lr(int e, int lr);
+#define THROW_PRINT_LR(e, lr_val) throw_print_lr(e, lr_val)
+#else
+#define THROW_PRINT_LR(e, lr_val) \
+    do {                          \
+    } while (0)
+#endif
+
+void __attribute__((noreturn)) assert_display_exit(void);
+void throw_display_lr(int e, int lr);
+
+#define DEBUG_THROW(e)                               \
+    do {                                             \
+        unsigned int lr_val;                         \
+        __asm volatile("mov %0, lr" : "=r"(lr_val)); \
+        throw_display_lr(e, lr_val);                 \
+        THROW_PRINT_LR(e, lr_val);                   \
+    } while (0)
+
+#endif  // HAVE_DEBUG_THROWS

--- a/include/os.h
+++ b/include/os.h
@@ -117,13 +117,6 @@ os is not an application (it calls ux upon user inputs)
 /* ----------------------------------------------------------------------- */
 /* -                          DEBUG FUNCTIONS                           - */
 /* ----------------------------------------------------------------------- */
-#ifdef HAVE_PRINTF
-void screen_printf(const char *format, ...);
-void mcu_usb_printf(const char *format, ...);
-#else  // !HAVE_PRINTF
-#define PRINTF(...)
-#endif  // !HAVE_PRINTF
-
 // redefined if string.h not included
 #ifdef HAVE_SPRINTF
 #ifndef __APPLE__

--- a/include/os_print.h
+++ b/include/os_print.h
@@ -4,3 +4,10 @@
 
 // avoid typing the size each time
 #define SPRINTF(strbuf, ...) snprintf(strbuf, sizeof(strbuf), __VA_ARGS__)
+
+#ifdef HAVE_PRINTF
+void screen_printf(const char *format, ...);
+void mcu_usb_printf(const char *format, ...);
+#else  // !HAVE_PRINTF
+#define PRINTF(...)
+#endif  // !HAVE_PRINTF

--- a/lib_cxng/include/lcx_ecdsa.h
+++ b/lib_cxng/include/lcx_ecdsa.h
@@ -152,15 +152,15 @@ DEPRECATED static inline size_t cx_ecdsa_sign(const cx_ecfp_private_key_t *pvkey
  *                      - CX_EC_INFINITE_POINT
  *                      - CX_INVALID_PARAMETER_VALUE
  */
-cx_err_t cx_ecdsa_sign_rs_no_throw(const cx_ecfp_private_key_t *key,
-                                   uint32_t                     mode,
-                                   cx_md_t                      hashID,
-                                   const uint8_t               *hash,
-                                   size_t                       hash_len,
-                                   size_t                       rs_len,
-                                   uint8_t                     *sig_r,
-                                   uint8_t                     *sig_s,
-                                   uint32_t                    *info);
+WARN_UNUSED_RESULT cx_err_t cx_ecdsa_sign_rs_no_throw(const cx_ecfp_private_key_t *key,
+                                                      uint32_t                     mode,
+                                                      cx_md_t                      hashID,
+                                                      const uint8_t               *hash,
+                                                      size_t                       hash_len,
+                                                      size_t                       rs_len,
+                                                      uint8_t                     *sig_r,
+                                                      uint8_t                     *sig_s,
+                                                      uint32_t                    *info);
 
 /**
  * @brief   Verifies an ECDSA signature according to ECDSA specification.
@@ -180,11 +180,11 @@ cx_err_t cx_ecdsa_sign_rs_no_throw(const cx_ecfp_private_key_t *key,
  *
  * @return             1 if the signature is verified, 0 otherwise.
  */
-bool cx_ecdsa_verify_no_throw(const cx_ecfp_public_key_t *pukey,
-                              const uint8_t              *hash,
-                              size_t                      hash_len,
-                              const uint8_t              *sig,
-                              size_t                      sig_len);
+WARN_UNUSED_RESULT bool cx_ecdsa_verify_no_throw(const cx_ecfp_public_key_t *pukey,
+                                                 const uint8_t              *hash,
+                                                 size_t                      hash_len,
+                                                 const uint8_t              *sig,
+                                                 size_t                      sig_len);
 
 /**
  * @deprecated

--- a/lib_cxng/include/lcx_ecschnorr.h
+++ b/lib_cxng/include/lcx_ecschnorr.h
@@ -71,13 +71,13 @@
  *                     - CX_EC_INFINITE_POINT
  *                     - CX_INVALID_PARAMETER_VALUE
  */
-cx_err_t cx_ecschnorr_sign_no_throw(const cx_ecfp_private_key_t *pvkey,
-                                    uint32_t                     mode,
-                                    cx_md_t                      hashID,
-                                    const uint8_t               *msg,
-                                    size_t                       msg_len,
-                                    uint8_t                     *sig,
-                                    size_t                      *sig_len);
+WARN_UNUSED_RESULT cx_err_t cx_ecschnorr_sign_no_throw(const cx_ecfp_private_key_t *pvkey,
+                                                       uint32_t                     mode,
+                                                       cx_md_t                      hashID,
+                                                       const uint8_t               *msg,
+                                                       size_t                       msg_len,
+                                                       uint8_t                     *sig,
+                                                       size_t                      *sig_len);
 
 /**
  * @deprecated
@@ -128,13 +128,13 @@ DEPRECATED static inline size_t cx_ecschnorr_sign(const cx_ecfp_private_key_t *p
  *
  * @return            1 if signature is verified, 0 otherwise.
  */
-bool cx_ecschnorr_verify(const cx_ecfp_public_key_t *pukey,
-                         uint32_t                    mode,
-                         cx_md_t                     hashID,
-                         const uint8_t              *msg,
-                         size_t                      msg_len,
-                         const uint8_t              *sig,
-                         size_t                      sig_len);
+WARN_UNUSED_RESULT bool cx_ecschnorr_verify(const cx_ecfp_public_key_t *pukey,
+                                            uint32_t                    mode,
+                                            cx_md_t                     hashID,
+                                            const uint8_t              *msg,
+                                            size_t                      msg_len,
+                                            const uint8_t              *sig,
+                                            size_t                      sig_len);
 
 #endif
 

--- a/lib_cxng/include/lcx_eddsa.h
+++ b/lib_cxng/include/lcx_eddsa.h
@@ -131,12 +131,12 @@ DEPRECATED static inline size_t cx_eddsa_sign(const cx_ecfp_private_key_t *pvkey
  *
  * @return              1 if the signature is verified, otherwise 0.
  */
-bool cx_eddsa_verify_no_throw(const cx_ecfp_public_key_t *pukey,
-                              cx_md_t                     hashID,
-                              const uint8_t              *hash,
-                              size_t                      hash_len,
-                              const uint8_t              *sig,
-                              size_t                      sig_len);
+WARN_UNUSED_RESULT bool cx_eddsa_verify_no_throw(const cx_ecfp_public_key_t *pukey,
+                                                 cx_md_t                     hashID,
+                                                 const uint8_t              *hash,
+                                                 size_t                      hash_len,
+                                                 const uint8_t              *sig,
+                                                 size_t                      sig_len);
 
 /**
  * @brief   Verifies a signature.

--- a/lib_cxng/include/lcx_groestl.h
+++ b/lib_cxng/include/lcx_groestl.h
@@ -65,7 +65,7 @@ size_t cx_groestl_get_output_size(const cx_groestl_t *ctx);
 /**
  * @brief   Initializes a GROESTL context.
  *
- * @param[out] hash Pointer to the context to init.ialize.
+ * @param[out] hash Pointer to the context to initialize.
  *
  * @param[in]  size Length of the digest.
  *

--- a/lib_cxng/include/lcx_hash.h
+++ b/lib_cxng/include/lcx_hash.h
@@ -143,7 +143,6 @@ size_t cx_hash_get_size(const cx_hash_t *ctx);
  *                     - INVALID_PARAMETER
  *                     - CX_INVALID_PARAMETER
  */
-// WARN_UNUSED_RESULT cx_err_t cx_hash_no_throw(cx_hash_t     *hash,
 WARN_UNUSED_RESULT cx_err_t cx_hash_no_throw(cx_hash_t     *hash,
                                              uint32_t       mode,
                                              const uint8_t *in,


### PR DESCRIPTION
## Description

Add some documentation for `LEDGER_ASSERT`
Allow `printf` like usage of `LEDGER_ASSERT` for error message
Minor cleanup on CX includes
Add `CX_ASSERT` macro

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
