### PR TITLE
ledger_assert: add header for HAVE_PRINTF

### DIFF
--- a/include/ledger_assert.h
+++ b/include/ledger_assert.h
@@ -2,6 +2,10 @@
 
 #include <stdbool.h>
 
+#ifdef HAVE_PRINTF
+#include "os.h"
+#endif
+
 #ifdef LEDGER_ASSERT_CONFIG_FILE_INFO
 #define LEDGER_ASSERT_CONFIG_MESSAGE_INFO   1
 #define LEDGER_ASSERT_CONFIG_LR_AND_PC_INFO 1


### PR DESCRIPTION
## Description

Add `os.h` include when using `HAVE_PRINTF` for ledger_assert

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
