### PR TITLE
lib_cxng: Introduce helpers for one-shot hashs

### DIFF
--- a/lib_cxng/include/lcx_blake2.h
+++ b/lib_cxng/include/lcx_blake2.h
@@ -34,6 +34,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/** BLAKE2B_256 message digest size */
+#define CX_BLAKE2B_256_SIZE 32
+
+/** BLAKE2B_512 message digest size */
+#define CX_BLAKE2B_512_SIZE 64
+
 /**  @private BLAKE2b constants */
 enum blake2b_constant {
     BLAKE2B_BLOCKBYTES    = 128,  ///< Size of a block
@@ -89,6 +95,80 @@ DEPRECATED static inline int cx_blake2b_init(cx_blake2b_t *hash, unsigned int ou
 {
     CX_THROW(cx_blake2b_init_no_throw(hash, out_len));
     return CX_BLAKE2B;
+}
+
+/**
+ * @brief   Computes a standalone one shot BLAKE2B_256 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_blake2b_256_hash_iovec(const cx_iovec_t *iovec,
+                                   size_t            iovec_len,
+                                   uint8_t           digest[static CX_BLAKE2B_256_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot BLAKE2B_256 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_blake2b_256_hash(const uint8_t *in,
+                                           size_t         in_len,
+                                           uint8_t        digest[static CX_BLAKE2B_256_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_blake2b_256_hash_iovec(&iovec, 1, digest);
+}
+
+/**
+ * @brief   Computes a standalone one shot BLAKE2B_512 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_blake2b_512_hash_iovec(const cx_iovec_t *iovec,
+                                   size_t            iovec_len,
+                                   uint8_t           digest[static CX_BLAKE2B_512_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot BLAKE2B_512 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_blake2b_512_hash(const uint8_t *in,
+                                           size_t         in_len,
+                                           uint8_t        digest[static CX_BLAKE2B_512_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_blake2b_512_hash_iovec(&iovec, 1, digest);
 }
 
 /**

--- a/lib_cxng/include/lcx_common.h
+++ b/lib_cxng/include/lcx_common.h
@@ -27,6 +27,7 @@
 #define LCX_COMMON_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define ARCH_LITTLE_ENDIAN
@@ -58,6 +59,14 @@ typedef struct uint64_s uint64bits_t;
 #else
 typedef uint64_t uint64bits_t;
 #endif
+
+/**
+ * @brief Similar to libc iovec type
+ */
+typedef struct {
+    const uint8_t *iov_base;
+    size_t         iov_len;
+} cx_iovec_t;
 
 // clang-format off
 /**

--- a/lib_cxng/include/lcx_ripemd160.h
+++ b/lib_cxng/include/lcx_ripemd160.h
@@ -79,6 +79,43 @@ static inline int cx_ripemd160_init(cx_ripemd160_t *hash)
 }
 
 /**
+ * @brief   Computes a standalone one shot Ripemd-160 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_ripemd160_hash_iovec(const cx_iovec_t *iovec,
+                                 size_t            iovec_len,
+                                 uint8_t           digest[static CX_RIPEMD160_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot Ripemd-160 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_ripemd160_hash(const uint8_t *in,
+                                         size_t         in_len,
+                                         uint8_t        digest[static CX_RIPEMD160_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_ripemd160_hash_iovec(&iovec, 1, digest);
+}
+
+/**
  * @brief   Computes a one shot Ripemd-160 digest.
  *
  * @param[in]  in      Input data.

--- a/lib_cxng/include/lcx_sha256.h
+++ b/lib_cxng/include/lcx_sha256.h
@@ -86,6 +86,43 @@ static inline int cx_sha224_init(cx_sha256_t *hash)
 #endif
 
 /**
+ * @brief   Computes a standalone one shot SHA-224 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha224_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA224_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA-224 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha224_hash(const uint8_t *in,
+                                      size_t         in_len,
+                                      uint8_t        digest[static CX_SHA224_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha224_hash_iovec(&iovec, 1, digest);
+}
+
+/**
  * @brief   Initializes a SHA-256 context.
  *
  * @param[out] hash Pointer to the context.
@@ -109,6 +146,43 @@ static inline int cx_sha256_init(cx_sha256_t *hash)
 {
     cx_sha256_init_no_throw(hash);
     return CX_SHA256;
+}
+
+/**
+ * @brief   Computes a standalone one shot SHA-256 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha256_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA256_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA-256 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha256_hash(const uint8_t *in,
+                                      size_t         in_len,
+                                      uint8_t        digest[static CX_SHA256_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha256_hash_iovec(&iovec, 1, digest);
 }
 
 /**

--- a/lib_cxng/include/lcx_sha3.h
+++ b/lib_cxng/include/lcx_sha3.h
@@ -35,6 +35,30 @@
 #include "lcx_hash.h"
 #include <stddef.h>
 
+/** SHA3_224 message digest size */
+#define CX_SHA3_224_SIZE 28
+
+/** SHA3_256 message digest size */
+#define CX_SHA3_256_SIZE 32
+
+/** SHA3_384 message digest size */
+#define CX_SHA3_384_SIZE 48
+
+/** SHA3_512 message digest size */
+#define CX_SHA3_512_SIZE 64
+
+/** KECCAK_224 message digest size */
+#define CX_KECCAK_224_SIZE 28
+
+/** KECCAK_256 message digest size */
+#define CX_KECCAK_256_SIZE 32
+
+/** KECCAK_384 message digest size */
+#define CX_KECCAK_384_SIZE 48
+
+/** KECCAK_512 message digest size */
+#define CX_KECCAK_512_SIZE 64
+
 /**
  * @brief KECCAK, SHA3 and SHA3-XOF context
  */
@@ -80,6 +104,154 @@ DEPRECATED static inline int cx_sha3_init(cx_sha3_t *hash, size_t size)
 }
 
 /**
+ * @brief   Computes a standalone one shot SHA3_224 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha3_224_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t           digest[static CX_SHA3_224_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA3_224 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha3_224_hash(const uint8_t *in,
+                                        size_t         in_len,
+                                        uint8_t        digest[static CX_SHA3_224_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha3_224_hash_iovec(&iovec, 1, digest);
+}
+
+/**
+ * @brief   Computes a standalone one shot SHA3_256 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha3_256_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t           digest[static CX_SHA3_256_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA3_256 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha3_256_hash(const uint8_t *in,
+                                        size_t         in_len,
+                                        uint8_t        digest[static CX_SHA3_256_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha3_256_hash_iovec(&iovec, 1, digest);
+}
+
+/**
+ * @brief   Computes a standalone one shot SHA3_384 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha3_384_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t           digest[static CX_SHA3_384_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA3_384 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha3_384_hash(const uint8_t *in,
+                                        size_t         in_len,
+                                        uint8_t        digest[static CX_SHA3_384_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha3_384_hash_iovec(&iovec, 1, digest);
+}
+
+/**
+ * @brief   Computes a standalone one shot SHA3_512 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha3_512_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t           digest[static CX_SHA3_512_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA3_512 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha3_512_hash(const uint8_t *in,
+                                        size_t         in_len,
+                                        uint8_t        digest[static CX_SHA3_512_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha3_512_hash_iovec(&iovec, 1, digest);
+}
+
+/**
  * @brief Initializes a KECCAK context.
  *
  * @details Supported output sizes in bits:
@@ -108,6 +280,154 @@ DEPRECATED static inline int cx_keccak_init(cx_sha3_t *hash, size_t size)
 {
     CX_THROW(cx_keccak_init_no_throw(hash, size));
     return CX_KECCAK;
+}
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_224 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_keccak_224_hash_iovec(const cx_iovec_t *iovec,
+                                  size_t            iovec_len,
+                                  uint8_t           digest[static CX_KECCAK_224_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_224 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_keccak_224_hash(const uint8_t *in,
+                                          size_t         in_len,
+                                          uint8_t        digest[static CX_KECCAK_224_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_keccak_224_hash_iovec(&iovec, 1, digest);
+}
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_256 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_keccak_256_hash_iovec(const cx_iovec_t *iovec,
+                                  size_t            iovec_len,
+                                  uint8_t           digest[static CX_KECCAK_256_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_256 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_keccak_256_hash(const uint8_t *in,
+                                          size_t         in_len,
+                                          uint8_t        digest[static CX_KECCAK_256_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_keccak_256_hash_iovec(&iovec, 1, digest);
+}
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_384 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_keccak_384_hash_iovec(const cx_iovec_t *iovec,
+                                  size_t            iovec_len,
+                                  uint8_t           digest[static CX_KECCAK_384_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_384 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_keccak_384_hash(const uint8_t *in,
+                                          size_t         in_len,
+                                          uint8_t        digest[static CX_KECCAK_384_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_keccak_384_hash_iovec(&iovec, 1, digest);
+}
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_512 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_keccak_512_hash_iovec(const cx_iovec_t *iovec,
+                                  size_t            iovec_len,
+                                  uint8_t           digest[static CX_KECCAK_512_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot KECCAK_512 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_keccak_512_hash(const uint8_t *in,
+                                          size_t         in_len,
+                                          uint8_t        digest[static CX_KECCAK_512_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_keccak_512_hash_iovec(&iovec, 1, digest);
 }
 
 /**
@@ -141,6 +461,49 @@ DEPRECATED static inline int cx_shake128_init(cx_sha3_t *hash, unsigned int out_
 }
 
 /**
+ * @brief   Computes a standalone one shot SHAKE128 digest.
+ *
+ * @param[in]  iovec       Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len   Length of the iovec array.
+ *
+ * @param[out] digest      Buffer where to store the digest.
+ *
+ * @param[in]  out_length  Length of the output in bytes.
+ *
+ * @return                 Error code:
+ *                         - CX_OK on success
+ */
+cx_err_t cx_shake128_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t          *digest,
+                                size_t            out_length);
+
+/**
+ * @brief   Computes a standalone one shot SHAKE128 digest.
+ *
+ * @param[in]  in         Input data.
+ *
+ * @param[in]  len        Length of the input data.
+ *
+ * @param[out] digest     Buffer where to store the digest.
+ *
+ * @param[in]  out_length Length of the output in bytes.
+ *
+ * @return                Error code:
+ *                        - CX_OK on success
+ */
+static inline cx_err_t cx_shake128_hash(const uint8_t *in,
+                                        size_t         in_len,
+                                        uint8_t       *digest,
+                                        size_t         out_length)
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_shake128_hash_iovec(&iovec, 1, digest, out_length);
+}
+
+/**
  * @brief   Initializes a SHA3-XOF context.
  *
  * @details SHAKE256 is a SHA3-XOF (Extendable Output Function
@@ -164,10 +527,52 @@ WARN_UNUSED_RESULT cx_err_t cx_shake256_init_no_throw(cx_sha3_t *hash, size_t ou
  * @deprecated
  * See #cx_shake256_init_no_throw
  */
-DEPRECATED static inline int cx_shake256_init(cx_sha3_t *hash, unsigned int out_size)
+DEPRECATED static inline int cx_shake256_init(cx_sha3_t *hash, unsigned int out_length)
 {
-    CX_THROW(cx_shake256_init_no_throw(hash, out_size));
+    CX_THROW(cx_shake256_init_no_throw(hash, out_length));
     return CX_SHAKE256;
+}
+/**
+ * @brief   Computes a standalone one shot SHAKE256 digest.
+ *
+ * @param[in]  iovec      Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len  Length of the iovec array.
+ *
+ * @param[out] digest     Buffer where to store the digest.
+ *
+ * @param[in]  out_length Length of the output in bytes.
+ *
+ * @return                Error code:
+ *                        - CX_OK on success
+ */
+cx_err_t cx_shake256_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t          *digest,
+                                size_t            out_length);
+
+/**
+ * @brief   Computes a standalone one shot SHAKE256 digest.
+ *
+ * @param[in]  in         Input data.
+ *
+ * @param[in]  len        Length of the input data.
+ *
+ * @param[out] digest     Buffer where to store the digest.
+ *
+ * @param[in]  out_length Length of the output in bytes.
+ *
+ * @return                Error code:
+ *                        - CX_OK on success
+ */
+static inline cx_err_t cx_shake256_hash(const uint8_t *in,
+                                        size_t         in_len,
+                                        uint8_t       *digest,
+                                        size_t         out_length)
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_shake256_hash_iovec(&iovec, 1, digest, out_length);
 }
 
 /**

--- a/lib_cxng/include/lcx_sha512.h
+++ b/lib_cxng/include/lcx_sha512.h
@@ -76,6 +76,43 @@ static inline int cx_sha384_init(cx_sha512_t *hash)
 }
 
 /**
+ * @brief   Computes a standalone one shot SHA-384 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha384_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA384_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA-384 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha384_hash(const uint8_t *in,
+                                      size_t         in_len,
+                                      uint8_t        digest[static CX_SHA384_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha384_hash_iovec(&iovec, 1, digest);
+}
+
+/**
  * @brief   Initializes a SHA-512 context.
  *
  * @param[out] hash Pointer to the context.
@@ -99,6 +136,43 @@ static inline int cx_sha512_init(cx_sha512_t *hash)
 {
     cx_sha512_init_no_throw(hash);
     return CX_SHA512;
+}
+
+/**
+ * @brief   Computes a standalone one shot SHA-512 digest.
+ *
+ * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.
+ *
+ * @param[in]  iovec_len Length of the iovec array.
+ *
+ * @param[out] digest    Buffer where to store the digest.
+ *
+ * @return               Error code:
+ *                       - CX_OK on success
+ */
+cx_err_t cx_sha512_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA512_SIZE]);
+
+/**
+ * @brief   Computes a standalone one shot SHA-512 digest.
+ *
+ * @param[in]  in      Input data.
+ *
+ * @param[in]  len     Length of the input data.
+ *
+ * @param[out] digest  Buffer where to store the digest.
+ *
+ * @return             Error code:
+ *                     - CX_OK on success
+ */
+static inline cx_err_t cx_sha512_hash(const uint8_t *in,
+                                      size_t         in_len,
+                                      uint8_t        digest[static CX_SHA512_SIZE])
+{
+    const cx_iovec_t iovec = {.iov_base = in, .iov_len = in_len};
+
+    return cx_sha512_hash_iovec(&iovec, 1, digest);
 }
 
 /**

--- a/src/cx_hash_iovec.c
+++ b/src/cx_hash_iovec.c
@@ -1,0 +1,245 @@
+
+/*******************************************************************************
+ *   (c) 2023 Ledger SAS.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+#include <stdint.h>   // uint*_t
+#include <string.h>   // memset, explicit_bzero
+#include <stdbool.h>  // bool
+
+#include "bolos_target.h"
+#include "cx.h"
+#include "lib_cxng/src/cx_ram.h"
+
+#ifdef TARGET_NANOS
+// The G_cx symbol is already defined in some apps.
+// In such cases, do not redefine it to avoid conflicts.
+__attribute__((weak)) union cx_u G_cx;
+#endif
+
+static cx_err_t hash_iovec(cx_hash_t        *hash_ctx,
+                           size_t            hash_ctx_size,
+                           cx_md_t           hash_id,
+                           const cx_iovec_t *iovec,
+                           size_t            iovec_len,
+                           uint8_t          *digest)
+{
+    cx_err_t error;
+
+    CX_CHECK(cx_hash_init(hash_ctx, hash_id));
+    for (size_t i = 0; i < iovec_len; i++) {
+        CX_CHECK(cx_hash_update(hash_ctx, iovec[i].iov_base, iovec[i].iov_len));
+    }
+    CX_CHECK(cx_hash_final(hash_ctx, digest));
+
+end:
+    explicit_bzero(hash_ctx, hash_ctx_size);
+
+    return error;
+}
+
+static cx_err_t hash_iovec_ex(cx_hash_t        *hash_ctx,
+                              size_t            hash_ctx_size,
+                              cx_md_t           hash_id,
+                              size_t            hash_digest_len,
+                              const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t          *digest)
+{
+    cx_err_t error;
+
+    CX_CHECK(cx_hash_init_ex(hash_ctx, hash_id, hash_digest_len));
+    for (size_t i = 0; i < iovec_len; i++) {
+        CX_CHECK(cx_hash_update(hash_ctx, iovec[i].iov_base, iovec[i].iov_len));
+    }
+    CX_CHECK(cx_hash_final(hash_ctx, digest));
+
+end:
+    explicit_bzero(hash_ctx, hash_ctx_size);
+
+    return error;
+}
+
+#ifdef HAVE_RIPEMD160
+cx_err_t cx_ripemd160_hash_iovec(const cx_iovec_t *iovec,
+                                 size_t            iovec_len,
+                                 uint8_t           digest[static CX_RIPEMD160_SIZE])
+{
+#ifdef TARGET_NANOS
+    cx_ripemd160_t *hash = &G_cx.ripemd160;
+#else
+    cx_ripemd160_t  ripemd160;
+    cx_ripemd160_t *hash = &ripemd160;
+#endif
+
+    return hash_iovec(
+        &hash->header, sizeof(cx_ripemd160_t), CX_RIPEMD160, iovec, iovec_len, digest);
+}
+#endif
+
+#ifdef HAVE_SHA224
+
+cx_err_t cx_sha224_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA224_SIZE])
+{
+#ifdef TARGET_NANOS
+    cx_sha256_t *hash = &G_cx.sha256;
+#else
+    cx_sha256_t     sha256;
+    cx_sha256_t    *hash = &sha256;
+#endif
+
+    return hash_iovec(&hash->header, sizeof(cx_sha256_t), CX_SHA224, iovec, iovec_len, digest);
+}
+#endif
+
+#ifdef HAVE_SHA256
+cx_err_t cx_sha256_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA256_SIZE])
+{
+#ifdef TARGET_NANOS
+    cx_sha256_t *hash = &G_cx.sha256;
+#else
+    cx_sha256_t     sha256;
+    cx_sha256_t    *hash = &sha256;
+#endif
+
+    return hash_iovec(&hash->header, sizeof(cx_sha256_t), CX_SHA256, iovec, iovec_len, digest);
+}
+#endif
+
+#ifdef HAVE_SHA384
+cx_err_t cx_sha384_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA384_SIZE])
+{
+#ifdef TARGET_NANOS
+    cx_sha512_t *hash = &G_cx.sha512;
+#else
+    cx_sha512_t     sha512;
+    cx_sha512_t    *hash = &sha512;
+#endif
+
+    return hash_iovec(&hash->header, sizeof(cx_sha512_t), CX_SHA384, iovec, iovec_len, digest);
+}
+#endif
+
+#ifdef HAVE_SHA512
+cx_err_t cx_sha512_hash_iovec(const cx_iovec_t *iovec,
+                              size_t            iovec_len,
+                              uint8_t           digest[static CX_SHA512_SIZE])
+{
+#ifdef TARGET_NANOS
+    cx_sha512_t *hash = &G_cx.sha512;
+#else
+    cx_sha512_t     sha512;
+    cx_sha512_t    *hash = &sha512;
+#endif
+
+    return hash_iovec(&hash->header, sizeof(cx_sha512_t), CX_SHA512, iovec, iovec_len, digest);
+}
+#endif
+
+#ifdef HAVE_SHA3
+#ifdef TARGET_NANOS
+#define ALLOCATE_SHA3_HASH() cx_sha3_t *hash = &G_cx.sha3
+#else
+#define ALLOCATE_SHA3_HASH() \
+    cx_sha3_t  sha3;         \
+    cx_sha3_t *hash = &sha3
+#endif
+
+#define CX_SHA3_BASED_FUNC(func_name, hash_id, digest_len)                                    \
+    cx_err_t func_name(                                                                       \
+        const cx_iovec_t *iovec, size_t iovec_len, uint8_t digest[static digest_len])         \
+    {                                                                                         \
+        ALLOCATE_SHA3_HASH();                                                                 \
+        return hash_iovec_ex(                                                                 \
+            &hash->header, sizeof(cx_sha3_t), hash_id, digest_len, iovec, iovec_len, digest); \
+    }
+
+CX_SHA3_BASED_FUNC(cx_sha3_224_hash_iovec, CX_SHA3, CX_SHA3_224_SIZE)
+CX_SHA3_BASED_FUNC(cx_sha3_256_hash_iovec, CX_SHA3, CX_SHA3_256_SIZE)
+CX_SHA3_BASED_FUNC(cx_sha3_384_hash_iovec, CX_SHA3, CX_SHA3_384_SIZE)
+CX_SHA3_BASED_FUNC(cx_sha3_512_hash_iovec, CX_SHA3, CX_SHA3_512_SIZE)
+
+CX_SHA3_BASED_FUNC(cx_keccak_224_hash_iovec, CX_KECCAK, CX_KECCAK_224_SIZE)
+CX_SHA3_BASED_FUNC(cx_keccak_256_hash_iovec, CX_KECCAK, CX_KECCAK_256_SIZE)
+CX_SHA3_BASED_FUNC(cx_keccak_384_hash_iovec, CX_KECCAK, CX_KECCAK_384_SIZE)
+CX_SHA3_BASED_FUNC(cx_keccak_512_hash_iovec, CX_KECCAK, CX_KECCAK_512_SIZE)
+
+cx_err_t cx_shake128_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t          *digest,
+                                size_t            out_length)
+{
+    ALLOCATE_SHA3_HASH();
+    return hash_iovec_ex(
+        &hash->header, sizeof(cx_sha3_t), CX_SHAKE128, out_length, iovec, iovec_len, digest);
+}
+
+cx_err_t cx_shake256_hash_iovec(const cx_iovec_t *iovec,
+                                size_t            iovec_len,
+                                uint8_t          *digest,
+                                size_t            out_length)
+{
+    ALLOCATE_SHA3_HASH();
+    return hash_iovec_ex(
+        &hash->header, sizeof(cx_sha3_t), CX_SHAKE256, out_length, iovec, iovec_len, digest);
+}
+#endif
+
+#ifdef HAVE_BLAKE2
+cx_err_t cx_blake2b_256_hash_iovec(const cx_iovec_t *iovec,
+                                   size_t            iovec_len,
+                                   uint8_t           digest[static CX_BLAKE2B_256_SIZE])
+{
+#ifdef TARGET_NANOS
+    cx_blake2b_t *hash = &G_cx.blake.blake2b;
+#else
+    cx_blake2b_t    blake;
+    cx_blake2b_t   *hash = &blake;
+#endif
+
+    return hash_iovec_ex(&hash->header,
+                         sizeof(cx_blake2b_t),
+                         CX_BLAKE2B,
+                         CX_BLAKE2B_256_SIZE,
+                         iovec,
+                         iovec_len,
+                         digest);
+}
+
+cx_err_t cx_blake2b_512_hash_iovec(const cx_iovec_t *iovec,
+                                   size_t            iovec_len,
+                                   uint8_t           digest[static CX_BLAKE2B_512_SIZE])
+{
+#ifdef TARGET_NANOS
+    cx_blake2b_t *hash = &G_cx.blake.blake2b;
+#else
+    cx_blake2b_t    blake;
+    cx_blake2b_t   *hash = &blake;
+#endif
+
+    return hash_iovec_ex(&hash->header,
+                         sizeof(cx_blake2b_t),
+                         CX_BLAKE2B,
+                         CX_BLAKE2B_512_SIZE,
+                         iovec,
+                         iovec_len,
+                         digest);
+}
+#endif


### PR DESCRIPTION
## Description

lib_cxng: Introduce helpers for one-shot hashs

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Tests:

Tested on Speculos and on device (NanoS and NanoX) with the following app-boilerplate patch:
[patch.txt](https://github.com/LedgerHQ/ledger-secure-sdk/files/14344832/patch.txt)


