### PR TITLE
Activate NFC by default

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -510,7 +510,11 @@ void io_seproxyhal_nfc_power(bool forceInit)
     uint8_t power
         = forceInit
               ? 1
+#ifdef HAVE_NFC_ACTIVATED_BY_DEFAULT
+              : !(os_setting_get(OS_SETTING_FEATURES, NULL, 0) & OS_SETTING_FEATURES_NFC_ENABLED);
+#else
               : (os_setting_get(OS_SETTING_FEATURES, NULL, 0) & OS_SETTING_FEATURES_NFC_ENABLED);
+#endif
     buffer[0] = SEPROXYHAL_TAG_NFC_POWER;
     buffer[1] = 0;
     buffer[2] = 1;


### PR DESCRIPTION
## Description

This PR is needed to allow BOLOS to activate NFC by default on STAX, non-breaking change

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [X] Other (for changes that might not fit in any category)

