### PR TITLE
Fix FWEO-1116 - Unicode chars not aligned on Flex

### DIFF
--- a/lib_nbgl/fonts/config-Inter-Medium36-1bpp.ini
+++ b/lib_nbgl/fonts/config-Inter-Medium36-1bpp.ini
@@ -7,6 +7,7 @@ loaded_baseline=29
 baseline_offset=1
 fontSize=36
 lineSize=40
+bottom_offset=2
 firstChar=0x20
 lastChar=0x7E
 crop=true

--- a/lib_nbgl/fonts/config-Inter-Medium36.ini
+++ b/lib_nbgl/fonts/config-Inter-Medium36.ini
@@ -7,6 +7,7 @@ loaded_baseline=29
 baseline_offset=1
 fontSize=36
 lineSize=40
+bottom_offset=2
 firstChar=0x20
 lastChar=0x7E
 crop=true

--- a/lib_nbgl/fonts/config-Inter-Regular28-1bpp.ini
+++ b/lib_nbgl/fonts/config-Inter-Regular28-1bpp.ini
@@ -5,6 +5,7 @@ font_id_name=BAGL_FONT_INTER_REGULAR_28px_1bpp
 loaded_baseline=22
 fontSize=28
 lineSize=36
+bottom_offset=1
 firstChar=0x20
 lastChar=0x7E
 crop=true

--- a/lib_nbgl/fonts/config-Inter-Regular28.ini
+++ b/lib_nbgl/fonts/config-Inter-Regular28.ini
@@ -5,6 +5,7 @@ font_id_name=BAGL_FONT_INTER_REGULAR_28px
 loaded_baseline=23
 fontSize=28
 lineSize=36
+bottom_offset=1
 firstChar=0x20
 lastChar=0x7E
 crop=true

--- a/lib_nbgl/fonts/config-Inter-SemiBold28-1bpp.ini
+++ b/lib_nbgl/fonts/config-Inter-SemiBold28-1bpp.ini
@@ -5,6 +5,7 @@ font_id_name=BAGL_FONT_INTER_SEMIBOLD_28px_1bpp
 loaded_baseline=22
 fontSize=28
 lineSize=36
+bottom_offset=1
 firstChar=0x20
 lastChar=0x7E
 crop=false

--- a/lib_nbgl/fonts/config-Inter-SemiBold28.ini
+++ b/lib_nbgl/fonts/config-Inter-SemiBold28.ini
@@ -5,6 +5,7 @@ font_id_name=BAGL_FONT_INTER_SEMIBOLD_28px
 loaded_baseline=23
 fontSize=28
 lineSize=36
+bottom_offset=1
 firstChar=0x20
 lastChar=0x7E
 crop=true


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledgerhq.atlassian.net/browse/FWEO-1116
Thanks to a new settings in Flex font ini files, an offset is applied on each generated unicode char (the ASCII ones are not concerned because they are taken from .png files)

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

