### PR TITLE
Fix FWEO-1133 - APP SDK - Streamed transactions shouldn't have a back arrow navigation

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -104,10 +104,15 @@ typedef struct {
     uint8_t token;               ///< the token that will be used as argument of the callback
     uint8_t nbPages;             ///< number of pages. (if 0, no navigation)
     uint8_t activePage;          ///< index of active page (from 0 to nbPages-1).
-    bool    withExitKey;         ///< if set to true, an exit button is drawn
+    bool    withExitKey;         ///< if set to true, an exit button is drawn (X on the left)
     bool    withBackKey;         ///< if set to true, the "back" key is drawn
     bool    withSeparationLine;  ///< if set to true, an horizontal line is drawn on top of bar in
                                  ///< light gray
+    bool withPageIndicator;  ///< on Flex, a "page on nb_pages" text can be added between back and
+                             ///< forward keys
+    bool visibleIndicator;   ///< on Flex, the page indicator can be visible or not.
+                             ///< if withPageIndicator is true and this boolean false, the back key
+                             ///< is placed as if there was an indicator
 #ifdef HAVE_PIEZO_SOUND
     tune_index_e tuneId;  ///< if not @ref NBGL_NO_TUNE, a tune will be played when pressing keys)
 #endif                    // HAVE_PIEZO_SOUND

--- a/lib_nbgl/include/nbgl_page.h
+++ b/lib_nbgl/include/nbgl_page.h
@@ -106,10 +106,12 @@ typedef struct nbgl_pageNavWithTap_s {
  *
  */
 typedef struct nbgl_pageNavWithButtons_s {
-    bool    quitButton;  ///< if set to true, a quit button (X) is displayed in the nav bar
-    bool    backButton;  ///< if set to true, a back button (<-) is displayed in the nav bar
-    uint8_t navToken;    ///< the token used as argument of the actionCallback when the nav buttons
-                         ///< are pressed (index param gives the page)
+    bool quitButton;  ///< if set to true, a quit button (X) is displayed in the nav bar
+    bool backButton;  ///< if set to true, a back button (<-) is displayed in the nav bar
+    bool
+        visiblePageIndicator;  ///< if set to true, the page indicator will be visible in navigation
+    uint8_t navToken;  ///< the token used as argument of the actionCallback when the nav buttons
+                       ///< are pressed (index param gives the page)
     const char
         *quitText;  ///< the text displayed in footer (on the left), used to quit (only on Flex)
 } nbgl_pageNavWithButtons_t;

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -889,14 +889,15 @@ int nbgl_layoutAddTopRightButton(nbgl_layout_t             *layout,
 int nbgl_layoutAddNavigationBar(nbgl_layout_t *layout, const nbgl_layoutNavigationBar_t *info)
 {
     nbgl_layoutFooter_t footerDesc;
-    footerDesc.type                   = FOOTER_NAV;
-    footerDesc.separationLine         = info->withSeparationLine;
-    footerDesc.navigation.activePage  = info->activePage;
-    footerDesc.navigation.nbPages     = info->nbPages;
-    footerDesc.navigation.withExitKey = info->withExitKey;
-    footerDesc.navigation.withBackKey = info->withBackKey;
-    footerDesc.navigation.token       = info->token;
-    footerDesc.navigation.tuneId      = info->tuneId;
+    footerDesc.type                         = FOOTER_NAV;
+    footerDesc.separationLine               = info->withSeparationLine;
+    footerDesc.navigation.activePage        = info->activePage;
+    footerDesc.navigation.nbPages           = info->nbPages;
+    footerDesc.navigation.withExitKey       = info->withExitKey;
+    footerDesc.navigation.withBackKey       = info->withBackKey;
+    footerDesc.navigation.withPageIndicator = false;
+    footerDesc.navigation.token             = info->token;
+    footerDesc.navigation.tuneId            = info->tuneId;
     return nbgl_layoutAddExtendedFooter(layout, &footerDesc);
 }
 
@@ -2575,13 +2576,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
             navContainer->obj.alignment   = BOTTOM_RIGHT;
             navContainer->obj.area.width  = SCREEN_WIDTH - textArea->obj.area.width;
             navContainer->obj.area.height = SIMPLE_FOOTER_HEIGHT;
-            layoutNavigationPopulate(navContainer,
-                                     footerDesc->textAndNav.navigation.nbPages,
-                                     footerDesc->textAndNav.navigation.activePage,
-                                     footerDesc->textAndNav.navigation.withExitKey,
-                                     footerDesc->textAndNav.navigation.withBackKey,
-                                     true,
-                                     layoutInt->layer);
+            layoutNavigationPopulate(navContainer, &footerDesc->navigation, layoutInt->layer);
             obj = layoutAddCallbackObj(layoutInt,
                                        (nbgl_obj_t *) navContainer,
                                        footerDesc->textAndNav.navigation.token,
@@ -2615,13 +2610,8 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
             layoutInt->footerContainer->obj.area.width = SCREEN_WIDTH;
 #endif  // TARGET_STAX
             layoutInt->footerContainer->obj.area.height = SIMPLE_FOOTER_HEIGHT;
-            layoutNavigationPopulate(layoutInt->footerContainer,
-                                     footerDesc->navigation.nbPages,
-                                     footerDesc->navigation.activePage,
-                                     footerDesc->navigation.withExitKey,
-                                     footerDesc->navigation.withBackKey,
-                                     false,
-                                     layoutInt->layer);
+            layoutNavigationPopulate(
+                layoutInt->footerContainer, &footerDesc->navigation, layoutInt->layer);
             layoutInt->footerContainer->nbChildren = 4;
             obj                                    = layoutAddCallbackObj(layoutInt,
                                        (nbgl_obj_t *) layoutInt->footerContainer,

--- a/lib_nbgl/src/nbgl_layout_internal.h
+++ b/lib_nbgl/src/nbgl_layout_internal.h
@@ -92,13 +92,9 @@ layoutObj_t *layoutAddCallbackObj(nbgl_layoutInternal_t *layout,
                                   nbgl_obj_t            *obj,
                                   uint8_t                token,
                                   tune_index_e           tuneId);
-void         layoutNavigationPopulate(nbgl_container_t *navContainer,
-                                      uint8_t           nbPages,
-                                      uint8_t           activePage,
-                                      bool              withExitKey,
-                                      bool              withBackKey,
-                                      bool              withPageIndicator,
-                                      uint8_t           layer);
+void         layoutNavigationPopulate(nbgl_container_t                 *navContainer,
+                                      const nbgl_layoutNavigationBar_t *navConfig,
+                                      uint8_t                           layer);
 bool         layoutNavigationCallback(nbgl_obj_t      *obj,
                                       nbgl_touchType_t eventType,
                                       uint8_t          nbPages,

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -23,7 +23,11 @@
 /*********************
  *      DEFINES
  *********************/
+#ifdef TARGET_STAX
 #define NB_MAX_PAGES_WITH_DASHES 10
+#else  // TARGET_STAX
+#define NB_MAX_PAGES_WITH_DASHES 6
+#endif  // TARGET_STAX
 
 // max number of letters in TEXT_ENTRY
 #define NB_MAX_LETTERS 9
@@ -734,7 +738,11 @@ static void draw_pageIndicator(nbgl_page_indicator_t *obj,
 
     if (obj->nbPages <= NB_MAX_PAGES_WITH_DASHES) {
         int i;
+#ifdef TARGET_STAX
 #define INTER_DASHES 10  // pixels
+#else                    // TARGET_STAX
+#define INTER_DASHES 8   // pixels
+#endif                   // TARGET_STAX
         // force height
         obj->obj.area.height = 4;
 

--- a/lib_nbgl/src/nbgl_page.c
+++ b/lib_nbgl/src/nbgl_page.c
@@ -543,13 +543,14 @@ nbgl_page_t *nbgl_pageDrawGenericContentExt(nbgl_layoutTouchCallback_t       onA
             footerDesc.separationLine = true;
             if (nav->nbPages > 1) {
                 if (nav->navWithButtons.quitText == NULL) {
-                    footerDesc.type                   = FOOTER_NAV;
-                    footerDesc.navigation.activePage  = nav->activePage;
-                    footerDesc.navigation.nbPages     = nav->nbPages;
-                    footerDesc.navigation.withExitKey = nav->navWithButtons.quitButton;
-                    footerDesc.navigation.withBackKey = nav->navWithButtons.backButton;
-                    footerDesc.navigation.token       = nav->navWithButtons.navToken;
-                    footerDesc.navigation.tuneId      = nav->tuneId;
+                    footerDesc.type                         = FOOTER_NAV;
+                    footerDesc.navigation.activePage        = nav->activePage;
+                    footerDesc.navigation.nbPages           = nav->nbPages;
+                    footerDesc.navigation.withExitKey       = nav->navWithButtons.quitButton;
+                    footerDesc.navigation.withBackKey       = nav->navWithButtons.backButton;
+                    footerDesc.navigation.withPageIndicator = false;
+                    footerDesc.navigation.token             = nav->navWithButtons.navToken;
+                    footerDesc.navigation.tuneId            = nav->tuneId;
                 }
                 else {
                     footerDesc.type                              = FOOTER_TEXT_AND_NAV;
@@ -560,8 +561,11 @@ nbgl_page_t *nbgl_pageDrawGenericContentExt(nbgl_layoutTouchCallback_t       onA
                     footerDesc.textAndNav.navigation.nbPages     = nav->nbPages;
                     footerDesc.textAndNav.navigation.withExitKey = false;
                     footerDesc.textAndNav.navigation.withBackKey = nav->navWithButtons.backButton;
-                    footerDesc.textAndNav.navigation.token       = nav->navWithButtons.navToken;
-                    footerDesc.textAndNav.navigation.tuneId      = nav->tuneId;
+                    footerDesc.textAndNav.navigation.visibleIndicator
+                        = nav->navWithButtons.visiblePageIndicator;
+                    footerDesc.textAndNav.navigation.withPageIndicator = true;
+                    footerDesc.textAndNav.navigation.token  = nav->navWithButtons.navToken;
+                    footerDesc.textAndNav.navigation.tuneId = nav->tuneId;
                 }
             }
             else if (nav->navWithButtons.quitText != NULL) {


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledgerhq.atlassian.net/browse/FWEO-1133 by a better analysis of when to draw the back navigation key.
Moreover, in transactions this back navigation key shall be placed at the same place, when we display the page number or not.

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

