### PR TITLE
Remove currentHeight unused var in nbgl_use_case

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -774,16 +774,14 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                          nbPair
  */
 uint8_t nbgl_useCaseGetNbPagesForTagValueList(const nbgl_layoutTagValueList_t *tagValueList)
 {
-    uint8_t  nbPages = 0;
-    uint8_t  nbPairs = tagValueList->nbPairs;
-    uint8_t  nbPairsInPage;
-    uint16_t currentHeight = 0;
-    uint8_t  i             = 0;
-    bool     tooLongToFit;
+    uint8_t nbPages = 0;
+    uint8_t nbPairs = tagValueList->nbPairs;
+    uint8_t nbPairsInPage;
+    uint8_t i = 0;
+    bool    tooLongToFit;
 
     while (i < tagValueList->nbPairs) {
         // upper margin
-        currentHeight += 24;
         nbPairsInPage = nbgl_useCaseGetNbTagValuesInPage(nbPairs, tagValueList, i, &tooLongToFit);
         i += nbPairsInPage;
         setNbPairs(nbPages, nbPairsInPage, tooLongToFit);


### PR DESCRIPTION
## Description

Just fix the compilation warning 
```
[CC]   build/stax/obj/nbgl_use_case.o
/work/apps/B2CA-969/stax-secure-sdk//lib_nbgl/src/nbgl_use_case.c:782:14: warning: variable 'currentHeight' set but not used [-Wunused-but-set-variable]
    uint16_t currentHeight = 0;
             ^
1 warning generated.
```

Also fix `clang-format` for the variable definitions in the same function.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [X] Other (for changes that might not fit in any category)

