### PR TITLE
Makefiles: Fix API_LEVEL location

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -20,6 +20,8 @@ __MAKEFILE_DEFINES__ := 1
 
 include $(BOLOS_SDK)/Makefile.target
 
+API_LEVEL := 0
+
 # APPNAME exposed to the app as a CFLAG because it might contain spaces
 CFLAGS += -DAPPNAME=\"$(APPNAME)\"
 

--- a/Makefile.target
+++ b/Makefile.target
@@ -33,7 +33,6 @@ ifeq ($(filter $(TARGET),$(TARGETS)),)
 $(error TARGET not set to a valid value (possible values: $(TARGETS)))
 endif
 
-API_LEVEL   := 0
 TARGET_PATH := $(BOLOS_SDK)/target/$(TARGET)
 TARGET_ID   := $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ID | cut -f3 -d' ')
 TARGET_NAME := $(sort $(shell cat $(TARGET_PATH)/include/bolos_target.h | grep TARGET_ | grep -v TARGET_ID | cut -f2 -d' '))


### PR DESCRIPTION
## Description

Makefiles: Fix API_LEVEL location
Some scripts expect it to be in Makefile.defines and we don't need it in Makefile.target. So keep it in the first place.

Fix a pseudo regression introduced by https://github.com/LedgerHQ/ledger-secure-sdk/pull/637

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
