### PR TITLE
Makefiles: Extract Makefile.target from Makefile.defines

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #   Ledger SDK
-#   (c) 2017 Ledger
+#   (c) 2024 Ledger
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,34 +15,10 @@
 #  limitations under the License.
 #*******************************************************************************
 
-# TARGET should be set as an environment variable otherwise it will be read from a `.target`
-# file in the SDK root repository
-TARGETS := nanos nanox nanos2 stax flex
-ifeq ($(TARGET),)
-ifeq ("$(wildcard $(BOLOS_SDK)/.target)","")
-$(error No TARGET specified and no .target file in SDK repository $(BOLOS_SDK))
-else
-TARGET := $(shell cat $(BOLOS_SDK)/.target)
-endif
-endif
+ifeq ($(__MAKEFILE_DEFINES__),)
+__MAKEFILE_DEFINES__ := 1
 
-ifeq ($(filter $(TARGET),$(TARGETS)),)
-$(error TARGET not set to a valid value (possible values: $(TARGETS)))
-endif
-
-API_LEVEL   := 0
-TARGET_PATH := $(BOLOS_SDK)/target/$(TARGET)
-TARGET_ID   := $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ID | cut -f3 -d' ')
-TARGET_NAME := $(sort $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ | grep -v TARGET_ID | cut -f2 -d' '))
-SDK_NAME    := "ledger-secure-sdk"
-SDK_VERSION := $(shell git -C $(BOLOS_SDK) describe --tags --exact-match  --match "v[0-9]*" --dirty)
-SDK_HASH    := $(shell git -C $(BOLOS_SDK) describe --always --dirty --exclude '*' --abbrev=40)
-ifeq ($(SDK_VERSION),)
-SDK_VERSION := "None"
-endif
-ifeq ($(SDK_HASH),)
-SDK_HASH := "None"
-endif
+include $(BOLOS_SDK)/Makefile.target
 
 # APPNAME exposed to the app as a CFLAG because it might contain spaces
 CFLAGS += -DAPPNAME=\"$(APPNAME)\"
@@ -56,22 +32,11 @@ APP_METADATA_LIST := TARGET TARGET_NAME APPVERSION SDK_NAME SDK_VERSION SDK_HASH
 DEFINES += $(foreach item,$(APP_METADATA_LIST), $(item)=\"$($(item))\")
 
 
-BUILD_DIR := build
-TARGET_BUILD_DIR := $(BUILD_DIR)/$(TARGET)
-BIN_DIR := $(TARGET_BUILD_DIR)/bin
-OBJ_DIR := $(TARGET_BUILD_DIR)/obj
-DBG_DIR := $(TARGET_BUILD_DIR)/dbg
-DEP_DIR := $(TARGET_BUILD_DIR)/dep
-GEN_SRC_DIR := $(TARGET_BUILD_DIR)/gen_src
-
 ### platform definitions
 DEFINES += gcc __IO=volatile
 
 # no assert by default
 DEFINES += NDEBUG
-
-# Debug mode disabled by default
-DEBUG:=0
 
 # default is not to display make commands
 log = $(if $(strip $(VERBOSE)),$1,@$1) # kept for retrocompat
@@ -243,5 +208,4 @@ endif
 # include builtin CX libs options
 -include $(BOLOS_SDK)/Makefile.conf.cx
 
-# define the default makefile target (high in include to avoid glyph.h or what not specific target to be the default one when no target passed on the make command line)
-all: default
+endif

--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -15,6 +15,8 @@
 #  limitations under the License.
 #*******************************************************************************
 
+include $(BOLOS_SDK)/Makefile.target
+
 #####################################################################
 #                            BLUETOOTH                              #
 #####################################################################
@@ -211,6 +213,8 @@ endif
 ifeq ($(TARGET_NAME), TARGET_FLEX)
 ICONNAME ?= $(ICON_FLEX)
 endif
+
+include $(BOLOS_SDK)/Makefile.defines
 
 include $(BOLOS_SDK)/Makefile.glyphs
 

--- a/Makefile.target
+++ b/Makefile.target
@@ -1,0 +1,64 @@
+#*******************************************************************************
+#   Ledger SDK
+#   (c) 2024 Ledger
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#*******************************************************************************
+
+ifeq ($(__MAKEFILE_TARGET__),)
+__MAKEFILE_TARGET__ := 1
+
+# TARGET should be set as an environment variable otherwise it will be read from a `.target`
+# file in the SDK root repository
+TARGETS := nanos nanox nanos2 stax flex
+ifeq ($(TARGET),)
+ifeq ("$(wildcard $(BOLOS_SDK)/.target)","")
+$(error No TARGET specified and no .target file in SDK repository $(BOLOS_SDK))
+else
+TARGET := $(shell cat $(BOLOS_SDK)/.target)
+endif
+endif
+
+ifeq ($(filter $(TARGET),$(TARGETS)),)
+$(error TARGET not set to a valid value (possible values: $(TARGETS)))
+endif
+
+API_LEVEL   := 0
+TARGET_PATH := $(BOLOS_SDK)/target/$(TARGET)
+TARGET_ID   := $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ID | cut -f3 -d' ')
+TARGET_NAME := $(sort $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ | grep -v TARGET_ID | cut -f2 -d' '))
+SDK_NAME    := "ledger-secure-sdk"
+SDK_VERSION := $(shell git -C $(BOLOS_SDK) describe --tags --exact-match  --match "v[0-9]*" --dirty)
+SDK_HASH    := $(shell git -C $(BOLOS_SDK) describe --always --dirty --exclude '*' --abbrev=40)
+ifeq ($(SDK_VERSION),)
+SDK_VERSION := "None"
+endif
+ifeq ($(SDK_HASH),)
+SDK_HASH := "None"
+endif
+
+BUILD_DIR := build
+TARGET_BUILD_DIR := $(BUILD_DIR)/$(TARGET)
+BIN_DIR := $(TARGET_BUILD_DIR)/bin
+OBJ_DIR := $(TARGET_BUILD_DIR)/obj
+DBG_DIR := $(TARGET_BUILD_DIR)/dbg
+DEP_DIR := $(TARGET_BUILD_DIR)/dep
+GEN_SRC_DIR := $(TARGET_BUILD_DIR)/gen_src
+
+# Debug mode disabled by default
+DEBUG:=0
+
+# define the default makefile target (high in include to avoid glyph.h or what not specific target to be the default one when no target passed on the make command line)
+all: default
+
+endif


### PR DESCRIPTION
## Description

Makefiles: Extract Makefile.target from Makefile.defines
This allow to include `Makefile.target` at the top of your app `Makefile`, then to define some app configuration that can depends on the target and eventually include the `Makefile.standard_app` which deals with including `Makefile.defines`.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
