### PR TITLE
Rework EdDSA functions

### DIFF
--- a/include/cx_stubs.h
+++ b/include/cx_stubs.h
@@ -133,3 +133,10 @@
 #define _NR_cx_swap_uint64                       0x81
 #define _NR_cx_x25519                            0x82
 #define _NR_cx_x448                              0x83
+#define _NR_cx_eddsa_final_hash                  0x84
+#define _NR_cx_eddsa_sign_init_first_hash        0x85
+#define _NR_cx_eddsa_sign_init_second_hash       0x86
+#define _NR_cx_eddsa_sign_hash                   0x87
+#define _NR_cx_eddsa_update_hash                 0x88
+#define _NR_cx_eddsa_verify_init_hash            0x89
+#define _NR_cx_eddsa_verify_hash                 0x8a

--- a/lib_cxng/cx.export
+++ b/lib_cxng/cx.export
@@ -136,3 +136,10 @@ cx_swap_uint32
 cx_swap_uint64
 cx_x25519
 cx_x448
+cx_eddsa_final_hash
+cx_eddsa_sign_init_first_hash
+cx_eddsa_sign_init_second_hash
+cx_eddsa_sign_hash
+cx_eddsa_update_hash
+cx_eddsa_verify_init_hash
+cx_eddsa_verify_hash

--- a/lib_cxng/src/cx_exported_functions.c
+++ b/lib_cxng/src/cx_exported_functions.c
@@ -157,4 +157,11 @@ unsigned long __attribute((section("._cx_exported_functions"))) cx_exported_func
     [_NR_cx_swap_uint64]                  = (unsigned long) cx_swap_uint64,
     [_NR_cx_x25519]                       = (unsigned long) cx_x25519,
     [_NR_cx_x448]                         = (unsigned long) cx_x448,
+    [_NR_cx_eddsa_final_hash]             = (unsigned long) cx_eddsa_final_hash,
+    [_NR_cx_eddsa_sign_init_first_hash]   = (unsigned long) cx_eddsa_sign_init_first_hash,
+    [_NR_cx_eddsa_sign_init_second_hash]  = (unsigned long) cx_eddsa_sign_init_second_hash,
+    [_NR_cx_eddsa_sign_hash]              = (unsigned long) cx_eddsa_sign_hash,
+    [_NR_cx_eddsa_update_hash]            = (unsigned long) cx_eddsa_update_hash,
+    [_NR_cx_eddsa_verify_init_hash]       = (unsigned long) cx_eddsa_verify_init_hash,
+    [_NR_cx_eddsa_verify_hash]            = (unsigned long) cx_eddsa_verify_hash,
 };

--- a/src/cx_stubs.S
+++ b/src/cx_stubs.S
@@ -148,6 +148,13 @@ CX_TRAMPOLINE _NR_cx_swap_uint32                           cx_swap_uint32
 CX_TRAMPOLINE _NR_cx_swap_uint64                           cx_swap_uint64
 CX_TRAMPOLINE _NR_cx_x25519                                cx_x25519
 CX_TRAMPOLINE _NR_cx_x448                                  cx_x448
+CX_TRAMPOLINE _NR_cx_eddsa_final_hash                      cx_eddsa_final_hash
+CX_TRAMPOLINE _NR_cx_eddsa_sign_init_first_hash            cx_eddsa_sign_init_first_hash
+CX_TRAMPOLINE _NR_cx_eddsa_sign_init_second_hash           cx_eddsa_sign_init_second_hash
+CX_TRAMPOLINE _NR_cx_eddsa_sign_hash                       cx_eddsa_sign_hash
+CX_TRAMPOLINE _NR_cx_eddsa_update_hash                     cx_eddsa_update_hash
+CX_TRAMPOLINE _NR_cx_eddsa_verify_init_hash                cx_eddsa_verify_init_hash
+CX_TRAMPOLINE _NR_cx_eddsa_verify_hash                     cx_eddsa_verify_hash
 
 .thumb_func
 cx_trampoline_helper:


### PR DESCRIPTION
## Description

This PR makes functions available to separate the edDSA message hash from the signature/verification functions. This way, if the message to hash is long, it can be hashed block by block.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
