### PR TITLE
CI: Drop nanos tests

### DIFF
--- a/.github/workflows/build_all_apps.yml
+++ b/.github/workflows/build_all_apps.yml
@@ -117,12 +117,6 @@ jobs:
           path: sdk
           ref: ${{ inputs.sdk_branch }}
 
-      - name: Build NanoS
-        if: "startsWith(matrix.repo_info.devices, 'nanos,')"
-        run: |
-          [ -n '${{ matrix.repo_info.build_directory }}' ] && cd ${{ matrix.repo_info.build_directory }}
-          TARGET=nanos BOLOS_SDK=$GITHUB_WORKSPACE/sdk make
-
       - name: Build NanoX
         if: "contains(matrix.repo_info.devices, 'nanox')"
         run: |

--- a/.github/workflows/check_clang_static_analyzer.yml
+++ b/.github/workflows/check_clang_static_analyzer.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [nanos, nanox, nanos2, stax, flex]
+        target: [nanox, nanos2, stax, flex]
         debug: [0, 1]
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Description

CI: Drop nanos tests

There won't be any new Os release of LNS that would use the master SDK branch.
Hence there is no reason to keep it fully supported and tested on all apps.
We should rather tests the app build using the LNS SDK branch

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
