### PR TITLE
Check nfc rAPDU against maximum NFC apdu size the MCU can handle

### DIFF
--- a/include/os_io_seproxyhal.h
+++ b/include/os_io_seproxyhal.h
@@ -135,6 +135,8 @@ void io_seproxyhal_send_nbgl_serialized(nbgl_serialized_event_type_e event, nbgl
 void io_set_timeout(unsigned int timeout);
 
 #ifdef HAVE_NFC
+// Needs to be aligned with RFAL_FEATURE_ISO_DEP_IBLOCK_MAX_LEN defined on mcu side in platform.h
+#define NFC_APDU_MAX_SIZE 256
 void io_seproxyhal_nfc_power(bool forceInit);
 #endif
 

--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -1354,7 +1354,8 @@ reply_apdu:
                             break;
 #ifdef HAVE_NFC
                         case APDU_NFC:
-                            if (tx_len > sizeof(G_io_apdu_buffer)) {
+                            if ((tx_len > sizeof(G_io_apdu_buffer))
+                                || (tx_len > NFC_APDU_MAX_SIZE)) {
                                 THROW(INVALID_PARAMETER);
                             }
                             // reply the NFC APDU over SEPROXYHAL protocol


### PR DESCRIPTION
## Description

Add new define NFC_APDU_MAX_SIZE (256), and check it against tx_len before sending nfc rAPDU.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Additional comments

This modification allows the OS to catch an nfc rAPDU overflow, before forwarding the rAPDU to the MCU
