### PR TITLE
Fix crash when using tag/value getter callback and TAG_VALUE_DETAILS

### DIFF
--- a/lib_nbgl/src/nbgl_page.c
+++ b/lib_nbgl/src/nbgl_page.c
@@ -105,29 +105,18 @@ static void addContent(nbgl_pageContent_t *content,
                     = {.type = HEADER_EMPTY, .separationLine = false, .emptySpace.height = 40};
                 nbgl_layoutAddHeader(layout, &headerDesc);
             }
-            uint16_t nbLines = nbgl_getTextNbLinesInWidth(
-                content->tagValueDetails.tagValueList.smallCaseForValue ? SMALL_BOLD_FONT
-                                                                        : LARGE_MEDIUM_FONT,
-                content->tagValueDetails.tagValueList.pairs[0].value,
-                SCREEN_WIDTH - 2 * BORDER_MARGIN,
-                content->tagValueDetails.tagValueList.wrapping);
-            // automatically display a button if content is longer that nbMaxLinesForValue
-            if (nbLines > (content->tagValueDetails.tagValueList.nbMaxLinesForValue)) {
-                nbgl_layoutButton_t buttonInfo;
-                content->tagValueDetails.tagValueList.nbMaxLinesForValue -= 3;
-                nbgl_layoutAddTagValueList(layout, &content->tagValueDetails.tagValueList);
-                buttonInfo.fittingContent = true;
-                buttonInfo.icon           = content->tagValueDetails.detailsButtonIcon;
-                buttonInfo.style          = WHITE_BACKGROUND;
-                buttonInfo.text           = content->tagValueDetails.detailsButtonText;
-                buttonInfo.token          = content->tagValueDetails.detailsButtonToken;
-                buttonInfo.tuneId         = content->tagValueDetails.tuneId;
-                buttonInfo.onBottom       = false;
-                nbgl_layoutAddButton(layout, &buttonInfo);
-            }
-            else {
-                nbgl_layoutAddTagValueList(layout, &content->tagValueDetails.tagValueList);
-            }
+            // display a button under tag/value
+            nbgl_layoutButton_t buttonInfo;
+            content->tagValueDetails.tagValueList.nbMaxLinesForValue -= 3;
+            nbgl_layoutAddTagValueList(layout, &content->tagValueDetails.tagValueList);
+            buttonInfo.fittingContent = true;
+            buttonInfo.icon           = content->tagValueDetails.detailsButtonIcon;
+            buttonInfo.style          = WHITE_BACKGROUND;
+            buttonInfo.text           = content->tagValueDetails.detailsButtonText;
+            buttonInfo.token          = content->tagValueDetails.detailsButtonToken;
+            buttonInfo.tuneId         = content->tagValueDetails.tuneId;
+            buttonInfo.onBottom       = false;
+            nbgl_layoutAddButton(layout, &buttonInfo);
             break;
         }
         case TAG_VALUE_CONFIRM: {


### PR DESCRIPTION
## Description

The goal of this PR is to fix a crash when using tag/value getter callback and TAG_VALUE_DETAILS.
In any case, when using TAG_VALUE_DETAILS, it's not necessary to recompute the number of lines, which has been computed in Use Case layer.

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
