### PR TITLE
Europa nbgl use case: No "Skip" bttn at sign page

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -503,10 +503,8 @@ static void displayReviewPage(uint8_t page, bool forceFullRefresh)
 #endif  // TARGET_STAX
         content.infoLongPress.longPressToken = CONFIRM_TOKEN;
         if (forwardNavOnly) {
-            // remove the "Skip" button in Footer
-#ifdef TARGET_STAX
+            // remove the "Skip" button
             navInfo.skipText = NULL;
-#endif  // TARGET_STAX
         }
     }
     else {


### PR DESCRIPTION
## Description

Fix Europa nbgl use_case: remove "Skip" button in confirmation page

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

