### PR TITLE
Handle swipe on screens without swipeable objects

### DIFF
--- a/lib_nbgl/src/nbgl_touch.c
+++ b/lib_nbgl/src/nbgl_touch.c
@@ -233,15 +233,20 @@ void nbgl_touchHandler(nbgl_touchStatePosition_t *touchStatePosition, uint32_t c
     memcpy(&lastTouchedPosition, touchStatePosition, sizeof(nbgl_touchStatePosition_t));
 
     if (touchStatePosition->state == RELEASED) {
-        nbgl_touchType_t swipe = nbgl_detectSwipe(touchStatePosition, &firstTouchedPosition);
+        nbgl_touchType_t swipe    = nbgl_detectSwipe(touchStatePosition, &firstTouchedPosition);
+        bool             consumed = false;
 
         if (swipe != NB_TOUCH_TYPES) {
             // Swipe detected
-            lastPressedObj = getSwipableObject(nbgl_screenGetTop(), swipe);
-            applytouchStatePosition(lastPressedObj, swipe);
+            nbgl_obj_t *swipedObj = getSwipableObject(nbgl_screenGetTop(), swipe);
+            // if a swipable object has been found
+            if (swipedObj) {
+                applytouchStatePosition(swipedObj, swipe);
+                consumed = true;
+            }
         }
-        else if ((lastPressedObj != NULL)
-                 && ((foundObj == lastPressedObj) || (nbgl_screenContainsObj(lastPressedObj)))) {
+        if (!consumed && (lastPressedObj != NULL)
+            && ((foundObj == lastPressedObj) || (nbgl_screenContainsObj(lastPressedObj)))) {
             // very strange if lastPressedObj != foundObj, let's consider that it's a normal release
             // on lastPressedObj make sure lastPressedObj still belongs to current screen before
             // "releasing" it


### PR DESCRIPTION
## Description

The goal of this PR is to handle swipe gesture detection (by polling) in the case of screens without swipeable objects.
In this case, the event shall not be seen as a swipe but as a regular touch release.

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

