### PR TITLE
NBGL: Check onModalConfirm != NULL before call

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -417,7 +417,9 @@ static void pageModalCallback(int token, uint8_t index)
     }
     else if (token == CHOICE_TOKEN) {
         if (index == 0) {
-            onModalConfirm();
+            if (onModalConfirm != NULL) {
+                onModalConfirm();
+            }
         }
         else {
             // display background, which should be the page where skip has been touched


### PR DESCRIPTION
onModalConfirm was not checked in nbgl_use_case, leading to potential crashes

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
