### PR TITLE
Makefile.standard_app: Require specific app icon for Flex device

### DIFF
--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -205,8 +205,11 @@ endif
 ifeq ($(TARGET_NAME), TARGET_NANOS2)
 ICONNAME ?= $(ICON_NANOSP)
 endif
-ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME),TARGET_STAX TARGET_FLEX))
+ifeq ($(TARGET_NAME), TARGET_STAX)
 ICONNAME ?= $(ICON_STAX)
+endif
+ifeq ($(TARGET_NAME), TARGET_FLEX)
+ICONNAME ?= $(ICON_FLEX)
 endif
 
 include $(BOLOS_SDK)/Makefile.glyphs


### PR DESCRIPTION
## Description

Makefile.standard_app: Require specific app icon for Flex device

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)
