### PR TITLE
Improve CX_CHECK

### DIFF
--- a/include/cx_errors.h
+++ b/include/cx_errors.h
@@ -12,12 +12,13 @@
  * Checks the error code of a function.
  * @hideinitializer
  */
-#define CX_CHECK(call) \
-    do {               \
-        error = call;  \
-        if (error) {   \
-            goto end;  \
-        }              \
+#define CX_CHECK(call)                                           \
+    do {                                                         \
+        error = call;                                            \
+        if (error) {                                             \
+            PRINTF("[CX_CHECK] - %s: %d\n", __FILE__, __LINE__); \
+            goto end;                                            \
+        }                                                        \
     } while (0)
 
 /**


### PR DESCRIPTION
Add `PRINTF` inside `CX_CHECK` to ease debug, and find the file/line of the error
