### PR TITLE
nbgl: Add force_page_start to nbgl_layoutTagValue_t

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -216,10 +216,14 @@ typedef struct {
  * @brief This structure contains a [tag,value] pair
  */
 typedef struct {
-    const char                *item;       ///< string giving the tag name
-    const char                *value;      ///< string giving the value name
+    const char *item;   ///< string giving the tag name
+    const char *value;  ///< string giving the value name
+#ifdef SCREEN_SIZE_WALLET
     const nbgl_icon_details_t *valueIcon;  ///< a buffer containing the 32px 1BPP icon for icon on
                                            ///< right of value (can be NULL)
+    int8_t force_page_start : 1;  ///< if set to 1, the tag will be displayed at the top of a new
+                                  ///< review page
+#endif
 } nbgl_layoutTagValue_t;
 
 /**

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -721,27 +721,31 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                          nbPair
 
     *tooLongToFit = false;
     while (nbPairsInPage < nbPairs) {
-        const char            *item;
-        const char            *value;
-        nbgl_layoutTagValue_t *callback_result;
-        nbgl_font_id_e         value_font;
+        const nbgl_layoutTagValue_t *pair;
+        nbgl_font_id_e               value_font;
+
         // margin between pairs
         if (nbPairsInPage > 0) {
             currentHeight += 12;
         }
         // fetch tag/value pair strings.
         if (tagValueList->pairs != NULL) {
-            value = tagValueList->pairs[startIndex + nbPairsInPage].value;
-            item  = tagValueList->pairs[startIndex + nbPairsInPage].item;
+            pair = &tagValueList->pairs[startIndex + nbPairsInPage];
         }
         else {
-            callback_result = tagValueList->callback(startIndex + nbPairsInPage);
-            value           = callback_result->value;
-            item            = callback_result->item;
+            pair = tagValueList->callback(startIndex + nbPairsInPage);
         }
+
+        if (pair->force_page_start && nbPairsInPage > 0) {
+            // This pair must be at the top of a page
+            break;
+        }
+
         // tag height
-        currentHeight += nbgl_getTextHeightInWidth(
-            SMALL_REGULAR_FONT, item, SCREEN_WIDTH - 2 * BORDER_MARGIN, tagValueList->wrapping);
+        currentHeight += nbgl_getTextHeightInWidth(SMALL_REGULAR_FONT,
+                                                   pair->item,
+                                                   SCREEN_WIDTH - 2 * BORDER_MARGIN,
+                                                   tagValueList->wrapping);
         // space between tag and value
         currentHeight += 4;
         // set value font
@@ -753,7 +757,7 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                          nbPair
         }
         // value height
         currentHeight += nbgl_getTextHeightInWidth(
-            value_font, value, SCREEN_WIDTH - 2 * BORDER_MARGIN, tagValueList->wrapping);
+            value_font, pair->value, SCREEN_WIDTH - 2 * BORDER_MARGIN, tagValueList->wrapping);
         if (currentHeight >= TAG_VALUE_AREA_HEIGHT) {
             break;
         }


### PR DESCRIPTION
## Description

nbgl: Add force_page_start to nbgl_layoutTagValue_t
This allow to force displaying a tag/value pair in a new page, hence allowing to display pairs in group when relevant.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
