### PR TITLE
Fix NFC support on Europa

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -31,10 +31,9 @@ endif
 #                               NFC                                 #
 #####################################################################
 ifeq ($(ENABLE_NFC), 1)
-ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME), TARGET_STAX))
+ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME), TARGET_STAX, TARGET_EUROPA))
     HAVE_APPLICATION_FLAG_BOLOS_SETTINGS = 1
     DEFINES += HAVE_NFC
-    SDK_SOURCE_PATH += lib_nfc
 endif
 endif
 


### PR DESCRIPTION
## Description

Add TARGET_EUROPA in makefile.standard_app for NFC support
Remove lib_nfc/ from SDK_SOURCE_PATH (Only used by the OS)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
