### PR TITLE
nbgl_use_case.c: Fix unitialized variable passed as a callback

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -292,7 +292,7 @@ static void tickerCallback(void)
 // function used to display the current page in review
 static void displaySettingsPage(uint8_t page, bool forceFullRefresh)
 {
-    nbgl_pageContent_t content;
+    nbgl_pageContent_t content = {0};
 
     if ((onNav == NULL) || (onNav(page, &content) == false)) {
         return;


### PR DESCRIPTION
## Description

nbgl_use_case.c: Fix unitialized variable passed as a callback

We might consider that it's the callback responsability to init it, but as it's not what is done in displayReviewPage() and it is safer for a small cost, let's do it!

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
