### PR TITLE
Reduce touch border exclusion on Stax: limit it to left border

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keyboard.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard.c
@@ -697,9 +697,11 @@ void nbgl_objDrawKeyboard(nbgl_keyboard_t *kbd)
 
     keyboardDraw(kbd);
 
-    // If a keyboard in the screen, exclude only top border from touch, to avoid missing touch on
+#ifdef TARGET_STAX
+    // If a keyboard in the screen, exclude nothing from touch, to avoid missing touch on
     // left keys
-    touch_exclude_borders(TOP_BORDER);
+    touch_exclude_borders(0);
+#endif  // TARGET_STAX
 }
 #endif  // HAVE_SE_TOUCH
 #endif  // NBGL_KEYBOARD

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -68,11 +68,11 @@ void nbgl_screenRedraw(void)
         return;
     }
     LOG_DEBUG(SCREEN_LOGGER, "nbgl_screenRedraw(): nbScreensOnStack = %d\n", nbScreensOnStack);
-#ifdef HAVE_SE_TOUCH
-    // by default, exclude left & top borders from touch
+#ifdef TARGET_STAX
+    // by default, exclude only left border from touch
     // if any sub-object is a keyboard, this will be modified when drawing it
-    touch_exclude_borders(TOP_BORDER | LEFT_BORDER);
-#endif  // HAVE_SE_TOUCH
+    touch_exclude_borders(LEFT_BORDER);
+#endif  // TARGET_STAX
 
     nbgl_screen_reinit();
     nbgl_redrawObject((nbgl_obj_t *) topOfStack, NULL, true);


### PR DESCRIPTION
## Description

The goal of this PR is to reduce touch border exclusion on Stax, by limiting it to left border instead of left+top border.
It partially fixes https://ledgerhq.atlassian.net/browse/FWEO-1097 (the rest of the fix will be in bolos)

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
