### PR TITLE
Fix typo in Makefile.standard_app for NFC activation

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -31,7 +31,7 @@ endif
 #                               NFC                                 #
 #####################################################################
 ifeq ($(ENABLE_NFC), 1)
-ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME), TARGET_STAX, TARGET_EUROPA))
+ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME), TARGET_STAX TARGET_EUROPA))
     HAVE_APPLICATION_FLAG_BOLOS_SETTINGS = 1
     DEFINES += HAVE_NFC
 endif


### PR DESCRIPTION
## Description

This PR fixes a typo in Makefile.standard_app that lead to NFC not beeing complied even if ENABLE_NFC=1 was present in app Makefile

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
