### PR TITLE
Extend #ifdef HAVE_SHA224

### DIFF
--- a/lib_cxng/include/lcx_sha256.h
+++ b/lib_cxng/include/lcx_sha256.h
@@ -83,7 +83,6 @@ static inline int cx_sha224_init(cx_sha256_t *hash)
     cx_sha224_init_no_throw(hash);
     return CX_SHA224;
 }
-#endif
 
 /**
  * @brief   Computes a standalone one shot SHA-224 digest.
@@ -121,6 +120,7 @@ static inline cx_err_t cx_sha224_hash(const uint8_t *in,
 
     return cx_sha224_hash_iovec(&iovec, 1, digest);
 }
+#endif  // HAVE_SHA224
 
 /**
  * @brief   Initializes a SHA-256 context.


### PR DESCRIPTION
## Description

Fix build issue when HAVE_SHA256 is defined but not HAVE_SHA224.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
