### PR TITLE
Reset cipher module at the end of cmac

### DIFF
--- a/lib_cxng/src/cx_cmac.c
+++ b/lib_cxng/src/cx_cmac.c
@@ -160,6 +160,7 @@ end:
     memset(sub_key1, 0, CMAC_MAX_BLOCK_LENGTH);
     memset(sub_key2, 0, CMAC_MAX_BLOCK_LENGTH);
     explicit_bzero(ctx->cmac_ctx, sizeof(cx_cmac_context_t));
+    ctx->cipher_info->base->ctx_reset();
     return error;
 }
 


### PR DESCRIPTION
## Description

Reset cipher module at the end of CMAC calculation.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

