### PR TITLE
Fix FWEO-1094 - Use small QRCode when needed

### DIFF
--- a/lib_nbgl/include/nbgl_draw.h
+++ b/lib_nbgl/include/nbgl_draw.h
@@ -47,10 +47,10 @@ nbgl_font_id_e nbgl_drawText(const nbgl_area_t *area,
                              uint16_t           textLen,
                              nbgl_font_id_e     fontId,
                              color_t            fontColor);
-void           nbgl_drawQrCode(const nbgl_area_t *area,
-                               uint8_t            version,
-                               const char        *text,
-                               color_t            backgroundColor);
+void           nbgl_drawQrCode(const nbgl_area_t    *area,
+                               nbgl_qrcode_version_t version,
+                               const char           *text,
+                               color_t               backgroundColor);
 
 /**********************
  *      MACROS

--- a/lib_nbgl/include/nbgl_types.h
+++ b/lib_nbgl/include/nbgl_types.h
@@ -186,8 +186,9 @@ typedef enum {
  *
  */
 typedef enum {
-    QRCODE_V4 = 0,  ///< QRCode V4, can encode text len up to 114 chars
-    QRCODE_V10      ///< QRCode V10, can encode text len up to 1500 chars
+    QRCODE_V4 = 0,   ///< QRCode V4, can encode text len up to 62 chars, display size = 264*264
+    QRCODE_V10,      ///< QRCode V10, can encode text len up to 1500 chars, display size = 228*228
+    QRCODE_V4_SMALL  ///< QRCode V4, can encode text len up to 1500 chars, display size = 132*132
 } nbgl_qrcode_version_t;
 
 /**

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1456,7 +1456,7 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
  *
  * @param layout the current layout
  * @param info structure giving the description of buttons (texts, icons, layout)
- * @return >= 0 if OK
+ * @return height of the control if OK
  */
 int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
 {
@@ -1545,6 +1545,15 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
         container->children[container->nbChildren] = (nbgl_obj_t *) textArea;
         container->nbChildren++;
     }
+    // ensure that fullHeight is fitting in main container height (with 16 px margin)
+    if ((fullHeight >= (layoutInt->container->obj.area.height - 16))
+        && (qrcode->version == QRCODE_V4)) {
+        qrcode->version = QRCODE_V4_SMALL;
+        // in QR V4 small, we use 4*4 screen pixels for one QR pixel
+        qrcode->obj.area.width  = QR_V4_NB_PIX_SIZE * 4;
+        qrcode->obj.area.height = qrcode->obj.area.width;
+        fullHeight -= QR_V4_NB_PIX_SIZE * 4;
+    }
     container->obj.area.height = fullHeight;
     container->layout          = VERTICAL;
     if (info->centered) {
@@ -1562,7 +1571,7 @@ int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info)
     // set this new container as child of main container
     layoutAddObject(layoutInt, (nbgl_obj_t *) container);
 
-    return 0;
+    return fullHeight;
 }
 #endif  // NBGL_QRCODE
 

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -1031,8 +1031,7 @@ static void draw_qrCode(nbgl_qrcode_t *obj, nbgl_obj_t *prevObj, bool computePos
     rectArea.width           = obj->obj.area.width;
     rectArea.height          = obj->obj.area.height;
     rectArea.backgroundColor = obj->obj.area.backgroundColor;
-    nbgl_drawQrCode(
-        &rectArea, (obj->version == QRCODE_V4) ? 4 : 10, obj->text, obj->foregroundColor);
+    nbgl_drawQrCode(&rectArea, obj->version, obj->text, obj->foregroundColor);
 }
 #endif  // NBGL_QRCODE
 


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledgerhq.atlassian.net/browse/FWEO-1094, by automatically detecting that a QR Code (+description) is not fitting in the screen, and use a smaller size (132x132 instead of 264x264)

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
