### PR TITLE
lib_nbgl / lib_ux_sync: Replace nbgl_layoutTagValueList_t with nbgl_contentTagValueList_t

### DIFF
--- a/lib_nbgl/doc/nbgl_use_case.dox
+++ b/lib_nbgl/doc/nbgl_use_case.dox
@@ -560,7 +560,7 @@ Here is the code to display something similar to example picture:
 // 4 pairs of tag/value to display
 static nbgl_layoutTagValue_t pairs[4];
 
-static nbgl_layoutTagValueList_t pairList = {
+static nbgl_contentTagValueList_t pairList = {
   .nbMaxLinesForValue = 0,
   .nbPairs = 4,
   .pairs = (nbgl_layoutTagValue_t*)pairs
@@ -604,7 +604,7 @@ static nbgl_layoutTagValue_t pair;
 
 static nbgl_layoutTagValue_t* getPair(uint8_t index);
 
-static nbgl_layoutTagValueList_t pairList = {
+static nbgl_contentTagValueList_t pairList = {
   .nbMaxLinesForValue = 0,
   .nbPairs = 4,
   .pairs = NULL, // to indicate that callback should be used
@@ -831,7 +831,7 @@ Here is the code to display something similar to example picture:
 // 2 pairs of tag/value to display in second page
 static nbgl_layoutTagValue_t pairs[2];
 
-static nbgl_layoutTagValueList_t pairList = {
+static nbgl_contentTagValueList_t pairList = {
   .nbMaxLinesForValue = 0,
   .nbPairs = 2,
   .pairs = (nbgl_layoutTagValue_t*)pairs

--- a/lib_nbgl/doc/nbgl_use_case_nanos.dox
+++ b/lib_nbgl/doc/nbgl_use_case_nanos.dox
@@ -355,7 +355,7 @@ static nbgl_layoutTagValue_t pairs[2] = {
   }
 };
 
-static nbgl_layoutTagValueList_t pairList = {
+static nbgl_contentTagValueList_t pairList = {
   .nbMaxLinesForValue = 0,
   .nbPairs = 2,
   .pairs = (nbgl_layoutTagValue_t*)pairs
@@ -392,7 +392,7 @@ static nbgl_layoutTagValue_t pair;
 
 static nbgl_layoutTagValue_t* getPair(uint8_t index);
 
-static nbgl_layoutTagValueList_t pairList = {
+static nbgl_contentTagValueList_t pairList = {
   .nbMaxLinesForValue = 0,
   .nbPairs = 5,
   .pairs = NULL, // to indicate that callback should be used

--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -188,28 +188,28 @@ void nbgl_useCaseHomeAndSettings(const char                   *appName,
                                  const nbgl_homeAction_t      *action,
                                  nbgl_callback_t               quitCallback);
 
-void nbgl_useCaseReview(nbgl_operationType_t             operationType,
-                        const nbgl_layoutTagValueList_t *tagValueList,
-                        const nbgl_icon_details_t       *icon,
-                        const char                      *reviewTitle,
-                        const char                      *reviewSubTitle,
-                        const char                      *finishTitle,
-                        nbgl_choiceCallback_t            choiceCallback);
+void nbgl_useCaseReview(nbgl_operationType_t              operationType,
+                        const nbgl_contentTagValueList_t *tagValueList,
+                        const nbgl_icon_details_t        *icon,
+                        const char                       *reviewTitle,
+                        const char                       *reviewSubTitle,
+                        const char                       *finishTitle,
+                        nbgl_choiceCallback_t             choiceCallback);
 
-void nbgl_useCaseReviewLight(nbgl_operationType_t             operationType,
-                             const nbgl_layoutTagValueList_t *tagValueList,
-                             const nbgl_icon_details_t       *icon,
-                             const char                      *reviewTitle,
-                             const char                      *reviewSubTitle,
-                             const char                      *finishTitle,
-                             nbgl_choiceCallback_t            choiceCallback);
+void nbgl_useCaseReviewLight(nbgl_operationType_t              operationType,
+                             const nbgl_contentTagValueList_t *tagValueList,
+                             const nbgl_icon_details_t        *icon,
+                             const char                       *reviewTitle,
+                             const char                       *reviewSubTitle,
+                             const char                       *finishTitle,
+                             nbgl_choiceCallback_t             choiceCallback);
 
-void nbgl_useCaseAddressReview(const char                      *address,
-                               const nbgl_layoutTagValueList_t *additionalTagValueList,
-                               const nbgl_icon_details_t       *icon,
-                               const char                      *reviewTitle,
-                               const char                      *reviewSubTitle,
-                               nbgl_choiceCallback_t            choiceCallback);
+void nbgl_useCaseAddressReview(const char                       *address,
+                               const nbgl_contentTagValueList_t *additionalTagValueList,
+                               const nbgl_icon_details_t        *icon,
+                               const char                       *reviewTitle,
+                               const char                       *reviewSubTitle,
+                               nbgl_choiceCallback_t             choiceCallback);
 
 void nbgl_useCaseReviewStatus(nbgl_reviewStatusType_t reviewStatusType,
                               nbgl_callback_t         quitCallback);
@@ -220,8 +220,8 @@ void nbgl_useCaseReviewStreamingStart(nbgl_operationType_t       operationType,
                                       const char                *reviewSubTitle,
                                       nbgl_choiceCallback_t      choiceCallback);
 
-void nbgl_useCaseReviewStreamingContinue(const nbgl_layoutTagValueList_t *tagValueList,
-                                         nbgl_choiceCallback_t            choiceCallback);
+void nbgl_useCaseReviewStreamingContinue(const nbgl_contentTagValueList_t *tagValueList,
+                                         nbgl_choiceCallback_t             choiceCallback);
 
 void nbgl_useCaseReviewStreamingFinish(const char           *finishTitle,
                                        nbgl_choiceCallback_t choiceCallback);
@@ -237,11 +237,11 @@ void nbgl_useCaseGenericConfiguration(const char                   *title,
 
 #ifdef HAVE_SE_TOUCH
 // utils
-uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                          nbPairs,
-                                         const nbgl_layoutTagValueList_t *tagValueList,
-                                         uint8_t                          startIndex,
-                                         bool                            *requireSpecificDisplay);
-uint8_t nbgl_useCaseGetNbPagesForTagValueList(const nbgl_layoutTagValueList_t *tagValueList);
+uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                           nbPairs,
+                                         const nbgl_contentTagValueList_t *tagValueList,
+                                         uint8_t                           startIndex,
+                                         bool                             *requireSpecificDisplay);
+uint8_t nbgl_useCaseGetNbPagesForTagValueList(const nbgl_contentTagValueList_t *tagValueList);
 
 // use case drawing
 void nbgl_useCaseHome(const char                *appName,
@@ -310,19 +310,19 @@ void nbgl_useCaseForwardOnlyReviewNoSkip(const char                *rejectText,
                                          nbgl_layoutTouchCallback_t buttonCallback,
                                          nbgl_navCallback_t         navCallback,
                                          nbgl_choiceCallback_t      choiceCallback);
-void nbgl_useCaseStaticReview(const nbgl_layoutTagValueList_t *tagValueList,
-                              const nbgl_pageInfoLongPress_t  *infoLongPress,
-                              const char                      *rejectText,
-                              nbgl_choiceCallback_t            callback);
-void nbgl_useCaseStaticReviewLight(const nbgl_layoutTagValueList_t *tagValueList,
-                                   const nbgl_pageInfoLongPress_t  *infoLongPress,
-                                   const char                      *rejectText,
-                                   nbgl_choiceCallback_t            callback);
+void nbgl_useCaseStaticReview(const nbgl_contentTagValueList_t *tagValueList,
+                              const nbgl_pageInfoLongPress_t   *infoLongPress,
+                              const char                       *rejectText,
+                              nbgl_choiceCallback_t             callback);
+void nbgl_useCaseStaticReviewLight(const nbgl_contentTagValueList_t *tagValueList,
+                                   const nbgl_pageInfoLongPress_t   *infoLongPress,
+                                   const char                       *rejectText,
+                                   nbgl_choiceCallback_t             callback);
 void nbgl_useCaseViewDetails(const char *tag, const char *value, bool wrapping);
 void nbgl_useCaseAddressConfirmation(const char *address, nbgl_choiceCallback_t callback);
-void nbgl_useCaseAddressConfirmationExt(const char                      *address,
-                                        nbgl_choiceCallback_t            callback,
-                                        const nbgl_layoutTagValueList_t *tagValueList);
+void nbgl_useCaseAddressConfirmationExt(const char                       *address,
+                                        nbgl_choiceCallback_t             callback,
+                                        const nbgl_contentTagValueList_t *tagValueList);
 #ifdef NBGL_KEYPAD
 void nbgl_useCaseKeypadDigits(const char                *title,
                               uint8_t                    minDigits,
@@ -377,21 +377,21 @@ void nbgl_useCaseSettings(uint8_t               initPage,
                           nbgl_actionCallback_t actionCallback);
 void nbgl_useCaseRegularReview(uint8_t initPage, uint8_t nbPages, nbgl_navCallback_t navCallback);
 void nbgl_useCaseForwardOnlyReview(nbgl_navCallback_t navCallback);
-void nbgl_useCaseStaticReview(nbgl_layoutTagValueList_t *tagValueList,
-                              const nbgl_icon_details_t *icon,
-                              const char                *reviewTitle,
-                              const char                *acceptText,
-                              const char                *rejectText,
-                              nbgl_choiceCallback_t      callback);
+void nbgl_useCaseStaticReview(nbgl_contentTagValueList_t *tagValueList,
+                              const nbgl_icon_details_t  *icon,
+                              const char                 *reviewTitle,
+                              const char                 *acceptText,
+                              const char                 *rejectText,
+                              nbgl_choiceCallback_t       callback);
 void nbgl_useCaseAddressConfirmation(const nbgl_icon_details_t *icon,
                                      const char                *title,
                                      const char                *address,
                                      nbgl_choiceCallback_t      callback);
-void nbgl_useCaseAddressConfirmationExt(const nbgl_icon_details_t       *icon,
-                                        const char                      *title,
-                                        const char                      *address,
-                                        nbgl_choiceCallback_t            callback,
-                                        const nbgl_layoutTagValueList_t *tagValueList);
+void nbgl_useCaseAddressConfirmationExt(const nbgl_icon_details_t        *icon,
+                                        const char                       *title,
+                                        const char                       *address,
+                                        nbgl_choiceCallback_t             callback,
+                                        const nbgl_contentTagValueList_t *tagValueList);
 #endif  // HAVE_SE_TOUCH
 void nbgl_useCaseSpinner(const char *text);
 #ifdef __cplusplus

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1297,10 +1297,10 @@ static uint8_t nbgl_useCaseGetNbPagesForGenericContents(
     return nbPages;
 }
 
-static void prepareAddressConfirmationPages(const char                      *address,
-                                            const nbgl_layoutTagValueList_t *tagValueList,
-                                            nbgl_content_t                  *firstPageContent,
-                                            nbgl_content_t                  *secondPageContent)
+static void prepareAddressConfirmationPages(const char                       *address,
+                                            const nbgl_contentTagValueList_t *tagValueList,
+                                            nbgl_content_t                   *firstPageContent,
+                                            nbgl_content_t                   *secondPageContent)
 {
     nbgl_contentTagValueConfirm_t *tagValueConfirm;
 
@@ -1356,7 +1356,7 @@ static void prepareAddressConfirmationPages(const char                      *add
         tagValueConfirm->detailsButtonText = NULL;
         tagValueConfirm->detailsButtonIcon = NULL;
         tagValueConfirm->tuneId            = TUNE_TAP_CASUAL;
-        memcpy(&tagValueConfirm->tagValueList, tagValueList, sizeof(nbgl_layoutTagValueList_t));
+        memcpy(&tagValueConfirm->tagValueList, tagValueList, sizeof(nbgl_contentTagValueList_t));
 
 #ifdef TARGET_STAX
         // no next page
@@ -1470,10 +1470,10 @@ static void bundleNavReviewStreamingChoice(bool confirm)
  *        - the tag/value doesn't fit in a page
  * @return the number of tag/value pairs fitting in a page
  */
-uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                          nbPairs,
-                                         const nbgl_layoutTagValueList_t *tagValueList,
-                                         uint8_t                          startIndex,
-                                         bool                            *requireSpecificDisplay)
+uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                           nbPairs,
+                                         const nbgl_contentTagValueList_t *tagValueList,
+                                         uint8_t                           startIndex,
+                                         bool                             *requireSpecificDisplay)
 {
     uint8_t  nbPairsInPage = 0;
     uint16_t currentHeight = 12;  // upper margin
@@ -1548,7 +1548,7 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                          nbPair
  * @param tagValueList list of tag/value pairs
  * @return the number of pages necessary to display the given list of tag/value pairs
  */
-uint8_t nbgl_useCaseGetNbPagesForTagValueList(const nbgl_layoutTagValueList_t *tagValueList)
+uint8_t nbgl_useCaseGetNbPagesForTagValueList(const nbgl_contentTagValueList_t *tagValueList)
 {
     uint8_t nbPages = 0;
     uint8_t nbPairs = tagValueList->nbPairs;
@@ -2249,10 +2249,10 @@ void nbgl_useCaseForwardOnlyReviewNoSkip(const char                *rejectText,
  * @param callback callback called when transaction is accepted (param is true) or rejected (param
  * is false)
  */
-void nbgl_useCaseStaticReview(const nbgl_layoutTagValueList_t *tagValueList,
-                              const nbgl_pageInfoLongPress_t  *infoLongPress,
-                              const char                      *rejectText,
-                              nbgl_choiceCallback_t            callback)
+void nbgl_useCaseStaticReview(const nbgl_contentTagValueList_t *tagValueList,
+                              const nbgl_pageInfoLongPress_t   *infoLongPress,
+                              const char                       *rejectText,
+                              nbgl_choiceCallback_t             callback)
 {
     uint8_t offset = 0;
 
@@ -2271,7 +2271,7 @@ void nbgl_useCaseStaticReview(const nbgl_layoutTagValueList_t *tagValueList,
         localContentsList[offset].type = TAG_VALUE_LIST;
         memcpy(&localContentsList[offset].content.tagValueList,
                tagValueList,
-               sizeof(nbgl_layoutTagValueList_t));
+               sizeof(nbgl_contentTagValueList_t));
         offset++;
     }
 
@@ -2304,10 +2304,10 @@ void nbgl_useCaseStaticReview(const nbgl_layoutTagValueList_t *tagValueList,
  * @param callback callback called when transaction is accepted (param is true) or rejected (param
  * is false)
  */
-void nbgl_useCaseStaticReviewLight(const nbgl_layoutTagValueList_t *tagValueList,
-                                   const nbgl_pageInfoLongPress_t  *infoLongPress,
-                                   const char                      *rejectText,
-                                   nbgl_choiceCallback_t            callback)
+void nbgl_useCaseStaticReviewLight(const nbgl_contentTagValueList_t *tagValueList,
+                                   const nbgl_pageInfoLongPress_t   *infoLongPress,
+                                   const char                       *rejectText,
+                                   nbgl_choiceCallback_t             callback)
 {
     uint8_t offset = 0;
 
@@ -2326,7 +2326,7 @@ void nbgl_useCaseStaticReviewLight(const nbgl_layoutTagValueList_t *tagValueList
         localContentsList[offset].type = TAG_VALUE_LIST;
         memcpy(&localContentsList[offset].content.tagValueList,
                tagValueList,
-               sizeof(nbgl_layoutTagValueList_t));
+               sizeof(nbgl_contentTagValueList_t));
         offset++;
     }
 
@@ -2362,13 +2362,13 @@ void nbgl_useCaseStaticReviewLight(const nbgl_layoutTagValueList_t *tagValueList
  * @param choiceCallback callback called when operation is accepted (param is true) or rejected
  * (param is false)
  */
-void nbgl_useCaseReview(nbgl_operationType_t             operationType,
-                        const nbgl_layoutTagValueList_t *tagValueList,
-                        const nbgl_icon_details_t       *icon,
-                        const char                      *reviewTitle,
-                        const char                      *reviewSubTitle,
-                        const char                      *finishTitle,
-                        nbgl_choiceCallback_t            choiceCallback)
+void nbgl_useCaseReview(nbgl_operationType_t              operationType,
+                        const nbgl_contentTagValueList_t *tagValueList,
+                        const nbgl_icon_details_t        *icon,
+                        const char                       *reviewTitle,
+                        const char                       *reviewSubTitle,
+                        const char                       *finishTitle,
+                        nbgl_choiceCallback_t             choiceCallback)
 {
     reset_callbacks();
     memset(&genericContext, 0, sizeof(genericContext));
@@ -2394,7 +2394,7 @@ void nbgl_useCaseReview(nbgl_operationType_t             operationType,
     localContentsList[1].type = TAG_VALUE_LIST;
     memcpy(&localContentsList[1].content.tagValueList,
            tagValueList,
-           sizeof(nbgl_layoutTagValueList_t));
+           sizeof(nbgl_contentTagValueList_t));
 
     // Eventually the long press page
     localContentsList[2].type = INFO_LONG_PRESS;
@@ -2422,13 +2422,13 @@ void nbgl_useCaseReview(nbgl_operationType_t             operationType,
  * @param choiceCallback callback called when operation is accepted (param is true) or rejected
  * (param is false)
  */
-void nbgl_useCaseReviewLight(nbgl_operationType_t             operationType,
-                             const nbgl_layoutTagValueList_t *tagValueList,
-                             const nbgl_icon_details_t       *icon,
-                             const char                      *reviewTitle,
-                             const char                      *reviewSubTitle,
-                             const char                      *finishTitle,
-                             nbgl_choiceCallback_t            choiceCallback)
+void nbgl_useCaseReviewLight(nbgl_operationType_t              operationType,
+                             const nbgl_contentTagValueList_t *tagValueList,
+                             const nbgl_icon_details_t        *icon,
+                             const char                       *reviewTitle,
+                             const char                       *reviewSubTitle,
+                             const char                       *finishTitle,
+                             nbgl_choiceCallback_t             choiceCallback)
 {
     reset_callbacks();
     memset(&genericContext, 0, sizeof(genericContext));
@@ -2451,7 +2451,7 @@ void nbgl_useCaseReviewLight(nbgl_operationType_t             operationType,
     localContentsList[1].type = TAG_VALUE_LIST;
     memcpy(&localContentsList[1].content.tagValueList,
            tagValueList,
-           sizeof(nbgl_layoutTagValueList_t));
+           sizeof(nbgl_contentTagValueList_t));
 
     // Eventually the long press page
     localContentsList[2].type = INFO_BUTTON;
@@ -2551,8 +2551,8 @@ void nbgl_useCaseReviewStreamingStart(nbgl_operationType_t       operationType,
  * @param choiceCallback callback called when more operation data are needed (param is true) or
  * operation is rejected (param is false)
  */
-void nbgl_useCaseReviewStreamingContinue(const nbgl_layoutTagValueList_t *tagValueList,
-                                         nbgl_choiceCallback_t            choiceCallback)
+void nbgl_useCaseReviewStreamingContinue(const nbgl_contentTagValueList_t *tagValueList,
+                                         nbgl_choiceCallback_t             choiceCallback)
 {
     // Should follow a call to nbgl_useCaseReviewStreamingStart
     memset(&genericContext, 0, sizeof(genericContext));
@@ -2572,7 +2572,7 @@ void nbgl_useCaseReviewStreamingContinue(const nbgl_layoutTagValueList_t *tagVal
     localContentsList[0].type = TAG_VALUE_LIST;
     memcpy(&localContentsList[0].content.tagValueList,
            tagValueList,
-           sizeof(nbgl_layoutTagValueList_t));
+           sizeof(nbgl_contentTagValueList_t));
 
     // compute number of pages & fill navigation structure
     bundleNavContext.reviewStreaming.stepPageNb
@@ -2688,9 +2688,9 @@ void nbgl_useCaseAddressConfirmation(const char *address, nbgl_choiceCallback_t 
  * @param tagValueList list of tag/value pairs (must fit in a single page, and be persistent because
  * no copy)
  */
-void nbgl_useCaseAddressConfirmationExt(const char                      *address,
-                                        nbgl_choiceCallback_t            callback,
-                                        const nbgl_layoutTagValueList_t *tagValueList)
+void nbgl_useCaseAddressConfirmationExt(const char                       *address,
+                                        nbgl_choiceCallback_t             callback,
+                                        const nbgl_contentTagValueList_t *tagValueList)
 {
     reset_callbacks();
     memset(&genericContext, 0, sizeof(genericContext));
@@ -2737,12 +2737,12 @@ void nbgl_useCaseAddressConfirmationExt(const char                      *address
  * @param choiceCallback callback called when transaction is accepted (param is true) or rejected
  * (param is false)
  */
-void nbgl_useCaseAddressReview(const char                      *address,
-                               const nbgl_layoutTagValueList_t *additionalTagValueList,
-                               const nbgl_icon_details_t       *icon,
-                               const char                      *reviewTitle,
-                               const char                      *reviewSubTitle,
-                               nbgl_choiceCallback_t            choiceCallback)
+void nbgl_useCaseAddressReview(const char                       *address,
+                               const nbgl_contentTagValueList_t *additionalTagValueList,
+                               const nbgl_icon_details_t        *icon,
+                               const char                       *reviewTitle,
+                               const char                       *reviewSubTitle,
+                               nbgl_choiceCallback_t             choiceCallback)
 {
     reset_callbacks();
     memset(&genericContext, 0, sizeof(genericContext));

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -28,7 +28,7 @@
 typedef struct ReviewContext_s {
     nbgl_navCallback_t         onNav;
     nbgl_choiceCallback_t      onChoice;
-    nbgl_layoutTagValueList_t  tagValueList;
+    nbgl_contentTagValueList_t tagValueList;
     const nbgl_icon_details_t *icon;
     const char                *reviewTitle;
     const char                *address;  // for address confirmation review
@@ -406,19 +406,19 @@ void nbgl_useCaseForwardOnlyReview(nbgl_navCallback_t navCallback)
  * @param callback callback called when transaction is accepted (param is true) or rejected (param
  * is false)
  */
-void nbgl_useCaseStaticReview(nbgl_layoutTagValueList_t *tagValueList,
-                              const nbgl_icon_details_t *icon,
-                              const char                *reviewTitle,
-                              const char                *acceptText,
-                              const char                *rejectText,
-                              nbgl_choiceCallback_t      callback)
+void nbgl_useCaseStaticReview(nbgl_contentTagValueList_t *tagValueList,
+                              const nbgl_icon_details_t  *icon,
+                              const char                 *reviewTitle,
+                              const char                 *acceptText,
+                              const char                 *rejectText,
+                              nbgl_choiceCallback_t       callback)
 {
     // memorize context
     memset(&context, 0, sizeof(UseCaseContext_t));
     context.review.forwardNavOnly = false;
     context.type                  = REVIEW_USE_CASE;
 
-    memcpy(&context.review.tagValueList, tagValueList, sizeof(nbgl_layoutTagValueList_t));
+    memcpy(&context.review.tagValueList, tagValueList, sizeof(nbgl_contentTagValueList_t));
 
     context.review.reviewTitle = reviewTitle;
     context.review.icon        = icon;
@@ -460,11 +460,11 @@ void nbgl_useCaseAddressConfirmation(const nbgl_icon_details_t *icon,
  * @param callback callback called when either confirm or reject page is double pressed
  * @param tagValueList list of tag/value pairs (must be persistent because no copy)
  */
-void nbgl_useCaseAddressConfirmationExt(const nbgl_icon_details_t       *icon,
-                                        const char                      *title,
-                                        const char                      *address,
-                                        nbgl_choiceCallback_t            callback,
-                                        const nbgl_layoutTagValueList_t *tagValueList)
+void nbgl_useCaseAddressConfirmationExt(const nbgl_icon_details_t        *icon,
+                                        const char                       *title,
+                                        const char                       *address,
+                                        nbgl_choiceCallback_t             callback,
+                                        const nbgl_contentTagValueList_t *tagValueList)
 {
     // memorize context
     memset(&context, 0, sizeof(UseCaseContext_t));
@@ -472,7 +472,7 @@ void nbgl_useCaseAddressConfirmationExt(const nbgl_icon_details_t       *icon,
     context.type                  = REVIEW_USE_CASE;
 
     if (tagValueList) {
-        memcpy(&context.review.tagValueList, tagValueList, sizeof(nbgl_layoutTagValueList_t));
+        memcpy(&context.review.tagValueList, tagValueList, sizeof(nbgl_contentTagValueList_t));
     }
 
     context.review.address     = address;

--- a/lib_ux_sync/include/ux_sync.h
+++ b/lib_ux_sync/include/ux_sync.h
@@ -18,25 +18,25 @@ ux_sync_ret_t ux_sync_homeAndSettings(const char                   *appName,
                                       const nbgl_contentInfoList_t *infosList,
                                       const nbgl_homeAction_t      *action);
 
-ux_sync_ret_t ux_sync_review(nbgl_operationType_t             operationType,
-                             const nbgl_layoutTagValueList_t *tagValueList,
-                             const nbgl_icon_details_t       *icon,
-                             const char                      *reviewTitle,
-                             const char                      *reviewSubTitle,
-                             const char                      *finishTitle);
+ux_sync_ret_t ux_sync_review(nbgl_operationType_t              operationType,
+                             const nbgl_contentTagValueList_t *tagValueList,
+                             const nbgl_icon_details_t        *icon,
+                             const char                       *reviewTitle,
+                             const char                       *reviewSubTitle,
+                             const char                       *finishTitle);
 
-ux_sync_ret_t ux_sync_reviewLight(nbgl_operationType_t             operationType,
-                                  const nbgl_layoutTagValueList_t *tagValueList,
-                                  const nbgl_icon_details_t       *icon,
-                                  const char                      *reviewTitle,
-                                  const char                      *reviewSubTitle,
-                                  const char                      *finishTitle);
+ux_sync_ret_t ux_sync_reviewLight(nbgl_operationType_t              operationType,
+                                  const nbgl_contentTagValueList_t *tagValueList,
+                                  const nbgl_icon_details_t        *icon,
+                                  const char                       *reviewTitle,
+                                  const char                       *reviewSubTitle,
+                                  const char                       *finishTitle);
 
-ux_sync_ret_t ux_sync_addressReview(const char                      *address,
-                                    const nbgl_layoutTagValueList_t *additionalTagValueList,
-                                    const nbgl_icon_details_t       *icon,
-                                    const char                      *reviewTitle,
-                                    const char                      *reviewSubTitle);
+ux_sync_ret_t ux_sync_addressReview(const char                       *address,
+                                    const nbgl_contentTagValueList_t *additionalTagValueList,
+                                    const nbgl_icon_details_t        *icon,
+                                    const char                       *reviewTitle,
+                                    const char                       *reviewSubTitle);
 
 ux_sync_ret_t ux_sync_reviewStatus(nbgl_reviewStatusType_t reviewStatusType);
 
@@ -47,7 +47,7 @@ ux_sync_ret_t ux_sync_reviewStreamingStart(nbgl_operationType_t       operationT
                                            const char                *reviewTitle,
                                            const char                *reviewSubTitle);
 
-ux_sync_ret_t ux_sync_reviewStreamingContinue(const nbgl_layoutTagValueList_t *tagValueList);
+ux_sync_ret_t ux_sync_reviewStreamingContinue(const nbgl_contentTagValueList_t *tagValueList);
 
 ux_sync_ret_t ux_sync_reviewStreamingFinish(const char *finishTitle);
 

--- a/lib_ux_sync/src/ux_sync.c
+++ b/lib_ux_sync/src/ux_sync.c
@@ -105,12 +105,12 @@ ux_sync_ret_t ux_sync_homeAndSettings(const char                   *appName,
  *         - UX_SYNC_RET_APPROVED
  *         - UX_SYNC_RET_REJECTED
  */
-ux_sync_ret_t ux_sync_review(nbgl_operationType_t             operationType,
-                             const nbgl_layoutTagValueList_t *tagValueList,
-                             const nbgl_icon_details_t       *icon,
-                             const char                      *reviewTitle,
-                             const char                      *reviewSubTitle,
-                             const char                      *finishTitle)
+ux_sync_ret_t ux_sync_review(nbgl_operationType_t              operationType,
+                             const nbgl_contentTagValueList_t *tagValueList,
+                             const nbgl_icon_details_t        *icon,
+                             const char                       *reviewTitle,
+                             const char                       *reviewSubTitle,
+                             const char                       *finishTitle)
 {
     ux_sync_init();
     nbgl_useCaseReview(operationType,
@@ -140,12 +140,12 @@ ux_sync_ret_t ux_sync_review(nbgl_operationType_t             operationType,
  *         - UX_SYNC_RET_APPROVED
  *         - UX_SYNC_RET_REJECTED
  */
-ux_sync_ret_t ux_sync_reviewLight(nbgl_operationType_t             operationType,
-                                  const nbgl_layoutTagValueList_t *tagValueList,
-                                  const nbgl_icon_details_t       *icon,
-                                  const char                      *reviewTitle,
-                                  const char                      *reviewSubTitle,
-                                  const char                      *finishTitle)
+ux_sync_ret_t ux_sync_reviewLight(nbgl_operationType_t              operationType,
+                                  const nbgl_contentTagValueList_t *tagValueList,
+                                  const nbgl_icon_details_t        *icon,
+                                  const char                       *reviewTitle,
+                                  const char                       *reviewSubTitle,
+                                  const char                       *finishTitle)
 {
     ux_sync_init();
     nbgl_useCaseReviewLight(operationType,
@@ -177,11 +177,11 @@ ux_sync_ret_t ux_sync_reviewLight(nbgl_operationType_t             operationType
  *         - UX_SYNC_RET_APPROVED
  *         - UX_SYNC_RET_REJECTED
  */
-ux_sync_ret_t ux_sync_addressReview(const char                      *address,
-                                    const nbgl_layoutTagValueList_t *additionalTagValueList,
-                                    const nbgl_icon_details_t       *icon,
-                                    const char                      *reviewTitle,
-                                    const char                      *reviewSubTitle)
+ux_sync_ret_t ux_sync_addressReview(const char                       *address,
+                                    const nbgl_contentTagValueList_t *additionalTagValueList,
+                                    const nbgl_icon_details_t        *icon,
+                                    const char                       *reviewTitle,
+                                    const char                       *reviewSubTitle)
 {
     ux_sync_init();
     nbgl_useCaseAddressReview(
@@ -258,7 +258,7 @@ ux_sync_ret_t ux_sync_reviewStreamingStart(nbgl_operationType_t       operationT
  *         - UX_SYNC_RET_APPROVED
  *         - UX_SYNC_RET_REJECTED
  */
-ux_sync_ret_t ux_sync_reviewStreamingContinue(const nbgl_layoutTagValueList_t *tagValueList)
+ux_sync_ret_t ux_sync_reviewStreamingContinue(const nbgl_contentTagValueList_t *tagValueList)
 
 {
     ux_sync_init();


### PR DESCRIPTION
## Description

nbgl_layoutTagValueList_t was already an alias of
nbgl_contentTagValueList_t. Now with choose to use this directly.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)
