### PR TITLE
Add a function to add input data to AES-CMAC

### DIFF
--- a/include/cx_stubs.h
+++ b/include/cx_stubs.h
@@ -141,3 +141,7 @@
 #define _NR_cx_eddsa_verify_init_hash            0x89
 #define _NR_cx_eddsa_verify_hash                 0x8a
 #define _NR_cx_aes_siv_update_mac                0x8b
+#define _NR_cx_cipher_reset                      0x8c
+#define _NR_cx_cmac_start                        0x8d
+#define _NR_cx_cmac_update                       0x8e
+#define _NR_cx_cmac_finish                       0x8f

--- a/include/cx_stubs.h
+++ b/include/cx_stubs.h
@@ -140,3 +140,4 @@
 #define _NR_cx_eddsa_update_hash                 0x88
 #define _NR_cx_eddsa_verify_init_hash            0x89
 #define _NR_cx_eddsa_verify_hash                 0x8a
+#define _NR_cx_aes_siv_update_mac                0x8b

--- a/lib_cxng/cx.export
+++ b/lib_cxng/cx.export
@@ -144,3 +144,7 @@ cx_eddsa_update_hash
 cx_eddsa_verify_init_hash
 cx_eddsa_verify_hash
 cx_aes_siv_update_mac
+cx_cipher_reset
+cx_cmac_start
+cx_cmac_update
+cx_cmac_finish

--- a/lib_cxng/cx.export
+++ b/lib_cxng/cx.export
@@ -143,3 +143,4 @@ cx_eddsa_sign_hash
 cx_eddsa_update_hash
 cx_eddsa_verify_init_hash
 cx_eddsa_verify_hash
+cx_aes_siv_update_mac

--- a/lib_cxng/include/lcx_aes_siv.h
+++ b/lib_cxng/include/lcx_aes_siv.h
@@ -104,6 +104,8 @@ WARN_UNUSED_RESULT cx_err_t cx_aes_siv_update_aad(cx_aes_siv_context_t *ctx,
                                                   const uint8_t        *aad,
                                                   size_t                aad_len);
 
+cx_err_t cx_aes_siv_update_mac(cx_aes_siv_context_t *ctx, const uint8_t *input, size_t in_len);
+
 /**
  * @brief Processes plaintext or ciphertext with AES-CTR.
  *

--- a/lib_cxng/src/cx_exported_functions.c
+++ b/lib_cxng/src/cx_exported_functions.c
@@ -165,4 +165,8 @@ unsigned long __attribute((section("._cx_exported_functions"))) cx_exported_func
     [_NR_cx_eddsa_verify_init_hash]       = (unsigned long) cx_eddsa_verify_init_hash,
     [_NR_cx_eddsa_verify_hash]            = (unsigned long) cx_eddsa_verify_hash,
     [_NR_cx_aes_siv_update_mac]           = (unsigned long) cx_aes_siv_update_mac,
+    [_NR_cx_cipher_reset]                 = (unsigned long) cx_cipher_reset,
+    [_NR_cx_cmac_start]                   = (unsigned long) cx_cmac_start,
+    [_NR_cx_cmac_update]                  = (unsigned long) cx_cmac_update,
+    [_NR_cx_cmac_finish]                  = (unsigned long) cx_cmac_finish,
 };

--- a/lib_cxng/src/cx_exported_functions.c
+++ b/lib_cxng/src/cx_exported_functions.c
@@ -164,4 +164,5 @@ unsigned long __attribute((section("._cx_exported_functions"))) cx_exported_func
     [_NR_cx_eddsa_update_hash]            = (unsigned long) cx_eddsa_update_hash,
     [_NR_cx_eddsa_verify_init_hash]       = (unsigned long) cx_eddsa_verify_init_hash,
     [_NR_cx_eddsa_verify_hash]            = (unsigned long) cx_eddsa_verify_hash,
+    [_NR_cx_aes_siv_update_mac]           = (unsigned long) cx_aes_siv_update_mac,
 };

--- a/src/cx_stubs.S
+++ b/src/cx_stubs.S
@@ -156,6 +156,10 @@ CX_TRAMPOLINE _NR_cx_eddsa_update_hash                     cx_eddsa_update_hash
 CX_TRAMPOLINE _NR_cx_eddsa_verify_init_hash                cx_eddsa_verify_init_hash
 CX_TRAMPOLINE _NR_cx_eddsa_verify_hash                     cx_eddsa_verify_hash
 CX_TRAMPOLINE _NR_cx_aes_siv_update_mac                    cx_aes_siv_update_mac
+CX_TRAMPOLINE _NR_cx_cipher_reset                          cx_cipher_reset
+CX_TRAMPOLINE _NR_cx_cmac_start                            cx_cmac_start
+CX_TRAMPOLINE _NR_cx_cmac_update                           cx_cmac_update
+CX_TRAMPOLINE _NR_cx_cmac_finish                           cx_cmac_finish
 
 .thumb_func
 cx_trampoline_helper:

--- a/src/cx_stubs.S
+++ b/src/cx_stubs.S
@@ -155,6 +155,7 @@ CX_TRAMPOLINE _NR_cx_eddsa_sign_hash                       cx_eddsa_sign_hash
 CX_TRAMPOLINE _NR_cx_eddsa_update_hash                     cx_eddsa_update_hash
 CX_TRAMPOLINE _NR_cx_eddsa_verify_init_hash                cx_eddsa_verify_init_hash
 CX_TRAMPOLINE _NR_cx_eddsa_verify_hash                     cx_eddsa_verify_hash
+CX_TRAMPOLINE _NR_cx_aes_siv_update_mac                    cx_aes_siv_update_mac
 
 .thumb_func
 cx_trampoline_helper:


### PR DESCRIPTION
## Description

This PR allows to update the AES-CMAC context with a block of the plaintext for AES-SIV encryption/decryption.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)


