### PR TITLE
Pbo europa touch read sensor buffer

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -80,12 +80,6 @@ typedef struct io_touch_info_s {
     uint8_t  h;
 } io_touch_info_t;
 
-typedef enum io_touch_debug_mode_e {
-    TOUCH_DEBUG_END            = 0,
-    TOUCH_DEBUG_READ_RAW_DATA  = 1,
-    TOUCH_DEBUG_READ_DIFF_DATA = 2,
-} io_touch_debug_mode_t;
-
 // bitfield for exclusion borders, for touch_exclude_borders() (if a bit is set, means that pixels
 // on this border are not taken into account)
 #define LEFT_BORDER   1
@@ -94,11 +88,21 @@ typedef enum io_touch_debug_mode_e {
 #define BOTTOM_BORDER 8
 
 #ifdef HAVE_SE_TOUCH
+
+typedef enum io_touch_debug_mode_e {
+    TOUCH_DEBUG_END                = 0,
+    TOUCH_DEBUG_READ_RAW_DATA      = 1,
+    TOUCH_DEBUG_READ_DIFF_DATA     = 2,
+    TOUCH_DEBUG_READ_SENSOR_BUFFER = 3,
+} io_touch_debug_mode_t;
+
 SYSCALL void    touch_get_last_info(io_touch_info_t *info);
 SYSCALL void    touch_set_state(bool enable);
 SYSCALL uint8_t touch_exclude_borders(uint8_t excluded_borders);
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-SYSCALL uint8_t touch_switch_debug_mode_and_read(io_touch_debug_mode_t mode, uint8_t *read_buffer);
+SYSCALL uint8_t touch_switch_debug_mode_and_read(io_touch_debug_mode_t mode,
+                                                 uint8_t               buffer_type,
+                                                 uint8_t              *read_buffer);
 #endif
 #endif
 #endif  // HAVE_SE_TOUCH

--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -140,9 +140,14 @@ void io_seproxyhal_nfc_power(bool forceInit);
 
 #ifdef HAVE_SE_TOUCH
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
+#ifdef HAVE_GT1151_TOUCH
 bolos_bool_t io_seproxyhal_touch_debug_read_sensi(uint8_t *sensi_data);
 bolos_bool_t io_seproxyhal_touch_debug_read_diff_data(uint8_t *sensi_data);
 bolos_bool_t io_seproxyhal_touch_debug_end(void);
+#endif
+#ifdef HAVE_EWD720_TOUCH
+bolos_bool_t io_seproxyhal_touch_debug_read_offset_data(uint8_t *offset_data);
+#endif
 #endif
 #endif
 

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -317,7 +317,7 @@
 #define SYSCALL_touch_exclude_borders_ID 0x01fa000d
 #define SYSCALL_touch_set_state_ID       0x01fa000e
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-#define SYSCALL_touch_debug_ID 0x02fa000f
+#define SYSCALL_touch_debug_ID 0x03fa000f
 #endif
 
 #endif  // HAVE_SE_TOUCH

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -521,6 +521,7 @@ void io_seproxyhal_nfc_power(bool forceInit)
 
 #ifdef HAVE_SE_TOUCH
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
+#ifdef HAVE_GT1151_TOUCH
 /**
  * @brief Set touch in read raw data mode and read raw data
  *
@@ -529,7 +530,7 @@ void io_seproxyhal_nfc_power(bool forceInit)
  */
 bolos_bool_t io_seproxyhal_touch_debug_read_sensi(uint8_t *sensi_data)
 {
-    return touch_switch_debug_mode_and_read(TOUCH_DEBUG_READ_RAW_DATA, sensi_data);
+    return touch_switch_debug_mode_and_read(TOUCH_DEBUG_READ_RAW_DATA, 0, sensi_data);
 }
 
 /**
@@ -540,7 +541,7 @@ bolos_bool_t io_seproxyhal_touch_debug_read_sensi(uint8_t *sensi_data)
  */
 bolos_bool_t io_seproxyhal_touch_debug_read_diff_data(uint8_t *diff_data)
 {
-    return touch_switch_debug_mode_and_read(TOUCH_DEBUG_READ_DIFF_DATA, diff_data);
+    return touch_switch_debug_mode_and_read(TOUCH_DEBUG_READ_DIFF_DATA, 0, diff_data);
 }
 
 /**
@@ -551,8 +552,23 @@ bolos_bool_t io_seproxyhal_touch_debug_read_diff_data(uint8_t *diff_data)
  */
 bolos_bool_t io_seproxyhal_touch_debug_end(void)
 {
-    return touch_switch_debug_mode_and_read(TOUCH_DEBUG_END, NULL);
+    return touch_switch_debug_mode_and_read(TOUCH_DEBUG_END, 0, NULL);
 }
+#endif
+#ifdef HAVE_EWD_720_TOUCH
+/**
+ * @brief Read ewd720 touch offset data
+ *
+ * @param diff_data Pointer to the buffer to store diff data
+ * @return BOLOS_TRUE/BOLOS_FALSE
+ */
+bolos_bool_t io_seproxyhal_touch_debug_read_sensor_buffer(uint8_t  buffer_type,
+                                                          uint8_t *sensor_buffer)
+{
+    return touch_switch_debug_mode_and_read(
+        TOUCH_DEBUG_READ_SENSOR_BUFFER, buffer_type, sensor_buffer);
+}
+#endif
 #endif
 #endif
 

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -2168,11 +2168,14 @@ uint8_t touch_exclude_borders(uint8_t excluded_borders)
 }
 
 #ifdef HAVE_TOUCH_READ_DEBUG_DATA_SYSCALL
-uint8_t touch_switch_debug_mode_and_read(io_touch_debug_mode_t mode, uint8_t *read_buffer)
+uint8_t touch_switch_debug_mode_and_read(io_touch_debug_mode_t mode,
+                                         uint8_t               buffer_type,
+                                         uint8_t              *read_buffer)
 {
-    unsigned int parameters[2];
+    unsigned int parameters[3];
     parameters[0] = (unsigned int) mode;
-    parameters[1] = (unsigned int) read_buffer;
+    parameters[1] = (unsigned int) buffer_type;  // Only applicable to ewd720 touch
+    parameters[2] = (unsigned int) read_buffer;
     return (uint8_t) SVC_Call(SYSCALL_touch_debug_ID, parameters);
 }
 #endif


### PR DESCRIPTION
## Description

Add one parameter to touch_switch_debug_mode_and_read syscall, to allow reading offset data on europa touch

Write new method io_seproxyhal_touch_debug_read_offset_data for europa

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

New syscall parameter, new syscall ID

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
