### PR TITLE
stax/eu: nbgl - add option for choice radio bars

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -189,6 +189,8 @@ typedef struct {
     uint8_t nbChoices;   ///< number of choices
     uint8_t initChoice;  ///< index of the current choice
     uint8_t token;       ///< the token that will be used as argument of the callback
+    bool    smallBars;   ///< use smaller choice bars instead of normal one (for situations where a
+                         ///< lot of choices are available).
 #ifdef HAVE_PIEZO_SOUND
     tune_index_e
         tuneId;  ///< if not @ref NBGL_NO_TUNE, a tune will be played when selecting a radio button)

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1389,8 +1389,13 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
         button->state                = OFF_STATE;
         container->children[1]       = (nbgl_obj_t *) button;
 
-        container->obj.area.width       = SCREEN_WIDTH - 2 * BORDER_MARGIN;
-        container->obj.area.height      = 32;
+        container->obj.area.width = SCREEN_WIDTH - 2 * BORDER_MARGIN;
+        if (choices->smallBars) {
+            container->obj.area.height = 32 / 2;
+        }
+        else {
+            container->obj.area.height = 32;
+        }
         container->obj.alignment        = NO_ALIGNMENT;
         container->obj.alignmentMarginX = BORDER_MARGIN;
         container->obj.alignmentMarginY = BORDER_MARGIN;


### PR DESCRIPTION
Add an option to draw smaller radio choice bars.
Useful when too much choices are available and don't fit within the screen.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

