### PR TITLE
Fix FWEO-1047 - Inverted shift and caps lock icons

### DIFF
--- a/lib_nbgl/serialization/nbgl_lib.py
+++ b/lib_nbgl/serialization/nbgl_lib.py
@@ -121,16 +121,7 @@ def parse_str(data: bytes) -> str:
 
     Returns the string
     """
-    size = 0
-    for b in data:
-        size += 1
-        if b == 0:
-            break
-
-    if size > 0:
-        return data[:size-1].decode()
-
-    return ""
+    return data.split(b'\x00')[0].decode()
 
 
 class NbglGenericJsonSerializable(ABC):

--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -350,7 +350,7 @@ static void keyboardDrawLetters(nbgl_keyboard_t *keyboard)
         nbgl_drawIcon(
             &rectArea,
             (keyboard->casing != LOWER_CASE) ? WHITE : BLACK,
-            (keyboard->casing != LOCKED_UPPER_CASE) ? (&C_shift_lock32px) : (&C_shift32px));
+            (keyboard->casing == LOCKED_UPPER_CASE) ? (&C_shift_lock32px) : (&C_shift32px));
         rectArea.backgroundColor = WHITE;
         offsetX                  = keyboard->obj.area.x0 + SHIFT_KEY_WIDTH;
     }


### PR DESCRIPTION
(cherry picked from commit 9fd7b8d721461c4be230a21db30b31a180c70ee8)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

