### PR TITLE
Europa: Always declare nbgl_hardwareSwipe_t

### DIFF
--- a/include/os_io.h
+++ b/include/os_io.h
@@ -81,9 +81,7 @@ typedef struct io_touch_info_s {
     uint8_t  state;
     uint8_t  w;
     uint8_t  h;
-#ifdef HAVE_HW_TOUCH_SWIPE
-    uint8_t swipe;
-#endif  // HAVE_HW_TOUCH_SWIPE
+    uint8_t  swipe;
 } io_touch_info_t;
 
 // bitfield for exclusion borders, for touch_exclude_borders() (if a bit is set, means that pixels

--- a/lib_nbgl/include/nbgl_types.h
+++ b/lib_nbgl/include/nbgl_types.h
@@ -199,7 +199,6 @@ typedef enum {
     PRESSED,   ///< the finger is currently pressing the screen
 } nbgl_touchState_t;
 
-#ifdef HAVE_HW_TOUCH_SWIPE
 /**
  * @brief Hardware powered detected swipe states
  */
@@ -210,7 +209,6 @@ typedef enum {
     HARDWARE_SWIPE_LEFT,
     NO_HARDWARE_SWIPE,
 } nbgl_hardwareSwipe_t;
-#endif  // HAVE_HW_TOUCH_SWIPE
 
 /**
  * @brief The different types of Touchscreen events


### PR DESCRIPTION
Declare nbgl_hardwareSwipe_t even if `HAVE_HW_TOUCH_SWIPE` is not defined. This type is needed for production testing, even if hardware swipe is not used in SDK.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
