### PR TITLE
Update the maximum number of infos for Flex

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -204,7 +204,7 @@ static const uint8_t nbMaxElementsPerContentType[] = {
     1,  // TAG_VALUE_DETAILS
     1,  // TAG_VALUE_CONFIRM
     2,  // SWITCHES_LIST
-    3,  // INFOS_LIST
+    2,  // INFOS_LIST
     4,  // CHOICES_LIST
     4,  // BARS_LIST
 #endif  // TARGET_STAX


### PR DESCRIPTION
## Description

Update the maximum number of infos for Flex in order to fit in one screen (max 2 instead of 3)
Flex device only.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)



