### PR TITLE
Makefile.app_params: Keep only last appFlags value

### DIFF
--- a/Makefile.app_params
+++ b/Makefile.app_params
@@ -105,7 +105,7 @@ APP_LOAD_PARAMS += --apiLevel $(API_LEVEL)
 APP_LOAD_PARAMS += --fileName bin/app.hex
 APP_LOAD_PARAMS += --appName $(APPNAME)
 ifneq ($(APP_FLAGS_APP_LOAD_PARAMS),)
-	APP_LOAD_PARAMS += --appFlags $(APP_FLAGS_APP_LOAD_PARAMS)
+	APP_LOAD_PARAMS += --appFlags $(lastword $(APP_FLAGS_APP_LOAD_PARAMS))
 endif
 APP_LOAD_PARAMS += --delete
 APP_LOAD_PARAMS += --tlv


### PR DESCRIPTION
## Description

Makefile.app_params: Keep only last appFlags value

This is fixing issues where app set multiples value for Nanox, and only the last one was used by LedgerBlue loadApp script, but the new Makefile.app_params was generating invalid parameter in such cases.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
