### PR TITLE
Flex: Fix HTA double segment issue

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -131,7 +131,11 @@ static uint8_t nbTouchableControls = 0;
 
 static inline uint8_t get_hold_to_approve_percent(uint32_t touch_duration)
 {
+#ifdef HAVE_DISPLAY_FAST_MODE
+    uint8_t current_step_nb = (touch_duration / HOLD_TO_APPROVE_STEP_DURATION_MS);
+#else
     uint8_t current_step_nb = (touch_duration / HOLD_TO_APPROVE_STEP_DURATION_MS) + 1;
+#endif
     return (current_step_nb * HOLD_TO_APPROVE_STEP_PERCENT);
 }
 


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/FWEO-1128

## Description

When fast mode is enabled, first "hold to approve" segments were displayed almost at the same time. One at touch, the other on the next ticker event.
This commit remove the first segment that is displayed at touch.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
