### PR TITLE
Add concept of Keyboard & Keypad contents to solve alignment issues in some screens

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -318,6 +318,59 @@ typedef struct {
 } nbgl_layoutButton_t;
 
 /**
+ * @brief The different types of keyboard contents
+ *
+ */
+typedef enum {
+    KEYBOARD_WITH_SUGGESTIONS,  ///< text entry area + suggestion buttons
+    KEYBOARD_WITH_BUTTON,       ///< text entry area + confirmation button
+    NB_KEYBOARD_CONTENT_TYPES
+} nbgl_layoutKeyboardContentType_t;
+
+/**
+ * @brief This structure contains info to build suggestion buttons
+ */
+typedef struct {
+    const char **buttons;  ///< array of 4 strings for buttons (last ones can be NULL)
+    int firstButtonToken;  ///< first token used for buttons, provided in onActionCallback (the next
+                           ///< 3 values will be used for other buttons)
+    uint8_t nbUsedButtons;  ///< the number of actually used buttons
+} nbgl_layoutSuggestionButtons_t;
+
+/**
+ * @brief This structure contains info to build a confirmation button
+ */
+typedef struct {
+    const char *text;    ///< text of the button
+    int         token;   ///< token of the button
+    bool        active;  ///< if true, button is active, otherwise inactive (grayed-out)
+} nbgl_layoutConfirmationButton_t;
+
+/**
+ * @brief This structure contains info to build a keyboard content (controls that are linked to
+ * keyboard)
+ */
+typedef struct {
+    nbgl_layoutKeyboardContentType_t type;   ///< type of content
+    const char                      *title;  ///< centered title explaining the screen
+    const char                      *text;   ///< already entered text
+    bool    numbered;   ///< if set to true, the text is preceded on the left by 'number.'
+    uint8_t number;     ///< if numbered is true, number used to build 'number.' text
+    bool    grayedOut;  ///< if true, the text is grayed out (but not the potential number)
+    int     textToken;  ///< the token that will be used as argument of the callback when text is
+                        ///< touched
+    union {
+        nbgl_layoutSuggestionButtons_t
+            suggestionButtons;  /// used if type is @ref KEYBOARD_WITH_SUGGESTIONS
+        nbgl_layoutConfirmationButton_t
+            confirmationButton;  /// used if type is @ref KEYBOARD_WITH_BUTTON
+    };
+#ifdef HAVE_PIEZO_SOUND
+    tune_index_e tuneId;  ///< if not @ref NBGL_NO_TUNE, a tune will be played
+#endif                    // HAVE_PIEZO_SOUND
+} nbgl_layoutKeyboardContent_t;
+
+/**
  * @brief The different types of extended header
  *
  */
@@ -527,43 +580,46 @@ int nbgl_layoutAddMenuList(nbgl_layout_t *layout, nbgl_layoutMenuList_t *list);
 /* layout objects for page with keyboard */
 int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInfo);
 #ifdef HAVE_SE_TOUCH
-int  nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout,
-                               uint8_t        index,
-                               uint32_t       keyMask,
-                               bool           updateCasing,
-                               keyboardCase_t casing);
-bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index);
-int  nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
-                                     uint8_t        nbUsedButtons,
-                                     const char    *buttonTexts[NB_MAX_SUGGESTION_BUTTONS],
-                                     int            firstButtonToken,
-                                     tune_index_e   tuneId);
-int  nbgl_layoutUpdateSuggestionButtons(nbgl_layout_t *layout,
-                                        uint8_t        index,
-                                        uint8_t        nbUsedButtons,
-                                        const char    *buttonTexts[NB_MAX_SUGGESTION_BUTTONS]);
-int  nbgl_layoutAddEnteredText(nbgl_layout_t *layout,
-                               bool           numbered,
-                               uint8_t        number,
-                               const char    *text,
-                               bool           grayedOut,
-                               int            offsetY,
-                               int            token);
-int  nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
-                                  uint8_t        index,
-                                  bool           numbered,
-                                  uint8_t        number,
-                                  const char    *text,
-                                  bool           grayedOut);
-int  nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout,
-                                      bool           active,
-                                      const char    *text,
-                                      int            token,
-                                      tune_index_e   tuneId);
-int  nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout,
+int            nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout,
                                          uint8_t        index,
-                                         bool           active,
-                                         const char    *text);
+                                         uint32_t       keyMask,
+                                         bool           updateCasing,
+                                         keyboardCase_t casing);
+bool           nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index);
+DEPRECATED int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
+                                               uint8_t        nbUsedButtons,
+                                               const char  *buttonTexts[NB_MAX_SUGGESTION_BUTTONS],
+                                               int          firstButtonToken,
+                                               tune_index_e tuneId);
+DEPRECATED int nbgl_layoutUpdateSuggestionButtons(
+    nbgl_layout_t *layout,
+    uint8_t        index,
+    uint8_t        nbUsedButtons,
+    const char    *buttonTexts[NB_MAX_SUGGESTION_BUTTONS]);
+DEPRECATED int nbgl_layoutAddEnteredText(nbgl_layout_t *layout,
+                                         bool           numbered,
+                                         uint8_t        number,
+                                         const char    *text,
+                                         bool           grayedOut,
+                                         int            offsetY,
+                                         int            token);
+DEPRECATED int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
+                                            uint8_t        index,
+                                            bool           numbered,
+                                            uint8_t        number,
+                                            const char    *text,
+                                            bool           grayedOut);
+DEPRECATED int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout,
+                                                bool           active,
+                                                const char    *text,
+                                                int            token,
+                                                tune_index_e   tuneId);
+DEPRECATED int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout,
+                                                   uint8_t        index,
+                                                   bool           active,
+                                                   const char    *text);
+int nbgl_layoutAddKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardContent_t *content);
+int nbgl_layoutUpdateKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardContent_t *content);
 #else   // HAVE_SE_TOUCH
 int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout, uint8_t index, uint32_t keyMask);
 int nbgl_layoutAddEnteredText(nbgl_layout_t *layout, const char *text, bool lettersOnly);
@@ -580,10 +636,20 @@ int nbgl_layoutUpdateKeypad(nbgl_layout_t *layout,
                             bool           enableValidate,
                             bool           enableBackspace,
                             bool           enableDigits);
-int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits);
-int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t nbActive);
-int nbgl_layoutAddEnteredDigits(nbgl_layout_t *layout, const char *text, int offsetY);
-int nbgl_layoutUpdateEnteredDigits(nbgl_layout_t *layout, uint8_t index, const char *text);
+DEPRECATED int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits);
+DEPRECATED int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout,
+                                             uint8_t        index,
+                                             uint8_t        nbActive);
+int            nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
+                                           const char    *title,
+                                           bool           hidden,
+                                           uint8_t        nbDigits,
+                                           const char    *text);
+int            nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
+                                              bool           hidden,
+                                              uint8_t        nbActiveDigits,
+                                              const char    *text);
+
 #else   // HAVE_SE_TOUCH
 /* layout objects for pages with keypad (nanos) */
 int nbgl_layoutAddKeypad(nbgl_layout_t     *layout,

--- a/lib_nbgl/src/nbgl_layout_keyboard.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard.c
@@ -21,7 +21,6 @@
 #include "glyphs.h"
 #include "os_pic.h"
 #include "os_helpers.h"
-#include "lcx_rng.h"
 
 /*********************
  *      DEFINES
@@ -37,6 +36,9 @@ enum {
     FIRST_BUTTON_INDEX
 };
 #endif  // TARGET_STAX
+
+#define TEXT_ENTRY_NORMAL_HEIGHT  64
+#define TEXT_ENTRY_COMPACT_HEIGHT 56
 
 /**********************
  *      MACROS
@@ -172,171 +174,161 @@ bool keyboardSwipeCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType)
 }
 #endif  // TARGET_STAX
 
-/**********************
- *   GLOBAL API FUNCTIONS
- **********************/
-
-/**
- * @brief Creates a keyboard on bottom of the screen, with the given configuration
- *
- * @param layout the current layout
- * @param kbdInfo configuration of the keyboard to draw (including the callback when touched)
- * @return the index of keyboard, to use in @ref nbgl_layoutUpdateKeyboard()
- */
-int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInfo)
+static nbgl_container_t *addTextEntry(nbgl_layoutInternal_t *layoutInt,
+                                      const char            *title,
+                                      const char            *text,
+                                      bool                   numbered,
+                                      uint8_t                number,
+                                      bool                   grayedOut,
+                                      int                    textToken,
+                                      bool                   compactMode)
 {
-    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
-    nbgl_keyboard_t       *keyboard;
+    nbgl_container_t *container;
+    nbgl_text_area_t *textArea;
+    layoutObj_t      *obj;
+    uint16_t          textEntryHeight
+        = (compactMode ? TEXT_ENTRY_COMPACT_HEIGHT : TEXT_ENTRY_NORMAL_HEIGHT) - 8;
 
-    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddKeyboard():\n");
-    if (layout == NULL) {
-        return -1;
-    }
-
-    // create keyboard
-    keyboard = (nbgl_keyboard_t *) nbgl_objPoolGet(KEYBOARD, layoutInt->layer);
-#ifdef TARGET_STAX
-    keyboard->obj.alignmentMarginY = 64;
-#endif  // TARGET_STAX
-    keyboard->obj.alignment = BOTTOM_MIDDLE;
-    keyboard->borderColor   = LIGHT_GRAY;
-    keyboard->callback      = PIC(kbdInfo->callback);
-    keyboard->lettersOnly   = kbdInfo->lettersOnly;
-    keyboard->mode          = kbdInfo->mode;
-    keyboard->keyMask       = kbdInfo->keyMask;
-    keyboard->casing        = kbdInfo->casing;
-    // set this new keyboard as child of the container
-    layoutAddObject(layoutInt, (nbgl_obj_t *) keyboard);
-
-    // return index of keyboard to be modified later on
-    return (layoutInt->container->nbChildren - 1);
-}
-
-/**
- * @brief Updates an existing keyboard on bottom of the screen, with the given configuration
- *
- * @param layout the current layout
- * @param index index returned by @ref nbgl_layoutAddKeyboard()
- * @param keyMask mask of keys to activate/deactivate on keyboard
- * @param updateCasing if true, update keyboard casing with given value
- * @param casing  casing to use
- * @return >=0 if OK
- */
-int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout,
-                              uint8_t        index,
-                              uint32_t       keyMask,
-                              bool           updateCasing,
-                              keyboardCase_t casing)
-{
-    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
-    nbgl_keyboard_t       *keyboard;
-
-    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateKeyboard(): keyMask = 0x%X\n", keyMask);
-    if (layout == NULL) {
-        return -1;
-    }
-
-    // get keyboard at given index
-    keyboard = (nbgl_keyboard_t *) layoutInt->container->children[index];
-    if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
-        return -1;
-    }
-    keyboard->keyMask = keyMask;
-    if (updateCasing) {
-        keyboard->casing = casing;
-    }
-
-    nbgl_redrawObject((nbgl_obj_t *) keyboard, NULL, false);
-
-    return 0;
-}
-
-/**
- * @brief function called to know whether the keyboard has been redrawn and needs a refresh
- *
- * @param layout the current layout
- * @param index index returned by @ref nbgl_layoutAddKeyboard()
- * @return true if keyboard needs a refresh
- */
-bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index)
-{
-    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
-    nbgl_keyboard_t       *keyboard;
-
-    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutKeyboardNeedsRefresh(): \n");
-    if (layout == NULL) {
-        return -1;
-    }
-
-    // get keyboard at given index
-    keyboard = (nbgl_keyboard_t *) layoutInt->container->children[index];
-    if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
-        return -1;
-    }
-    if (keyboard->needsRefresh) {
-        keyboard->needsRefresh = false;
-        return true;
-    }
-
-    return false;
-}
-
-/**
- * @brief Adds up to 4 black suggestion buttons under the previously added object
- *
- * @param layout the current layout
- * @param nbUsedButtons the number of actually used buttons
- * @param buttonTexts array of 4 strings for buttons (last ones can be NULL)
- * @param firstButtonToken first token used for buttons, provided in onActionCallback (the next 3
- * values will be used for other buttons)
- * @param tuneId tune to play when any button is pressed
- * @return >= 0 if OK
- */
-int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
-                                    uint8_t        nbUsedButtons,
-                                    const char    *buttonTexts[NB_MAX_SUGGESTION_BUTTONS],
-                                    int            firstButtonToken,
-                                    tune_index_e   tuneId)
-{
-    layoutObj_t           *obj;
-    nbgl_container_t      *container;
-    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
-
-    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddSuggestionButtons():\n");
-    if (layout == NULL) {
-        return -1;
-    }
-
-    nbActiveButtons           = nbUsedButtons;
+    // create a container, to store title, entered text and underline
     container                 = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
-    container->layout         = VERTICAL;
-    container->obj.area.width = SCREEN_WIDTH;
+    container->nbChildren     = 4;
+    container->children       = nbgl_containerPoolGet(container->nbChildren, layoutInt->layer);
+    container->obj.area.width = AVAILABLE_WIDTH;
+    container->obj.alignment  = CENTER;
+
+    if (title != NULL) {
+        // create text area for title
+        textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor     = BLACK;
+        textArea->text          = title;
+        textArea->textAlignment = CENTER;
+        textArea->fontId        = SMALL_REGULAR_FONT;
+        textArea->wrapping      = true;
+        textArea->obj.alignment = TOP_MIDDLE;
+        textArea->obj.area.width  = AVAILABLE_WIDTH;
+        textArea->obj.area.height = nbgl_getTextHeightInWidth(
+            textArea->fontId, textArea->text, textArea->obj.area.width, textArea->wrapping);
+        container->children[0]     = (nbgl_obj_t *) textArea;
+        container->obj.area.height = textArea->obj.area.height;
+    }
+
+    if (numbered) {
+        // create Word num typed text
+        textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor = BLACK;
+        snprintf(numText, sizeof(numText), "%d.", number);
+        textArea->text          = numText;
+        textArea->textAlignment = CENTER;
+        textArea->fontId        = LARGE_MEDIUM_1BPP_FONT;
+#ifdef TARGET_STAX
+        textArea->obj.area.width = 50;
+#else   // TARGET_STAX
+        textArea->obj.area.width       = 66;
+#endif  // TARGET_STAX
+        if (title != NULL) {
+            textArea->obj.alignmentMarginY = 8;
+            textArea->obj.alignTo          = container->children[0];
+            textArea->obj.alignment        = BOTTOM_LEFT;
+        }
+        else {
+            textArea->obj.alignment = TOP_LEFT;
+        }
+        textArea->obj.area.height = textEntryHeight;
+        // set this text area as child of the container
+        container->children[1] = (nbgl_obj_t *) textArea;
+    }
+
+    // create text area for entered text
+    textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+    textArea->textColor     = grayedOut ? LIGHT_GRAY : BLACK;
+    textArea->text          = text;
+    textArea->textAlignment = MID_LEFT;
+    textArea->fontId        = LARGE_MEDIUM_1BPP_FONT;
+    if (title != NULL) {
+        textArea->obj.alignmentMarginY = 8;
+        textArea->obj.alignTo          = container->children[0];
+        textArea->obj.alignment        = BOTTOM_LEFT;
+    }
+    else {
+        textArea->obj.alignment = TOP_LEFT;
+    }
+    textArea->obj.area.width = AVAILABLE_WIDTH;
+    if (numbered) {
+#ifdef TARGET_STAX
+        textArea->obj.alignmentMarginX = 50;
+#else   // TARGET_STAX
+        textArea->obj.alignmentMarginX = 66;
+#endif  // TARGET_STAX
+        textArea->obj.area.width -= textArea->obj.alignmentMarginX;
+    }
+    textArea->obj.area.height  = textEntryHeight;
+    textArea->autoHideLongLine = true;
+
+    obj = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) textArea, textToken, NBGL_NO_TUNE);
+    if (obj == NULL) {
+        return NULL;
+    }
+    textArea->obj.touchMask = (1 << TOUCHED);
+    textArea->obj.touchId   = ENTERED_TEXT_ID;
+    container->children[2]  = (nbgl_obj_t *) textArea;
+    container->obj.area.height
+        += textArea->obj.area.height + textArea->obj.alignmentMarginY + ((title != NULL) ? 4 : 8);
+
+    // create gray line
+    nbgl_line_t *line = (nbgl_line_t *) nbgl_objPoolGet(LINE, layoutInt->layer);
+    line->lineColor   = LIGHT_GRAY;
+    // align on bottom of the container
+    line->obj.alignment   = BOTTOM_MIDDLE;
+    line->obj.area.width  = SCREEN_WIDTH - 2 * 32;
+    line->obj.area.height = 4;
+    line->direction       = HORIZONTAL;
+    line->thickness       = 2;
+    line->offset          = 2;
+    // set this line as child of the container
+    container->children[3] = (nbgl_obj_t *) line;
+
+    return container;
+}
+
+static nbgl_container_t *addSuggestionButtons(nbgl_layoutInternal_t *layoutInt,
+                                              uint8_t                nbUsedButtons,
+                                              const char           **buttonTexts,
+                                              int                    firstButtonToken,
+                                              tune_index_e           tuneId,
+                                              bool                   compactMode)
+{
+    nbgl_container_t *suggestionsContainer;
+    layoutObj_t      *obj;
+
+    nbActiveButtons      = nbUsedButtons;
+    suggestionsContainer = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
+    suggestionsContainer->layout         = VERTICAL;
+    suggestionsContainer->obj.area.width = SCREEN_WIDTH;
 #ifdef TARGET_STAX
     // 2 rows of buttons with radius=32, and a intervale of 8px
-    container->obj.area.height = 2 * SMALL_BUTTON_HEIGHT + INTERNAL_MARGIN;
-    container->nbChildren      = nbUsedButtons;
-    container->children = (nbgl_obj_t **) nbgl_containerPoolGet(NB_MAX_VISIBLE_SUGGESTION_BUTTONS,
-                                                                layoutInt->layer);
+    suggestionsContainer->obj.area.height = 2 * SMALL_BUTTON_HEIGHT + INTERNAL_MARGIN;
+    suggestionsContainer->nbChildren      = nbActiveButtons;
+    suggestionsContainer->children        = (nbgl_obj_t **) nbgl_containerPoolGet(
+        NB_MAX_VISIBLE_SUGGESTION_BUTTONS, layoutInt->layer);
 #else   // TARGET_STAX
     // 1 row of buttons + 24px + page indicator
-    container->obj.area.height = SMALL_BUTTON_HEIGHT + 28;
+    suggestionsContainer->obj.area.height = SMALL_BUTTON_HEIGHT + 28;
     // on Flex, the first child is used by the progress indicator, if more that 2 buttons
-    container->nbChildren = nbUsedButtons + FIRST_BUTTON_INDEX;
-    container->children   = (nbgl_obj_t **) nbgl_containerPoolGet(
+    suggestionsContainer->nbChildren = nbActiveButtons + FIRST_BUTTON_INDEX;
+    suggestionsContainer->children   = (nbgl_obj_t **) nbgl_containerPoolGet(
         NB_MAX_VISIBLE_SUGGESTION_BUTTONS + 1, layoutInt->layer);
 
-    // the container is swipable on Flex
-    container->obj.touchMask = (1 << SWIPED_LEFT) | (1 << SWIPED_RIGHT);
-    container->obj.touchId   = CONTROLS_ID;  // TODO: change this value
-    obj = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) container, 0, NBGL_NO_TUNE);
+    // the suggestionsContainer is swipable on Flex
+    suggestionsContainer->obj.touchMask = (1 << SWIPED_LEFT) | (1 << SWIPED_RIGHT);
+    suggestionsContainer->obj.touchId   = CONTROLS_ID;  // TODO: change this value
+    obj = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) suggestionsContainer, 0, NBGL_NO_TUNE);
     if (obj == NULL) {
-        return -1;
+        return NULL;
     }
 #endif  // TARGET_STAX
-    container->obj.alignmentMarginY = 24;
-    // align this control on top of keyboard (that must have been added just before)
-    container->obj.alignment = TOP_MIDDLE;
-    container->obj.alignTo   = layoutInt->container->children[layoutInt->container->nbChildren - 1];
+    // put suggestionsContainer at 24px of the bottom of main container
+    suggestionsContainer->obj.alignmentMarginY = compactMode ? 12 : 24;
+    suggestionsContainer->obj.alignment        = BOTTOM_MIDDLE;
 
     // create all possible suggestion buttons, even if not displayed at first
     nbgl_objPoolGetArray(BUTTON, NB_MAX_SUGGESTION_BUTTONS, 0, (nbgl_obj_t **) &choiceButtons);
@@ -344,7 +336,7 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
         obj = layoutAddCallbackObj(
             layoutInt, (nbgl_obj_t *) choiceButtons[i], firstButtonToken + i, tuneId);
         if (obj == NULL) {
-            return -1;
+            return NULL;
         }
 
         choiceButtons[i]->innerColor      = BLACK;
@@ -380,20 +372,22 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
         choiceButtons[i]->obj.touchId   = CONTROLS_ID + i;
         // some buttons may not be visible
         if (i < MIN(NB_MAX_VISIBLE_SUGGESTION_BUTTONS, nbActiveButtons)) {
-            container->children[i + FIRST_BUTTON_INDEX] = (nbgl_obj_t *) choiceButtons[i];
+            suggestionsContainer->children[i + FIRST_BUTTON_INDEX]
+                = (nbgl_obj_t *) choiceButtons[i];
         }
     }
-#ifndef TARGET_STAX
+#ifdef TARGET_FLEX
     // on Flex, the first child is used by the progress indicator, if more that 2 buttons
     nbgl_page_indicator_t *indicator
         = (nbgl_page_indicator_t *) nbgl_objPoolGet(PAGE_INDICATOR, layoutInt->layer);
-    indicator->activePage                     = 0;
-    indicator->nbPages                        = (nbUsedButtons + 1) / 2;
-    indicator->obj.area.width                 = 184;
-    indicator->obj.alignment                  = BOTTOM_MIDDLE;
-    indicator->style                          = CURRENT_INDICATOR;
-    container->children[PAGE_INDICATOR_INDEX] = (nbgl_obj_t *) indicator;
-    // also allocate the semi disc that may be displayed on the left or right of the full buttons
+    indicator->activePage                                = 0;
+    indicator->nbPages                                   = (nbActiveButtons + 1) / 2;
+    indicator->obj.area.width                            = 184;
+    indicator->obj.alignment                             = BOTTOM_MIDDLE;
+    indicator->style                                     = CURRENT_INDICATOR;
+    suggestionsContainer->children[PAGE_INDICATOR_INDEX] = (nbgl_obj_t *) indicator;
+    // also allocate the semi disc that may be displayed on the left or right of the full
+    // buttons
     nbgl_objPoolGetArray(IMAGE, 2, 0, (nbgl_obj_t **) &partialButtonImages);
     partialButtonImages[0]->buffer          = &C_left_half_64px;
     partialButtonImages[0]->obj.alignment   = TOP_LEFT;
@@ -403,8 +397,230 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
     partialButtonImages[1]->obj.alignment   = TOP_RIGHT;
     partialButtonImages[1]->foregroundColor = BLACK;
     partialButtonImages[1]->transformation  = NO_TRANSFORMATION;
-    updateSuggestionButtons(container, 0, 0);
+    updateSuggestionButtons(suggestionsContainer, 0, 0);
 #endif  // TARGET_STAX
+
+    return suggestionsContainer;
+}
+
+static nbgl_button_t *addConfirmationButton(nbgl_layoutInternal_t *layoutInt,
+                                            bool                   active,
+                                            const char            *text,
+                                            int                    token,
+                                            tune_index_e           tuneId,
+                                            bool                   compactMode)
+{
+    nbgl_button_t *button;
+    layoutObj_t   *obj;
+
+    button = (nbgl_button_t *) nbgl_objPoolGet(BUTTON, layoutInt->layer);
+    obj    = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) button, token, tuneId);
+    if (obj == NULL) {
+        return NULL;
+    }
+
+    // put button at 24px of the bottom of main container
+    button->obj.alignmentMarginY = compactMode ? 12 : 24;
+    button->obj.alignment        = BOTTOM_MIDDLE;
+    button->foregroundColor      = WHITE;
+    if (active) {
+        button->innerColor    = BLACK;
+        button->borderColor   = BLACK;
+        button->obj.touchMask = (1 << TOUCHED);
+        button->obj.touchId   = BOTTOM_BUTTON_ID;
+    }
+    else {
+        button->borderColor = LIGHT_GRAY;
+        button->innerColor  = LIGHT_GRAY;
+    }
+    button->text            = PIC(text);
+    button->fontId          = SMALL_BOLD_1BPP_FONT;
+    button->obj.area.width  = AVAILABLE_WIDTH;
+    button->obj.area.height = BUTTON_DIAMETER;
+    button->radius          = BUTTON_RADIUS;
+
+    return button;
+}
+
+/**********************
+ *   GLOBAL API FUNCTIONS
+ **********************/
+
+/**
+ * @brief Creates a keyboard on bottom of the screen, with the given configuration
+ *
+ * @param layout the current layout
+ * @param kbdInfo configuration of the keyboard to draw (including the callback when touched)
+ * @return the index of keyboard, to use in @ref nbgl_layoutUpdateKeyboard()
+ */
+int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInfo)
+{
+    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_keyboard_t       *keyboard;
+
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddKeyboard():\n");
+    if (layout == NULL) {
+        return -1;
+    }
+    // footer must be empty
+    if (layoutInt->footerContainer != NULL) {
+        return -1;
+    }
+
+    // create keyboard
+    keyboard                  = (nbgl_keyboard_t *) nbgl_objPoolGet(KEYBOARD, layoutInt->layer);
+    keyboard->obj.area.width  = SCREEN_WIDTH;
+    keyboard->obj.area.height = 3 * KEYBOARD_KEY_HEIGHT;
+    if (!kbdInfo->lettersOnly) {
+        keyboard->obj.area.height += KEYBOARD_KEY_HEIGHT;
+    }
+#ifdef TARGET_STAX
+    keyboard->obj.alignmentMarginY = 64;
+#endif  // TARGET_STAX
+    keyboard->obj.alignment = BOTTOM_MIDDLE;
+    keyboard->borderColor   = LIGHT_GRAY;
+    keyboard->callback      = PIC(kbdInfo->callback);
+    keyboard->lettersOnly   = kbdInfo->lettersOnly;
+    keyboard->mode          = kbdInfo->mode;
+    keyboard->keyMask       = kbdInfo->keyMask;
+    keyboard->casing        = kbdInfo->casing;
+
+    // the keyboard occupies the footer
+    layoutInt->footerContainer = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
+    layoutInt->footerContainer->obj.area.width = SCREEN_WIDTH;
+    layoutInt->footerContainer->layout         = VERTICAL;
+    layoutInt->footerContainer->children
+        = (nbgl_obj_t **) nbgl_containerPoolGet(1, layoutInt->layer);
+    layoutInt->footerContainer->obj.alignment = BOTTOM_MIDDLE;
+    layoutInt->footerContainer->obj.area.height
+        = keyboard->obj.area.height + keyboard->obj.alignmentMarginY;
+    layoutInt->footerContainer->children[0] = (nbgl_obj_t *) keyboard;
+    layoutInt->footerContainer->nbChildren  = 1;
+
+    // add footer to layout children
+    layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t *) layoutInt->footerContainer;
+    layoutInt->nbChildren++;
+
+    // subtract footer height from main container height
+    layoutInt->container->obj.area.height -= layoutInt->footerContainer->obj.area.height;
+
+    // create the 2 children for main container (to hold keyboard content)
+    layoutAddObject(layoutInt, (nbgl_obj_t *) NULL);
+    layoutAddObject(layoutInt, (nbgl_obj_t *) NULL);
+
+    layoutInt->footerType = 0xFF;
+
+    return layoutInt->footerContainer->obj.area.height;
+}
+
+/**
+ * @brief Updates an existing keyboard on bottom of the screen, with the given configuration
+ *
+ * @param layout the current layout
+ * @param index index returned by @ref nbgl_layoutAddKeyboard() (unused)
+ * @param keyMask mask of keys to activate/deactivate on keyboard
+ * @param updateCasing if true, update keyboard casing with given value
+ * @param casing  casing to use
+ * @return >=0 if OK
+ */
+int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout,
+                              uint8_t        index,
+                              uint32_t       keyMask,
+                              bool           updateCasing,
+                              keyboardCase_t casing)
+{
+    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_keyboard_t       *keyboard;
+
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateKeyboard(): keyMask = 0x%X\n", keyMask);
+    if (layout == NULL) {
+        return -1;
+    }
+    UNUSED(index);
+
+    // get existing keyboard (in the footer container)
+    keyboard = (nbgl_keyboard_t *) layoutInt->footerContainer->children[0];
+    if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
+        return -1;
+    }
+    keyboard->keyMask = keyMask;
+    if (updateCasing) {
+        keyboard->casing = casing;
+    }
+
+    nbgl_redrawObject((nbgl_obj_t *) keyboard, NULL, false);
+
+    return 0;
+}
+
+/**
+ * @brief function called to know whether the keyboard has been redrawn and needs a refresh
+ *
+ * @param layout the current layout
+ * @param index index returned by @ref nbgl_layoutAddKeyboard() (unused)
+ * @return true if keyboard needs a refresh
+ */
+bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index)
+{
+    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_keyboard_t       *keyboard;
+
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutKeyboardNeedsRefresh(): \n");
+    if (layout == NULL) {
+        return -1;
+    }
+    UNUSED(index);
+
+    // get existing keyboard (in the footer container)
+    keyboard = (nbgl_keyboard_t *) layoutInt->footerContainer->children[0];
+    if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
+        return -1;
+    }
+    if (keyboard->needsRefresh) {
+        keyboard->needsRefresh = false;
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * @brief Adds up to 4 black suggestion buttons under the previously added object
+ * @deprecated Use @ref nbgl_layoutAddKeyboardContent instead
+ *
+ * @param layout the current layout
+ * @param nbUsedButtons the number of actually used buttons
+ * @param buttonTexts array of 4 strings for buttons (last ones can be NULL)
+ * @param firstButtonToken first token used for buttons, provided in onActionCallback (the next 3
+ * values will be used for other buttons)
+ * @param tuneId tune to play when any button is pressed
+ * @return >= 0 if OK
+ */
+int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
+                                    uint8_t        nbUsedButtons,
+                                    const char    *buttonTexts[NB_MAX_SUGGESTION_BUTTONS],
+                                    int            firstButtonToken,
+                                    tune_index_e   tuneId)
+{
+    nbgl_container_t      *container;
+    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    // if a centered info has be used for title, entered text is the second child
+    uint8_t enteredTextIndex = (layoutInt->container->nbChildren == 2) ? 0 : 1;
+
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddSuggestionButtons():\n");
+    if (layout == NULL) {
+        return -1;
+    }
+
+    container = addSuggestionButtons(
+        layoutInt, nbUsedButtons, buttonTexts, firstButtonToken, tuneId, false);
+    // set this container as 2nd or 3rd child of the main layout container
+    layoutInt->container->children[enteredTextIndex + 1] = (nbgl_obj_t *) container;
+    if (layoutInt->container->children[enteredTextIndex] != NULL) {
+        ((nbgl_container_t *) layoutInt->container->children[enteredTextIndex])
+            ->obj.alignmentMarginY
+            -= (container->obj.area.height + container->obj.alignmentMarginY + 20) / 2;
+    }
     // set this new container as child of the main container
     layoutAddObject(layoutInt, (nbgl_obj_t *) container);
 
@@ -415,9 +631,10 @@ int nbgl_layoutAddSuggestionButtons(nbgl_layout_t *layout,
 /**
  * @brief Updates the number and/or the text suggestion buttons created with @ref
  * nbgl_layoutAddSuggestionButtons()
+ * @deprecated Use @ref nbgl_layoutUpdateKeyboardContent instead
  *
  * @param layout the current layout
- * @param index index returned by @ref nbgl_layoutAddSuggestionButtons()
+ * @param index index returned by @ref nbgl_layoutAddSuggestionButtons() (unused)
  * @param nbUsedButtons the number of actually used buttons
  * @param buttonTexts array of 4 strings for buttons (last ones can be NULL)
  * @return >= 0 if OK
@@ -429,13 +646,15 @@ int nbgl_layoutUpdateSuggestionButtons(nbgl_layout_t *layout,
 {
     nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
     nbgl_container_t      *container;
+    uint8_t                enteredTextIndex = (layoutInt->container->nbChildren == 2) ? 0 : 1;
 
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateSuggestionButtons():\n");
     if (layout == NULL) {
         return -1;
     }
+    UNUSED(index);
 
-    container = (nbgl_container_t *) layoutInt->container->children[index];
+    container = (nbgl_container_t *) layoutInt->container->children[enteredTextIndex + 1];
     if ((container == NULL) || (container->obj.type != CONTAINER)) {
         return -1;
     }
@@ -491,6 +710,7 @@ int nbgl_layoutUpdateSuggestionButtons(nbgl_layout_t *layout,
  * @brief Adds a "text entry" area under the previously entered object. This area can be preceded
  * (beginning of line) by an index, indicating for example the entered world. A vertical gray line
  * is placed under the text. This text must be vertical placed in the screen with offsetY
+ * @deprecated Use @ref nbgl_layoutAddKeyboardContent instead
  *
  * @note This area is touchable
  *
@@ -512,96 +732,55 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout,
                               int            token)
 {
     nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
-    nbgl_text_area_t      *textArea;
-    nbgl_line_t           *line;
-    layoutObj_t           *obj;
+    nbgl_container_t      *container;
+    uint8_t                enteredTextIndex = (layoutInt->container->nbChildren == 2) ? 0 : 1;
+    bool compactMode = ((layoutInt->container->children[enteredTextIndex + 1] != NULL)
+                        && (layoutInt->container->children[enteredTextIndex + 1]->type == BUTTON)
+                        && (layoutInt->container->nbChildren == 3));
 
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddEnteredText():\n");
     if (layout == NULL) {
         return -1;
     }
+    UNUSED(offsetY);
 
-    // create gray line
-    line                       = (nbgl_line_t *) nbgl_objPoolGet(LINE, layoutInt->layer);
-    line->lineColor            = LIGHT_GRAY;
-    line->obj.alignmentMarginY = offsetY;
-    line->obj.alignTo     = layoutInt->container->children[layoutInt->container->nbChildren - 1];
-    line->obj.alignment   = TOP_MIDDLE;
-    line->obj.area.width  = SCREEN_WIDTH - 2 * 32;
-    line->obj.area.height = 4;
-    line->direction       = HORIZONTAL;
-    line->thickness       = 2;
-    line->offset          = 2;
-    // set this new line as child of the main container
-    layoutAddObject(layoutInt, (nbgl_obj_t *) line);
+    container
+        = addTextEntry(layoutInt, NULL, text, numbered, number, grayedOut, token, compactMode);
 
-    if (numbered) {
-        // create Word num typed text
-        textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-        textArea->textColor = BLACK;
-        snprintf(numText, sizeof(numText), "%d.", number);
-        textArea->text          = numText;
-        textArea->textAlignment = CENTER;
-        textArea->fontId        = LARGE_MEDIUM_1BPP_FONT;
-#ifdef TARGET_STAX
-        textArea->obj.alignmentMarginY = 12;
-#else   // TARGET_STAX
-        textArea->obj.alignmentMarginY = 16;
-#endif  // TARGET_STAX
-        textArea->obj.alignTo   = (nbgl_obj_t *) line;
-        textArea->obj.alignment = TOP_LEFT;
-#ifdef TARGET_STAX
-        textArea->obj.area.width = 50;
-#else   // TARGET_STAX
-        textArea->obj.area.width       = 66;
-#endif  // TARGET_STAX
-        textArea->obj.area.height = nbgl_getFontLineHeight(textArea->fontId);
-        // set this new text area as child of the main container
-        layoutAddObject(layoutInt, (nbgl_obj_t *) textArea);
+    // set this container as first or 2nd child of the main layout container
+    layoutInt->container->children[enteredTextIndex] = (nbgl_obj_t *) container;
+
+    if (layoutInt->container->children[enteredTextIndex + 1] != NULL) {
+        if (layoutInt->container->children[enteredTextIndex + 1]->type == BUTTON) {
+            nbgl_button_t *button
+                = (nbgl_button_t *) layoutInt->container->children[enteredTextIndex + 1];
+            container->obj.alignmentMarginY
+                -= (button->obj.area.height + button->obj.alignmentMarginY
+                    + (compactMode ? 12 : 20))
+                   / 2;
+        }
+        else if (layoutInt->container->children[enteredTextIndex + 1]->type == CONTAINER) {
+            nbgl_container_t *suggestionContainer
+                = (nbgl_container_t *) layoutInt->container->children[enteredTextIndex + 1];
+            container->obj.alignmentMarginY
+                -= (suggestionContainer->obj.area.height + suggestionContainer->obj.alignmentMarginY
+                    + (compactMode ? 12 : 20))
+                   / 2;
+        }
+    }
+    // if a centered info has be used for title, entered text is the second child and we have to
+    // adjust layout
+    if (layoutInt->container->nbChildren == 3) {
+        container->obj.alignmentMarginY += layoutInt->container->children[0]->area.height / 2;
     }
 
-    // create text area
-    textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-    textArea->textColor     = grayedOut ? LIGHT_GRAY : BLACK;
-    textArea->text          = text;
-    textArea->textAlignment = MID_LEFT;
-    textArea->fontId        = LARGE_MEDIUM_1BPP_FONT;
-#ifdef TARGET_STAX
-    textArea->obj.alignmentMarginY = 12;
-#else   // TARGET_STAX
-    textArea->obj.alignmentMarginY = 16;
-#endif  // TARGET_STAX
-    textArea->obj.alignTo    = (nbgl_obj_t *) line;
-    textArea->obj.alignment  = TOP_LEFT;
-    textArea->obj.area.width = line->obj.area.width;
-    if (numbered) {
-#ifdef TARGET_STAX
-        textArea->obj.alignmentMarginX = 50;
-#else   // TARGET_STAX
-        textArea->obj.alignmentMarginX = 66;
-#endif  // TARGET_STAX
-        textArea->obj.area.width -= textArea->obj.alignmentMarginX;
-    }
-    textArea->obj.area.height  = nbgl_getFontLineHeight(textArea->fontId);
-    textArea->autoHideLongLine = true;
-
-    obj = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) textArea, token, NBGL_NO_TUNE);
-    if (obj == NULL) {
-        return -1;
-    }
-    textArea->token         = token;
-    textArea->obj.touchMask = (1 << TOUCHED);
-    textArea->obj.touchId   = ENTERED_TEXT_ID;
-
-    // set this new text area as child of the container
-    layoutAddObject(layoutInt, (nbgl_obj_t *) textArea);
-
-    // return index of text area to be modified later on
-    return (layoutInt->container->nbChildren - 1);
+    // return 0
+    return 0;
 }
 
 /**
  * @brief Updates an existing "text entry" area, created with @ref nbgl_layoutAddEnteredText()
+ * @deprecated Use @ref nbgl_layoutUpdateKeyboardContent instead
  *
  * @param layout the current layout
  * @param index index of the text (return value of @ref nbgl_layoutAddEnteredText())
@@ -620,15 +799,22 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
                                  bool           grayedOut)
 {
     nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_container_t      *container;
     nbgl_text_area_t      *textArea;
+    uint8_t                enteredTextIndex = (layoutInt->container->nbChildren == 2) ? 0 : 1;
 
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText():\n");
     if (layout == NULL) {
         return -1;
     }
+    UNUSED(index);
 
-    // update main text area
-    textArea = (nbgl_text_area_t *) layoutInt->container->children[index];
+    // update text entry area
+    container = (nbgl_container_t *) layoutInt->container->children[enteredTextIndex];
+    if ((container == NULL) || (container->obj.type != CONTAINER)) {
+        return -1;
+    }
+    textArea = (nbgl_text_area_t *) container->children[2];
     if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
         return -1;
     }
@@ -640,7 +826,7 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
     // update number text area
     if (numbered) {
         // it is the previously created object
-        textArea = (nbgl_text_area_t *) layoutInt->container->children[index - 1];
+        textArea = (nbgl_text_area_t *) layoutInt->container->children[1];
         snprintf(numText, sizeof(numText), "%d.", number);
         textArea->text = numText;
         nbgl_redrawObject((nbgl_obj_t *) textArea, NULL, false);
@@ -654,6 +840,7 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
 
 /**
  * @brief Adds a black full width confirmation button on top of the previously added keyboard.
+ * @deprecated Use @ref nbgl_layoutAddKeyboardContent instead
  *
  * @param layout the current layout
  * @param active if true, button is active, otherwise inactive (grayed-out)
@@ -668,54 +855,33 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout,
                                      int            token,
                                      tune_index_e   tuneId)
 {
-    layoutObj_t           *obj;
     nbgl_button_t         *button;
-    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_layoutInternal_t *layoutInt        = (nbgl_layoutInternal_t *) layout;
+    uint8_t                enteredTextIndex = (layoutInt->container->nbChildren == 2) ? 0 : 1;
+    bool                   compactMode      = (layoutInt->container->nbChildren == 3);
 
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddConfirmationButton():\n");
     if (layout == NULL) {
         return -1;
     }
 
-    button = (nbgl_button_t *) nbgl_objPoolGet(BUTTON, layoutInt->layer);
-    obj    = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) button, token, tuneId);
-    if (obj == NULL) {
-        return -1;
+    button = addConfirmationButton(layoutInt, active, text, token, tuneId, compactMode);
+    // set this button as second child of the main layout container
+    layoutInt->container->children[enteredTextIndex + 1] = (nbgl_obj_t *) button;
+    if (layoutInt->container->children[enteredTextIndex] != NULL) {
+        ((nbgl_container_t *) layoutInt->container->children[enteredTextIndex])
+            ->obj.alignmentMarginY
+            -= (button->obj.area.height + button->obj.alignmentMarginY + (compactMode ? 12 : 20))
+               / 2;
     }
-
-#ifdef TARGET_STAX
-    button->obj.alignmentMarginY = BOTTOM_BORDER_MARGIN;
-#else   // TARGET_STAX
-    button->obj.alignmentMarginY = 24;
-#endif  // TARGET_STAX
-    button->obj.alignment   = TOP_MIDDLE;
-    button->foregroundColor = WHITE;
-    if (active) {
-        button->innerColor    = BLACK;
-        button->borderColor   = BLACK;
-        button->obj.touchMask = (1 << TOUCHED);
-        button->obj.touchId   = BOTTOM_BUTTON_ID;
-    }
-    else {
-        button->borderColor = LIGHT_GRAY;
-        button->innerColor  = LIGHT_GRAY;
-    }
-    button->text            = PIC(text);
-    button->fontId          = SMALL_BOLD_1BPP_FONT;
-    button->obj.area.width  = AVAILABLE_WIDTH;
-    button->obj.area.height = BUTTON_DIAMETER;
-    button->radius          = BUTTON_RADIUS;
-    button->obj.alignTo     = layoutInt->container->children[layoutInt->container->nbChildren - 1];
-    // set this new button as child of the container
-    layoutAddObject(layoutInt, (nbgl_obj_t *) button);
-
-    // return index of button to be modified later on
-    return (layoutInt->container->nbChildren - 1);
+    // return 0
+    return 0;
 }
 
 /**
  * @brief Updates an existing black full width confirmation button on top of the previously added
 keyboard.
+ * @deprecated Use @ref nbgl_layoutUpdateKeyboardContent instead
  *
  * @param layout the current layout
  * @param index returned value of @ref nbgl_layoutAddConfirmationButton()
@@ -730,6 +896,9 @@ int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout,
 {
     nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
     nbgl_button_t         *button;
+    uint8_t                enteredTextIndex = (layoutInt->container->nbChildren == 2) ? 0 : 1;
+
+    UNUSED(index);
 
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateConfirmationButton():\n");
     if (layout == NULL) {
@@ -737,7 +906,7 @@ int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout,
     }
 
     // update main text area
-    button = (nbgl_button_t *) layoutInt->container->children[index];
+    button = (nbgl_button_t *) layoutInt->container->children[enteredTextIndex + 1];
     if ((button == NULL) || (button->obj.type != BUTTON)) {
         return -1;
     }
@@ -756,5 +925,184 @@ int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout,
     nbgl_redrawObject((nbgl_obj_t *) button, NULL, false);
     return 0;
 }
+
+/**
+ * @brief Adds an area containing a potential title, a text entry and either confirmation
+ * or suggestion buttons, on top of the keyboard
+ *
+ * @param layout the current layout
+ * @param content structure containing the info
+ * @return the height of the area if OK
+ */
+int nbgl_layoutAddKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardContent_t *content)
+{
+    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_container_t      *container;
+    bool compactMode = ((content->type == KEYBOARD_WITH_BUTTON) && (content->title != NULL));
+
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddKeyboardContent():\n");
+    if (layout == NULL) {
+        return -1;
+    }
+
+    container = addTextEntry(layoutInt,
+                             content->title,
+                             content->text,
+                             content->numbered,
+                             content->number,
+                             content->grayedOut,
+                             content->textToken,
+                             compactMode);
+
+    // set this container as first child of the main layout container
+    layoutInt->container->children[0] = (nbgl_obj_t *) container;
+
+    if (content->type == KEYBOARD_WITH_SUGGESTIONS) {
+        nbgl_container_t *suggestionsContainer
+            = addSuggestionButtons(layoutInt,
+                                   content->suggestionButtons.nbUsedButtons,
+                                   content->suggestionButtons.buttons,
+                                   content->suggestionButtons.firstButtonToken,
+                                   content->tuneId,
+                                   compactMode);
+        // set this container as second child of the main layout container
+        layoutInt->container->children[1] = (nbgl_obj_t *) suggestionsContainer;
+        container->obj.alignmentMarginY
+            -= (suggestionsContainer->obj.area.height + suggestionsContainer->obj.alignmentMarginY
+                + (compactMode ? 12 : 20))
+               / 2;
+    }
+    else if (content->type == KEYBOARD_WITH_BUTTON) {
+        nbgl_button_t *button = addConfirmationButton(layoutInt,
+                                                      content->confirmationButton.active,
+                                                      content->confirmationButton.text,
+                                                      content->confirmationButton.token,
+                                                      content->tuneId,
+                                                      compactMode);
+        // set this button as second child of the main layout container
+        layoutInt->container->children[1] = (nbgl_obj_t *) button;
+        container->obj.alignmentMarginY
+            -= (button->obj.area.height + button->obj.alignmentMarginY + (compactMode ? 12 : 20))
+               / 2;
+    }
+
+    return layoutInt->container->obj.area.height;
+}
+
+/**
+ * @brief Updates an area containing a potential title, a text entry and either confirmation
+ * or suggestion buttons, on top of the keyboard
+ * This area must have been built with @ref nbgl_layoutAddKeyboardContent, and the type must not
+ * change
+ *
+ * @param layout the current layout
+ * @param content structure containing the updated info
+ * @return the height of the area if OK
+ */
+int nbgl_layoutUpdateKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardContent_t *content)
+{
+    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_container_t      *container;
+    nbgl_text_area_t      *textArea;
+
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateKeyboardContent():\n");
+    if (layout == NULL) {
+        return -1;
+    }
+
+    // get top container from main container (it shall be the 1st object)
+    container = (nbgl_container_t *) layoutInt->container->children[0];
+
+    if (content->numbered) {
+        // get Word number typed text
+        textArea = (nbgl_text_area_t *) container->children[1];
+        snprintf(numText, sizeof(numText), "%d.", content->number);
+        nbgl_redrawObject((nbgl_obj_t *) textArea, NULL, false);
+    }
+
+    // get text area for entered text
+    textArea            = (nbgl_text_area_t *) container->children[2];
+    textArea->textColor = content->grayedOut ? LIGHT_GRAY : BLACK;
+    textArea->text      = content->text;
+    nbgl_redrawObject((nbgl_obj_t *) textArea, NULL, false);
+
+    if (content->type == KEYBOARD_WITH_SUGGESTIONS) {
+        nbActiveButtons = content->suggestionButtons.nbUsedButtons;
+        nbgl_container_t *suggestionsContainer
+            = (nbgl_container_t *) layoutInt->container->children[1];
+        suggestionsContainer->nbChildren = nbActiveButtons + FIRST_BUTTON_INDEX;
+
+        // update suggestion buttons
+        for (int i = 0; i < NB_MAX_SUGGESTION_BUTTONS; i++) {
+            choiceButtons[i]->text = content->suggestionButtons.buttons[i];
+            // some buttons may not be visible
+            if (i < MIN(NB_MAX_VISIBLE_SUGGESTION_BUTTONS, nbActiveButtons)) {
+                if ((i % 2) == 0) {
+                    choiceButtons[i]->obj.alignmentMarginX = BORDER_MARGIN;
+#ifdef TARGET_STAX
+                    // second row 8px under the first one
+                    if (i != 0) {
+                        choiceButtons[i]->obj.alignmentMarginY = INTERNAL_MARGIN;
+                    }
+                    choiceButtons[i]->obj.alignment = NO_ALIGNMENT;
+#else   // TARGET_STAX
+                    if (i == 0) {
+                        choiceButtons[i]->obj.alignment = TOP_LEFT;
+                    }
+#endif  // TARGET_STAX
+                }
+                else {
+                    choiceButtons[i]->obj.alignmentMarginX = INTERNAL_MARGIN;
+                    choiceButtons[i]->obj.alignment        = MID_RIGHT;
+                    choiceButtons[i]->obj.alignTo          = (nbgl_obj_t *) choiceButtons[i - 1];
+                }
+                suggestionsContainer->children[i + FIRST_BUTTON_INDEX]
+                    = (nbgl_obj_t *) choiceButtons[i];
+            }
+            else {
+                suggestionsContainer->children[i + FIRST_BUTTON_INDEX] = NULL;
+            }
+        }
+        suggestionsContainer->forceClean = true;
+#ifndef TARGET_STAX
+        // on Flex, the first child is used by the progress indicator, if more that 2 buttons
+        nbgl_page_indicator_t *indicator
+            = (nbgl_page_indicator_t *) suggestionsContainer->children[PAGE_INDICATOR_INDEX];
+        indicator->nbPages    = (nbActiveButtons + 1) / 2;
+        indicator->activePage = 0;
+        updateSuggestionButtons(suggestionsContainer, 0, 0);
+#endif  // TARGET_STAX
+
+        nbgl_redrawObject((nbgl_obj_t *) suggestionsContainer, NULL, false);
+    }
+    else if (content->type == KEYBOARD_WITH_BUTTON) {
+        // update main text area
+        nbgl_button_t *button = (nbgl_button_t *) layoutInt->container->children[1];
+        if ((button == NULL) || (button->obj.type != BUTTON)) {
+            return -1;
+        }
+        button->text = content->confirmationButton.text;
+
+        if (content->confirmationButton.active) {
+            button->innerColor    = BLACK;
+            button->borderColor   = BLACK;
+            button->obj.touchMask = (1 << TOUCHED);
+            button->obj.touchId   = BOTTOM_BUTTON_ID;
+        }
+        else {
+            button->borderColor = LIGHT_GRAY;
+            button->innerColor  = LIGHT_GRAY;
+        }
+        nbgl_redrawObject((nbgl_obj_t *) button, NULL, false);
+    }
+
+    // if the entered text doesn't fit, indicate it by returning 1 instead of 0, for different
+    // refresh
+    if (nbgl_getSingleLineTextWidth(textArea->fontId, content->text) > textArea->obj.area.width) {
+        return 1;
+    }
+    return 0;
+}
+
 #endif  // NBGL_KEYBOARD
 #endif  // HAVE_SE_TOUCH

--- a/lib_nbgl/src/nbgl_layout_keypad.c
+++ b/lib_nbgl/src/nbgl_layout_keypad.c
@@ -21,11 +21,15 @@
 #include "glyphs.h"
 #include "os_pic.h"
 #include "os_helpers.h"
-#include "lcx_rng.h"
 
 /*********************
  *      DEFINES
  *********************/
+#ifdef TARGET_STAX
+#define DIGIT_ICON C_round_24px
+#else  // TARGET_STAX
+#define DIGIT_ICON C_pin_24
+#endif  // TARGET_STAX
 
 /**********************
  *      MACROS
@@ -66,30 +70,54 @@ int nbgl_layoutAddKeypad(nbgl_layout_t *layout, keyboardCallback_t callback, boo
     if (layout == NULL) {
         return -1;
     }
+    // footer must be empty
+    if (layoutInt->footerContainer != NULL) {
+        return -1;
+    }
 
     // create keypad
     keypad                       = (nbgl_keypad_t *) nbgl_objPoolGet(KEYPAD, layoutInt->layer);
     keypad->obj.alignmentMarginY = 0;
     keypad->obj.alignment        = BOTTOM_MIDDLE;
     keypad->obj.alignTo          = NULL;
+    keypad->obj.area.width       = SCREEN_WIDTH;
+    keypad->obj.area.height      = 4 * KEYPAD_KEY_HEIGHT;
     keypad->borderColor          = LIGHT_GRAY;
     keypad->callback             = PIC(callback);
     keypad->enableDigits         = true;
     keypad->enableBackspace      = false;
     keypad->enableValidate       = false;
     keypad->shuffled             = shuffled;
-    // set this new keypad as child of the container
-    layoutAddObject(layoutInt, (nbgl_obj_t *) keypad);
 
-    // return index of keypad to be modified later on
-    return (layoutInt->container->nbChildren - 1);
+    // the keypad occupies the footer
+    layoutInt->footerContainer = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
+    layoutInt->footerContainer->obj.area.width = SCREEN_WIDTH;
+    layoutInt->footerContainer->layout         = VERTICAL;
+    layoutInt->footerContainer->children
+        = (nbgl_obj_t **) nbgl_containerPoolGet(1, layoutInt->layer);
+    layoutInt->footerContainer->obj.alignment   = BOTTOM_MIDDLE;
+    layoutInt->footerContainer->obj.area.height = keypad->obj.area.height;
+    layoutInt->footerContainer->children[layoutInt->footerContainer->nbChildren]
+        = (nbgl_obj_t *) keypad;
+    layoutInt->footerContainer->nbChildren++;
+
+    // add to layout children
+    layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t *) layoutInt->footerContainer;
+    layoutInt->nbChildren++;
+
+    // subtract footer height from main container height
+    layoutInt->container->obj.area.height -= layoutInt->footerContainer->obj.area.height;
+
+    layoutInt->footerType = 0xFF;
+
+    return layoutInt->footerContainer->obj.area.height;
 }
 
 /**
  * @brief Updates an existing keypad on bottom of the screen, with the given configuration
  *
  * @param layout the current layout
- * @param index index returned by @ref nbgl_layoutAddKeypad()
+ * @param index index returned by @ref nbgl_layoutAddKeypad() (unused, for compatibility)
  * @param enableValidate if true, enable Validate key
  * @param enableBackspace if true, enable Backspace key
  * @param enableDigits if true, enable all digit keys
@@ -111,9 +139,10 @@ int nbgl_layoutUpdateKeypad(nbgl_layout_t *layout,
     if (layout == NULL) {
         return -1;
     }
+    UNUSED(index);
 
-    // get existing keypad
-    keypad = (nbgl_keypad_t *) layoutInt->container->children[index];
+    // get existing keypad (in the footer container)
+    keypad = (nbgl_keypad_t *) layoutInt->footerContainer->children[0];
     if ((keypad == NULL) || (keypad->obj.type != KEYPAD)) {
         return -1;
     }
@@ -132,6 +161,7 @@ int nbgl_layoutUpdateKeypad(nbgl_layout_t *layout,
  * @brief Adds a placeholder for hidden digits on top of a keypad, to represent the entered digits,
  * as full circles The placeholder is "underligned" with a thin horizontal line of the expected full
  * length
+ * @deprecated Use @ref nbgl_layouAddKeypadContent instead
  *
  * @note It must be the last added object, after potential back key, title, and keypad. Vertical
  * positions of title and hidden digits will be computed here
@@ -169,18 +199,9 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits)
     container->children = nbgl_containerPoolGet(container->nbChildren, layoutInt->layer);
     // <space> pixels between each icon (knowing that the effective round are 18px large and the
     // icon 24px)
-    container->obj.area.width = nbDigits * C_round_24px.width + (nbDigits + 1) * space;
+    container->obj.area.width = nbDigits * DIGIT_ICON.width + (nbDigits - 1) * space;
 #ifdef TARGET_STAX
-    container->obj.area.height = 48;
-    // distance from digits to title is fixed to 20 px, except if title is more than 1 line and a
-    // back key is present
-    if ((layoutInt->container->nbChildren != 3)
-        || (layoutInt->container->children[1]->area.height == 32)) {
-        container->obj.alignmentMarginY = 20;
-    }
-    else {
-        container->obj.alignmentMarginY = 12;
-    }
+    container->obj.area.height = 50;
 #else   // TARGET_STAX
     container->obj.area.height = 64;
 #endif  // TARGET_STAX
@@ -195,21 +216,16 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits)
     // create children of the container, as images (empty circles)
     nbgl_objPoolGetArray(IMAGE, nbDigits, layoutInt->layer, (nbgl_obj_t **) container->children);
     for (int i = 0; i < nbDigits; i++) {
-        nbgl_image_t *image = (nbgl_image_t *) container->children[i];
-#ifdef TARGET_STAX
-        image->buffer = &C_round_24px;
-#else   // TARGET_STAX
-        image->buffer = &C_pin_24;
-#endif  // TARGET_STAX
-        image->foregroundColor      = WHITE;
-        image->obj.alignmentMarginX = space;
+        nbgl_image_t *image    = (nbgl_image_t *) container->children[i];
+        image->buffer          = &DIGIT_ICON;
+        image->foregroundColor = WHITE;
         if (i > 0) {
-            image->obj.alignment = MID_RIGHT;
-            image->obj.alignTo   = (nbgl_obj_t *) container->children[i - 1];
+            image->obj.alignment        = MID_RIGHT;
+            image->obj.alignTo          = (nbgl_obj_t *) container->children[i - 1];
+            image->obj.alignmentMarginX = space;
         }
         else {
-            image->obj.alignment        = NO_ALIGNMENT;
-            image->obj.alignmentMarginY = (container->obj.area.height - C_round_24px.width) / 2;
+            image->obj.alignment = MID_LEFT;
         }
     }
 #ifdef TARGET_STAX
@@ -234,6 +250,7 @@ int nbgl_layoutAddHiddenDigits(nbgl_layout_t *layout, uint8_t nbDigits)
 
 /**
  * @brief Updates an existing set of hidden digits, with the given configuration
+ * @deprecated Use @ref nbgl_layoutUpdateKeypadContent instead
  *
  * @param layout the current layout
  * @param index index returned by @ref nbgl_layoutAddHiddenDigits()
@@ -285,11 +302,7 @@ int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t 
             image->foregroundColor = WHITE;
         }
         else {
-#ifdef TARGET_STAX
-            image->buffer = &C_round_24px;
-#else   // TARGET_STAX
-            image->buffer = &C_pin_24;
-#endif  // TARGET_STAX
+            image->buffer          = &DIGIT_ICON;
             image->foregroundColor = BLACK;
         }
     }
@@ -298,97 +311,241 @@ int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t 
 
     return 0;
 }
+
 /**
- * @brief Adds a "digits entry" area under the previously entered object. A horizontal gray line
- * is placed under the text. This text is vertically placed in the screen with offsetY
+ * @brief Adds an area with a title and a placeholder for hidden digits on top of a keypad, to
+ * represent the entered digits as small discs. On Stax, the placeholder is "underligned" with a
+ * thin horizontal line of the expected full length
+ *
+ * @note It shall be the only object added in the layout, beside a potential header and the keypad
+ * itself
  *
  * @param layout the current layout
- * @param text string to display in the area
- * @param offsetY vertical offset from the top of the page
- * @return >= 0 if OK
+ * @param title the text to use on top of the digits
+ * @param hidden if set to true, digits appear as discs, otherwise as visible digits (given in text
+ * param)
+ * @param nbDigits number of digits to be displayed (only used if hidden is true)
+ * @param text only used if hidden is false
+ * @return the height of this area, if no error, < 0 otherwise
  */
-int nbgl_layoutAddEnteredDigits(nbgl_layout_t *layout, const char *text, int offsetY)
+int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
+                                const char    *title,
+                                bool           hidden,
+                                uint8_t        nbDigits,
+                                const char    *text)
 {
     nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_container_t      *container;
     nbgl_text_area_t      *textArea;
-    nbgl_line_t           *line;
 
-    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddEnteredDigits():\n");
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddKeypadContent():\n");
     if (layout == NULL) {
         return -1;
     }
+    // create a container, to store both title and "digits" (and line on Stax)
+    container             = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
+    container->nbChildren = 2;
+#ifdef TARGET_STAX
+    container->nbChildren++;  // +1 for the line
+#endif                        // TARGET_STAX
+    container->children       = nbgl_containerPoolGet(container->nbChildren, layoutInt->layer);
+    container->obj.area.width = AVAILABLE_WIDTH;
+    container->obj.alignment  = CENTER;
 
+    // create text area for title
+    textArea                  = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+    textArea->textColor       = BLACK;
+    textArea->text            = title;
+    textArea->textAlignment   = CENTER;
+    textArea->fontId          = SMALL_REGULAR_FONT;
+    textArea->wrapping        = true;
+    textArea->obj.alignment   = TOP_MIDDLE;
+    textArea->obj.area.width  = AVAILABLE_WIDTH;
+    textArea->obj.area.height = nbgl_getTextHeightInWidth(
+        textArea->fontId, textArea->text, textArea->obj.area.width, textArea->wrapping);
+    container->children[0] = (nbgl_obj_t *) textArea;
+    container->obj.area.height += textArea->obj.area.height;
+
+    if (hidden) {
+        nbgl_container_t *digitsContainer;
+        uint8_t           space;
+
+        if (nbDigits > KEYPAD_MAX_DIGITS) {
+            return -1;
+        }
+        // space between "digits"
+        if (nbDigits > 8) {
+            space = 4;
+        }
+        else {
+            space = 12;
+        }
+
+        // create digits container, to store "discs"
+        digitsContainer = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
+        digitsContainer->nbChildren = nbDigits;
+        digitsContainer->children
+            = nbgl_containerPoolGet(digitsContainer->nbChildren, layoutInt->layer);
+        // <space> pixels between each icon (knowing that the effective round are 18px large and the
+        // icon 24px)
+        digitsContainer->obj.area.width = nbDigits * DIGIT_ICON.width + (nbDigits - 1) * space;
+#ifdef TARGET_STAX
+        digitsContainer->obj.area.height = 50;
+#else   // TARGET_STAX
+        digitsContainer->obj.area.height = 64;
+#endif  // TARGET_STAX
+        // align at the bottom of title
+        digitsContainer->obj.alignTo   = container->children[0];
+        digitsContainer->obj.alignment = BOTTOM_MIDDLE;
+        container->children[1]         = (nbgl_obj_t *) digitsContainer;
+        container->obj.area.height += digitsContainer->obj.area.height;
+
+        // create children of the container, as images (empty circles)
+        nbgl_objPoolGetArray(
+            IMAGE, nbDigits, layoutInt->layer, (nbgl_obj_t **) digitsContainer->children);
+        for (int i = 0; i < nbDigits; i++) {
+            nbgl_image_t *image    = (nbgl_image_t *) digitsContainer->children[i];
+            image->buffer          = &DIGIT_ICON;
+            image->foregroundColor = WHITE;
+            if (i > 0) {
+                image->obj.alignment        = MID_RIGHT;
+                image->obj.alignTo          = (nbgl_obj_t *) digitsContainer->children[i - 1];
+                image->obj.alignmentMarginX = space;
+            }
+            else {
+                image->obj.alignment = MID_LEFT;
+            }
+        }
+    }
+    else {
+        // create text area
+        textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor     = BLACK;
+        textArea->text          = text;
+        textArea->textAlignment = MID_LEFT;
+        textArea->fontId        = LARGE_MEDIUM_1BPP_FONT;
+        textArea->obj.area.width   = container->obj.area.width;
+        textArea->obj.area.height  = nbgl_getFontLineHeight(textArea->fontId);
+        textArea->autoHideLongLine = true;
+        // align at the bottom of title
+        textArea->obj.alignTo   = container->children[0];
+        textArea->obj.alignment = BOTTOM_MIDDLE;
+        container->children[1]  = (nbgl_obj_t *) textArea;
+        container->obj.area.height += textArea->obj.area.height;
+    }
+
+    // set this new container as child of the main container
+    layoutAddObject(layoutInt, (nbgl_obj_t *) container);
+#ifdef TARGET_STAX
+    nbgl_line_t *line;
     // create gray line
     line                       = (nbgl_line_t *) nbgl_objPoolGet(LINE, layoutInt->layer);
     line->lineColor            = LIGHT_GRAY;
-    line->obj.alignmentMarginY = offsetY;
-    line->obj.alignTo     = layoutInt->container->children[layoutInt->container->nbChildren - 1];
-    line->obj.alignment   = TOP_MIDDLE;
-    line->obj.area.width  = SCREEN_WIDTH - 2 * 32;
-    line->obj.area.height = 4;
-    line->direction       = HORIZONTAL;
-    line->thickness       = 2;
-    line->offset          = 2;
-    // set this new line as child of the main container
-    layoutAddObject(layoutInt, (nbgl_obj_t *) line);
-
-    // create text area
-    textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-    textArea->textColor     = BLACK;
-    textArea->text          = text;
-    textArea->textAlignment = MID_LEFT;
-    textArea->fontId        = LARGE_MEDIUM_1BPP_FONT;
-#ifdef TARGET_STAX
-    textArea->obj.alignmentMarginY = 12;
-#else   // TARGET_STAX
-    textArea->obj.alignmentMarginY = 16;
+    line->obj.alignmentMarginY = 0;
+    line->obj.alignTo          = NULL;
+    line->obj.alignment        = BOTTOM_MIDDLE;
+    line->obj.area.width       = container->obj.area.width;
+    line->obj.area.height      = 4;
+    line->direction            = HORIZONTAL;
+    line->thickness            = 2;
+    line->offset               = 2;
+    container->children[2]     = (nbgl_obj_t *) line;
 #endif  // TARGET_STAX
-    textArea->obj.alignTo      = (nbgl_obj_t *) line;
-    textArea->obj.alignment    = TOP_LEFT;
-    textArea->obj.area.width   = line->obj.area.width;
-    textArea->obj.area.height  = nbgl_getFontLineHeight(textArea->fontId);
-    textArea->autoHideLongLine = true;
 
-    // set this new text area as child of the container
-    layoutAddObject(layoutInt, (nbgl_obj_t *) textArea);
-
-    // return index of text area to be modified later on
-    return (layoutInt->container->nbChildren - 1);
+    // return height of the area
+    return container->obj.area.height;
 }
 
 /**
- * @brief Updates an existing "digits entry" area, created with @ref nbgl_layoutAddEnteredDigits()
+ * @brief Updates an existing set of hidden digits, with the given configuration
  *
  * @param layout the current layout
- * @param index index of the text (return value of @ref nbgl_layoutAddEnteredDigits())
- * @param text string to display in the area
- * @return <0 if error, 0 if OK with text fitting the area, 1 of 0K with text
- * not fitting the area
+ * @param hidden if set to true, digits appear as discs, otherwise as visible digits (given in text
+ * param)
+ * @param nbActiveDigits number of "active" digits (represented by discs instead of circles) (only
+ * used if hidden is true)
+ * @param text only used if hidden is false
+ *
+ * @return >=0 if OK
  */
-int nbgl_layoutUpdateEnteredDigits(nbgl_layout_t *layout, uint8_t index, const char *text)
+int nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
+                                   bool           hidden,
+                                   uint8_t        nbActiveDigits,
+                                   const char    *text)
 {
     nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
-    nbgl_text_area_t      *textArea;
+    nbgl_container_t      *container;
+    nbgl_image_t          *image;
 
-    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredDigits():\n");
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutUpdateHiddenDigits(): nbActive = %d\n", nbActiveDigits);
     if (layout == NULL) {
         return -1;
     }
 
-    // update main text area
-    textArea = (nbgl_text_area_t *) layoutInt->container->children[index];
-    if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
-        return -1;
-    }
-    textArea->text          = text;
-    textArea->textColor     = BLACK;
-    textArea->textAlignment = MID_LEFT;
-    nbgl_redrawObject((nbgl_obj_t *) textArea, NULL, false);
+    UNUSED(index);
 
-    // if the text doesn't fit, indicate it by returning 1 instead of 0, for different refresh
-    if (nbgl_getSingleLineTextWidth(textArea->fontId, text) > textArea->obj.area.width) {
-        return 1;
+    if (hidden) {
+        // get digits container (second child of the main container)
+        container = (nbgl_container_t *) ((nbgl_container_t *) layoutInt->container->children[0])
+                        ->children[1];
+        // sanity check
+        if ((container == NULL) || (container->obj.type != CONTAINER)) {
+            return -1;
+        }
+        if (nbActiveDigits > container->nbChildren) {
+            return -1;
+        }
+        if (nbActiveDigits == 0) {
+            // deactivate the first digit
+            image = (nbgl_image_t *) container->children[0];
+            if ((image == NULL) || (image->obj.type != IMAGE)) {
+                return -1;
+            }
+            image->foregroundColor = WHITE;
+        }
+        else {
+            image = (nbgl_image_t *) container->children[nbActiveDigits - 1];
+            if ((image == NULL) || (image->obj.type != IMAGE)) {
+                return -1;
+            }
+            // if the last "active" is already active, it means that we are decreasing the number of
+            // active otherwise we are increasing it
+            if (image->foregroundColor == BLACK) {
+                // all digits are already active
+                if (nbActiveDigits == container->nbChildren) {
+                    return 0;
+                }
+                // deactivate the next digit
+                image                  = (nbgl_image_t *) container->children[nbActiveDigits];
+                image->foregroundColor = WHITE;
+            }
+            else {
+                image->buffer          = &DIGIT_ICON;
+                image->foregroundColor = BLACK;
+            }
+        }
+
+        nbgl_redrawObject((nbgl_obj_t *) image, NULL, false);
     }
+    else {
+        // update main text area (second child of the main container)
+        nbgl_text_area_t *textArea
+            = (nbgl_text_area_t *) ((nbgl_container_t *) layoutInt->container->children[0])
+                  ->children[1];
+        if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
+            return -1;
+        }
+        textArea->text          = text;
+        textArea->textColor     = BLACK;
+        textArea->textAlignment = MID_LEFT;
+        nbgl_redrawObject((nbgl_obj_t *) textArea, NULL, false);
+
+        // if the text doesn't fit, indicate it by returning 1 instead of 0, for different refresh
+        if (nbgl_getSingleLineTextWidth(textArea->fontId, text) > textArea->obj.area.width) {
+            return 1;
+        }
+    }
+
     return 0;
 }
 #endif  // NBGL_KEYPAD

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -1036,13 +1036,7 @@ static void draw_qrCode(nbgl_qrcode_t *obj, nbgl_obj_t *prevObj, bool computePos
  */
 static void draw_keyboard(nbgl_keyboard_t *obj, nbgl_obj_t *prevObj, bool computePosition)
 {
-#ifdef HAVE_SE_TOUCH
-    obj->obj.area.width  = SCREEN_WIDTH;
-    obj->obj.area.height = 3 * KEYBOARD_KEY_HEIGHT;
-    if (!obj->lettersOnly) {
-        obj->obj.area.height += KEYBOARD_KEY_HEIGHT;
-    }
-#else   // HAVE_SE_TOUCH
+#ifndef HAVE_SE_TOUCH
     obj->obj.area.width  = KEYBOARD_WIDTH;
     obj->obj.area.height = KEYBOARD_KEY_HEIGHT;
 #endif  // HAVE_SE_TOUCH
@@ -1073,10 +1067,7 @@ static void draw_keyboard(nbgl_keyboard_t *obj, nbgl_obj_t *prevObj, bool comput
  */
 static void draw_keypad(nbgl_keypad_t *obj, nbgl_obj_t *prevObj, bool computePosition)
 {
-#ifdef HAVE_SE_TOUCH
-    obj->obj.area.width  = SCREEN_WIDTH;
-    obj->obj.area.height = 4 * KEYPAD_KEY_HEIGHT;
-#else   // HAVE_SE_TOUCH
+#ifndef HAVE_SE_TOUCH
     obj->obj.area.height = KEYPAD_HEIGHT;
     obj->obj.area.width  = KEYPAD_WIDTH;
 #endif  // HAVE_SE_TOUCH

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -87,8 +87,6 @@ typedef struct KeypadContext_s {
     uint8_t        pinLen;
     uint8_t        pinMinDigits;
     uint8_t        pinMaxDigits;
-    uint32_t       keypadIndex;
-    uint32_t       digitsIndex;
     nbgl_layout_t *layoutCtx;
     bool           hidden;
 } KeypadContext_t;
@@ -884,7 +882,8 @@ static void displayGenericContextPage(uint8_t pageIdx, bool forceFullRefresh)
     const nbgl_content_t *p_content = NULL;
 
     if ((navType == STREAMING_NAV) && (pageIdx >= bundleNavContext.reviewStreaming.stepPageNb)) {
-        return bundleNavReviewStreamingChoice(true);
+        bundleNavReviewStreamingChoice(true);
+        return;
     }
 
     if (navInfo.activePage == pageIdx) {
@@ -1126,20 +1125,15 @@ static void updateKeyPad(bool add)
         }
     }
     if (keypadContext.hidden == true) {
-        nbgl_layoutUpdateHiddenDigits(
-            keypadContext.layoutCtx, keypadContext.digitsIndex, keypadContext.pinLen);
+        nbgl_layoutUpdateKeypadContent(keypadContext.layoutCtx, true, keypadContext.pinLen, NULL);
     }
     else {
-        nbgl_layoutUpdateEnteredDigits(keypadContext.layoutCtx,
-                                       keypadContext.digitsIndex,
-                                       (const char *) keypadContext.pinEntry);
+        nbgl_layoutUpdateKeypadContent(
+            keypadContext.layoutCtx, false, 0, (const char *) keypadContext.pinEntry);
     }
     if (redrawKeypad) {
-        nbgl_layoutUpdateKeypad(keypadContext.layoutCtx,
-                                keypadContext.keypadIndex,
-                                enableValidate,
-                                enableBackspace,
-                                enableDigits);
+        nbgl_layoutUpdateKeypad(
+            keypadContext.layoutCtx, 0, enableValidate, enableBackspace, enableDigits);
     }
 
     if ((!add) && (keypadContext.pinLen == 0)) {
@@ -1163,8 +1157,7 @@ static void keypadCallback(char touchedKey)
 
         case VALIDATE_KEY:
             // Gray out keyboard / buttons as a first user feedback
-            nbgl_layoutUpdateKeypad(
-                keypadContext.layoutCtx, keypadContext.keypadIndex, false, false, true);
+            nbgl_layoutUpdateKeypad(keypadContext.layoutCtx, 0, false, false, true);
             nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_FAST_REFRESH,
                                                POST_REFRESH_FORCE_POWER_ON);
 
@@ -1194,9 +1187,13 @@ static void keypadGenericUseCase(const char                *title,
                                  nbgl_pinValidCallback_t    validatePinCallback,
                                  nbgl_layoutTouchCallback_t actionCallback)
 {
-    nbgl_layoutDescription_t  layoutDescription = {0};
-    nbgl_layoutCenteredInfo_t centeredInfo      = {0};
-    int                       status            = -1;
+    nbgl_layoutDescription_t layoutDescription = {0};
+    nbgl_layoutHeader_t      headerDesc        = {.type               = HEADER_BACK_AND_TEXT,
+                                                  .separationLine     = true,
+                                                  .backAndText.token  = backToken,
+                                                  .backAndText.tuneId = tuneId,
+                                                  .backAndText.text   = NULL};
+    int                      status            = -1;
 
     if ((minDigits > KEYPAD_MAX_DIGITS) || (maxDigits > KEYPAD_MAX_DIGITS)) {
         return;
@@ -1213,34 +1210,21 @@ static void keypadGenericUseCase(const char                *title,
     keypadContext.layoutCtx            = nbgl_layoutGet(&layoutDescription);
     keypadContext.hidden               = hidden;
 
-    // set navigation bar
-    nbgl_layoutAddProgressIndicator(
-        keypadContext.layoutCtx, 0, 0, (backToken != 0), backToken, tuneId);
-
-    // add text description
-    centeredInfo.text1 = title;
-    centeredInfo.style = LARGE_CASE_INFO;
-    centeredInfo.onTop = true;
-    nbgl_layoutAddCenteredInfo(keypadContext.layoutCtx, &centeredInfo);
+    // set back key in header
+    nbgl_layoutAddHeader(keypadContext.layoutCtx, &headerDesc);
 
     // add keypad
     status = nbgl_layoutAddKeypad(keypadContext.layoutCtx, keypadCallback, shuffled);
     if (status < 0) {
         return;
     }
-    keypadContext.keypadIndex = (unsigned int) status;
+    // add keypad content
+    status = nbgl_layoutAddKeypadContent(
+        keypadContext.layoutCtx, title, keypadContext.hidden, maxDigits, "");
 
-    // add digits entry
-    if (keypadContext.hidden == true) {
-        status = nbgl_layoutAddHiddenDigits(keypadContext.layoutCtx, maxDigits);
-    }
-    else {
-        status = nbgl_layoutAddEnteredDigits(keypadContext.layoutCtx, "", 0);
-    }
     if (status < 0) {
         return;
     }
-    keypadContext.digitsIndex = (unsigned int) status;
 
     // validation pin callback
     onValidatePin = validatePinCallback;
@@ -1852,7 +1836,7 @@ void nbgl_useCaseGenericConfiguration(const char                   *title,
                                       const nbgl_genericContents_t *contents,
                                       nbgl_callback_t               quitCallback)
 {
-    return nbgl_useCaseGenericSettings(title, initPage, contents, NULL, quitCallback);
+    nbgl_useCaseGenericSettings(title, initPage, contents, NULL, quitCallback);
 }
 
 /**
@@ -1961,24 +1945,45 @@ void nbgl_useCaseStatus(const char *message, bool isSuccess, nbgl_callback_t qui
 void nbgl_useCaseReviewStatus(nbgl_reviewStatusType_t reviewStatusType,
                               nbgl_callback_t         quitCallback)
 {
+    const char *msg;
+    bool        isSuccess;
     switch (reviewStatusType) {
         case STATUS_TYPE_OPERATION_SIGNED:
-            return nbgl_useCaseStatus("Operation signed", true, quitCallback);
+            msg       = "Operation signed";
+            isSuccess = true;
+            break;
         case STATUS_TYPE_OPERATION_REJECTED:
-            return nbgl_useCaseStatus("Operation rejected", false, quitCallback);
+            msg       = "Operation rejected";
+            isSuccess = false;
+            break;
         case STATUS_TYPE_TRANSACTION_SIGNED:
-            return nbgl_useCaseStatus("Transaction signed", true, quitCallback);
+            msg       = "Transaction signed";
+            isSuccess = true;
+            break;
         case STATUS_TYPE_TRANSACTION_REJECTED:
-            return nbgl_useCaseStatus("Transaction rejected", false, quitCallback);
+            msg       = "Transaction rejected";
+            isSuccess = false;
+            break;
         case STATUS_TYPE_MESSAGE_SIGNED:
-            return nbgl_useCaseStatus("Message signed", true, quitCallback);
+            msg       = "Message signed";
+            isSuccess = true;
+            break;
         case STATUS_TYPE_MESSAGE_REJECTED:
-            return nbgl_useCaseStatus("Message rejected", false, quitCallback);
+            msg       = "Message rejected";
+            isSuccess = false;
+            break;
         case STATUS_TYPE_ADDRESS_VERIFIED:
-            return nbgl_useCaseStatus("Address verified", true, quitCallback);
+            msg       = "Address verified";
+            isSuccess = true;
+            break;
         case STATUS_TYPE_ADDRESS_REJECTED:
-            return nbgl_useCaseStatus("Address verification\ncancelled", false, quitCallback);
+            msg       = "Address verification\ncancelled";
+            isSuccess = false;
+            break;
+        default:
+            return;
     }
+    nbgl_useCaseStatus(msg, isSuccess, quitCallback);
 }
 
 /**


### PR DESCRIPTION
## Description

The goal of this PR is to simplify the management of screens containing keyboard or keypad.
These screen also often contain a title, some control to display entered text or digits, and some controls to validate or interact. All these controls have currently to be added one by one, and their vertical aligment is tricky.
The idea of this PR is to add the concepts of keypad content and keyboard content to handle all these control as a single area (like in Figma).
The old API is kept but depracated

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

