### PR TITLE
Fix wrong behaviour when popping a NBGL screen when no background remaining

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -558,7 +558,8 @@ void nbgl_keyboardTouchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType)
     if (keyboard->mode == MODE_LETTERS) {
         keyboardCase_t cur_casing = keyboard->casing;
         // if the casing mode was upper (not-locked), go back to lower case
-        if ((keyboard->casing == UPPER_CASE) && (firstIndex != SHIFT_KEY_INDEX)) {
+        if ((keyboard->casing == UPPER_CASE) && (firstIndex != SHIFT_KEY_INDEX)
+            && ((IS_KEY_MASKED(firstIndex)) == 0)) {
             keyboard->casing = LOWER_CASE;
             // just redraw, refresh will be done by client (user of keyboard)
             nbgl_redrawObject((nbgl_obj_t *) keyboard, NULL, false);

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -404,6 +404,12 @@ int nbgl_screenPop(uint8_t screenIndex)
     // release used objects and containers
     nbgl_objPoolRelease(screenIndex);
     nbgl_containerPoolRelease(screenIndex);
+
+    // special case when we pop the only modal and no real background is under it
+    if ((nbScreensOnStack == 1) && (screenStack[0].container.nbChildren == 0)) {
+        nbScreensOnStack = 0;
+        topOfStack       = NULL;
+    }
     return 0;
 }
 
@@ -423,6 +429,8 @@ int nbgl_screenReset(void)
             nbgl_objPoolRelease(screenIndex);
             nbgl_containerPoolRelease(screenIndex);
         }
+        screenStack[screenIndex].container.children   = NULL;
+        screenStack[screenIndex].container.nbChildren = 0;
     }
     nbScreensOnStack = 0;
     topOfStack       = NULL;


### PR DESCRIPTION
## Description

The goal of this PR is to fix a bad behavior of NBGL screen management.
Indeed, when a modal screen is "popped", the screen counter is decremented, but when there is no screen occuping the background (screen level 0), and no other modal, the counter should be reset to 0.

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
