### PR TITLE
Clean-up unused string ids propagation for screenshots generation

### DIFF
--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -58,15 +58,8 @@ typedef struct {
     const char *text1;  ///< first text (can be null)
     const char *text2;  ///< second text (can be null)
 #ifdef HAVE_SE_TOUCH
-    const char *text3;  ///< third text (can be null)
-#endif                  // HAVE_SE_TOUCH
-#ifdef BUILD_SCREENSHOTS
-    uint16_t textId1;  ///< first text ID (can be 0)
-    uint16_t textId2;  ///< second text ID (can be 0)
-#ifdef HAVE_SE_TOUCH
-    uint16_t textId3;                       ///< third text ID (can be 0)
+    const char *text3;                      ///< third text (can be null)
 #endif                                      // HAVE_SE_TOUCH
-#endif                                      // BUILD_SCREENSHOTS
     const nbgl_icon_details_t      *icon;   ///< a buffer containing the 1BPP icon
     bool                            onTop;  ///< if set to true, align only horizontally
     nbgl_contentCenteredInfoStyle_t style;  ///< style to apply to this info

--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -220,12 +220,9 @@ typedef const char *(*nbgl_menuListCallback_t)(uint8_t choiceIndex);
  * a description (names array)
  */
 typedef struct {
-    nbgl_menuListCallback_t callback;  ///< function to call to retrieve a menu list item text
-#ifdef BUILD_SCREENSHOTS
-    const uint16_t (*getStringID)(uint8_t choiceIndex);  ///< return the string ID of choice
-#endif                                                   // BUILD_SCREENSHOTS
-    uint8_t nbChoices;       ///< total number of choices in the menu list
-    uint8_t selectedChoice;  ///< index of the selected choice (centered, in bold)
+    nbgl_menuListCallback_t callback;        ///< function to call to retrieve a menu list item text
+    uint8_t                 nbChoices;       ///< total number of choices in the menu list
+    uint8_t                 selectedChoice;  ///< index of the selected choice (centered, in bold)
 
 } nbgl_layoutMenuList_t;
 
@@ -666,15 +663,12 @@ int            nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
                                               uint8_t        nbActiveDigits,
                                               const char    *text);
 
-#else  // HAVE_SE_TOUCH
+#else   // HAVE_SE_TOUCH
 /* layout objects for pages with keypad (nanos) */
-int nbgl_layoutAddKeypad(nbgl_layout_t       *layout,
-                         keyboardCallback_t   callback,
-                         const char          *text,
-#ifdef BUILD_SCREENSHOTS
-                         UX_LOC_STRINGS_INDEX textId,
-#endif  // BUILD_SCREENSHOTS
-                         bool                 shuffled);
+int nbgl_layoutAddKeypad(nbgl_layout_t     *layout,
+                         keyboardCallback_t callback,
+                         const char        *text,
+                         bool               shuffled);
 int nbgl_layoutUpdateKeypad(nbgl_layout_t *layout,
                             uint8_t        index,
                             bool           enableValidate,

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -391,7 +391,7 @@ typedef struct PACKED__ nbgl_button_s {
     nbgl_font_id_e fontId;       ///< id of the font to use, if any
     bool        localized;  ///< if set to true, means the following 'text' field is considered as a
     const char *text;       ///< single line UTF-8 text (NULL terminated)
-#if (defined(HAVE_LANGUAGE_PACK) || defined(BUILD_SCREENSHOTS))
+#ifdef HAVE_LANGUAGE_PACK
     UX_LOC_STRINGS_INDEX textId;          ///< id of the text single line UTF-8 text
 #endif                                    // HAVE_LANGUAGE_PACK
     onTextDrawCallback_t onDrawCallback;  ///< function called if not NULL, with above token as
@@ -418,7 +418,7 @@ typedef struct PACKED__ nbgl_text_area_s {
                          ///< stop display here
     const char *text;    ///< ASCII text to draw (NULL terminated). Can be NULL.
     uint16_t    len;     ///< number of bytes to write (if 0, max number of chars or strlen is used)
-#if (defined(HAVE_LANGUAGE_PACK) || defined(BUILD_SCREENSHOTS))
+#ifdef HAVE_LANGUAGE_PACK
     UX_LOC_STRINGS_INDEX textId;  ///< id of the  UTF-8 text
 #endif                            // HAVE_LANGUAGE_PACK
     onTextDrawCallback_t

--- a/lib_nbgl/include/nbgl_step.h
+++ b/lib_nbgl/include/nbgl_step.h
@@ -88,14 +88,10 @@ typedef uint8_t nbgl_stepPosition_t;
 nbgl_step_t nbgl_stepDrawText(nbgl_stepPosition_t               pos,
                               nbgl_stepButtonCallback_t         onActionCallback,
                               nbgl_screenTickerConfiguration_t *ticker,
-#ifdef BUILD_SCREENSHOTS
-                              uint16_t txtId,
-                              uint16_t subTxtId,
-#endif  // BUILD_SCREENSHOTS
-                              const char                     *text,
-                              const char                     *subText,
-                              nbgl_contentCenteredInfoStyle_t style,
-                              bool                            modal);
+                              const char                       *text,
+                              const char                       *subText,
+                              nbgl_contentCenteredInfoStyle_t   style,
+                              bool                              modal);
 nbgl_step_t nbgl_stepDrawCenteredInfo(nbgl_stepPosition_t               pos,
                                       nbgl_stepButtonCallback_t         onActionCallback,
                                       nbgl_screenTickerConfiguration_t *ticker,

--- a/lib_nbgl/src/nbgl_flow.c
+++ b/lib_nbgl/src/nbgl_flow.c
@@ -98,12 +98,8 @@ static void drawStep(FlowContext_t             *ctx,
                      nbgl_stepPosition_t        pos,
                      bool                       modal,
                      const nbgl_icon_details_t *icon,
-#ifdef BUILD_SCREENSHOTS
-                     uint16_t txtId,
-                     uint16_t subTxtId,
-#endif  // BUILD_SCREENSHOTS
-                     const char *txt,
-                     const char *subTxt)
+                     const char                *txt,
+                     const char                *subTxt)
 {
     nbgl_layoutCenteredInfo_t info;
     if ((ctx->loop) && (ctx->nbSteps > 1)) {
@@ -114,26 +110,13 @@ static void drawStep(FlowContext_t             *ctx,
     }
 
     if (icon == NULL) {
-        ctx->stepCtx = nbgl_stepDrawText(pos,
-                                         actionCallback,
-                                         NULL,
-#ifdef BUILD_SCREENSHOTS
-                                         txtId,
-                                         subTxtId,
-#endif  // BUILD_SCREENSHOTS
-                                         txt,
-                                         subTxt,
-                                         REGULAR_INFO,
-                                         modal);
+        ctx->stepCtx
+            = nbgl_stepDrawText(pos, actionCallback, NULL, txt, subTxt, REGULAR_INFO, modal);
     }
     else {
-        info.icon  = icon;
-        info.text1 = txt;
-        info.text2 = subTxt;
-#ifdef BUILD_SCREENSHOTS
-        info.textId1 = txtId;
-        info.textId2 = subTxtId;
-#endif  // BUILD_SCREENSHOTS
+        info.icon    = icon;
+        info.text1   = txt;
+        info.text2   = subTxt;
         info.onTop   = false;
         info.style   = REGULAR_INFO;
         ctx->stepCtx = nbgl_stepDrawCenteredInfo(pos, actionCallback, NULL, &info, modal);
@@ -184,16 +167,7 @@ static void actionCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
     if (step->init != NULL) {
         step->init();
     }
-    drawStep(ctx,
-             pos,
-             ctx->modal,
-             step->icon,
-#ifdef BUILD_SCREENSHOTS
-             step->textId,
-             step->subTextId,
-#endif  // BUILD_SCREENSHOTS
-             txt,
-             step->subText);
+    drawStep(ctx, pos, ctx->modal, step->icon, txt, step->subText);
     nbgl_refresh();
 }
 
@@ -240,16 +214,7 @@ nbgl_flow_t nbgl_flowDraw(const nbgl_stepDesc_t *steps,
         step->init();
     }
 
-    drawStep(ctx,
-             pos,
-             ctx->modal,
-             step->icon,
-#ifdef BUILD_SCREENSHOTS
-             step->textId,
-             step->subTextId,
-#endif  // BUILD_SCREENSHOTS
-             txt,
-             step->subText);
+    drawStep(ctx, pos, ctx->modal, step->icon, txt, step->subText);
     nbgl_refresh();
     return (nbgl_flow_t) ctx;
 }

--- a/lib_nbgl/src/nbgl_fonts.c
+++ b/lib_nbgl/src/nbgl_fonts.c
@@ -97,6 +97,7 @@ const unsigned int C_unicode_characters_count
 uint16_t last_nb_lines   = 0;
 uint16_t last_nb_pages   = 0;
 bool     last_bold_state = false;
+void     store_string_infos(char *text, uint16_t nb_lines, uint16_t nb_pages, bool bold);
 #endif  // BUILD_SCREENSHOTS
 
 /**********************

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1212,9 +1212,9 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
         // init text area for this choice
         if (choices->localized == true) {
             textArea->localized = true;
-#if (defined(HAVE_LANGUAGE_PACK) || defined(BUILD_SCREENSHOTS))
+#ifdef HAVE_LANGUAGE_PACK
             textArea->textId = choices->nameIds[i];
-#endif  //(defined(HAVE_LANGUAGE_PACK)||defined(BUILD_SCREENSHOTS))
+#endif  // HAVE_LANGUAGE_PACK
         }
         else {
             textArea->text = PIC(choices->names[i]);
@@ -1303,12 +1303,9 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
         }
     }
     if (info->text1 != NULL) {
-        textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-        textArea->textColor = BLACK;
-        textArea->text      = PIC(info->text1);
-#ifdef BUILD_SCREENSHOTS
-        textArea->textId = PIC(info->textId1);
-#endif  // BUILD_SCREENSHOTS
+        textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor     = BLACK;
+        textArea->text          = PIC(info->text1);
         textArea->textAlignment = CENTER;
         if (info->style != NORMAL_INFO) {
             textArea->fontId = LARGE_MEDIUM_FONT;
@@ -1342,12 +1339,9 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
         container->nbChildren++;
     }
     if (info->text2 != NULL) {
-        textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-        textArea->textColor = (info->style == NORMAL_INFO) ? DARK_GRAY : BLACK;
-        textArea->text      = PIC(info->text2);
-#ifdef BUILD_SCREENSHOTS
-        textArea->textId = PIC(info->textId2);
-#endif  // BUILD_SCREENSHOTS
+        textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor     = (info->style == NORMAL_INFO) ? DARK_GRAY : BLACK;
+        textArea->text          = PIC(info->text2);
         textArea->textAlignment = CENTER;
         textArea->fontId
             = (info->style != LARGE_CASE_BOLD_INFO) ? SMALL_REGULAR_FONT : SMALL_BOLD_FONT;
@@ -1409,15 +1403,12 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
         }
     }
     if (info->text3 != NULL) {
-        textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-        textArea->textColor = (info->style == LARGE_CASE_GRAY_INFO) ? DARK_GRAY : BLACK;
-        textArea->text      = PIC(info->text3);
-#ifdef BUILD_SCREENSHOTS
-        textArea->textId = PIC(info->textId3);
-#endif  // BUILD_SCREENSHOTS
-        textArea->textAlignment   = CENTER;
-        textArea->fontId          = SMALL_REGULAR_FONT;
-        textArea->wrapping        = true;
+        textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor     = (info->style == LARGE_CASE_GRAY_INFO) ? DARK_GRAY : BLACK;
+        textArea->text          = PIC(info->text3);
+        textArea->textAlignment = CENTER;
+        textArea->fontId        = SMALL_REGULAR_FONT;
+        textArea->wrapping      = true;
         textArea->obj.area.width  = AVAILABLE_WIDTH;
         textArea->obj.area.height = nbgl_getTextHeightInWidth(
             textArea->fontId, textArea->text, textArea->obj.area.width, textArea->wrapping);

--- a/lib_nbgl/src/nbgl_layout_keypad_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_keypad_nanos.c
@@ -41,10 +41,6 @@
  *  PROTOTYPES
  **********************/
 
-#ifdef BUILD_SCREENSHOTS
-extern const char *get_ux_loc_string(uint32_t index);
-#endif  // BUILD_SCREENSHOTS
-
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
@@ -64,10 +60,7 @@ extern const char *get_ux_loc_string(uint32_t index);
 int nbgl_layoutAddKeypad(nbgl_layout_t     *layout,
                          keyboardCallback_t callback,
                          const char        *text,
-#ifdef BUILD_SCREENSHOTS
-                         UX_LOC_STRINGS_INDEX textId,
-#endif  // BUILD_SCREENSHOTS
-                         bool shuffled)
+                         bool               shuffled)
 {
     nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
     nbgl_keypad_t         *keypad;
@@ -78,18 +71,15 @@ int nbgl_layoutAddKeypad(nbgl_layout_t     *layout,
         return -1;
     }
 
-    textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-    textArea->textColor = WHITE;
-    textArea->text      = PIC(text);
-#ifdef BUILD_SCREENSHOTS
-    textArea->textId = textId;
-#endif  // BUILD_SCREENSHOTS
-    textArea->textAlignment        = CENTER;
-    textArea->fontId               = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
-    textArea->obj.area.width       = AVAILABLE_WIDTH;
-    textArea->obj.area.height      = 12;
-    textArea->wrapping             = false;
-    textArea->obj.alignment        = TOP_MIDDLE;
+    textArea                  = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+    textArea->textColor       = WHITE;
+    textArea->text            = PIC(text);
+    textArea->textAlignment   = CENTER;
+    textArea->fontId          = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
+    textArea->obj.area.width  = AVAILABLE_WIDTH;
+    textArea->obj.area.height = 12;
+    textArea->wrapping        = false;
+    textArea->obj.alignment   = TOP_MIDDLE;
     textArea->obj.alignmentMarginY = 3;
     // set this new obj as child of main container
     layoutAddObject(layoutInt, (nbgl_obj_t *) textArea);

--- a/lib_nbgl/src/nbgl_layout_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_nanos.c
@@ -331,15 +331,7 @@ int nbgl_layoutAddMenuList(nbgl_layout_t *layout, nbgl_layoutMenuList_t *list)
         textArea = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
 
         // init text area for this choice
-        textArea->text = list->callback(i);
-#ifdef BUILD_SCREENSHOTS
-        if (list->getStringID) {
-            textArea->textId = list->getStringID(i);
-        }
-        else {
-            textArea->textId = 0xFFFF;
-        }
-#endif  // BUILD_SCREENSHOTS
+        textArea->text                 = list->callback(i);
         textArea->textAlignment        = CENTER;
         textArea->obj.area.width       = AVAILABLE_WIDTH;
         textArea->obj.area.height      = 12;
@@ -402,12 +394,9 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
         container->nbChildren++;
     }
     if (info->text1 != NULL) {
-        textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-        textArea->textColor = WHITE;
-        textArea->text      = PIC(info->text1);
-#ifdef BUILD_SCREENSHOTS
-        textArea->textId = PIC(info->textId1);
-#endif  // BUILD_SCREENSHOTS
+        textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor     = WHITE;
+        textArea->text          = PIC(info->text1);
         textArea->textAlignment = CENTER;
         textArea->fontId = (info->style == REGULAR_INFO) ? BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp
                                                          : BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
@@ -415,16 +404,6 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
         textArea->wrapping       = true;
         uint16_t nbLines
             = nbgl_getTextNbLinesInWidth(textArea->fontId, textArea->text, AVAILABLE_WIDTH, true);
-#ifdef BUILD_SCREENSHOTS
-        /*
-        store_string_infos(textArea->textId, textArea->text, last_nb_lines, (last_nb_lines + 3)/4,
-        last_bold_state); fprintf(stdout, "Calling store_string_infos from
-        nbgl_layoutAddCenteredInfo, text1 =>%s<= (id=%d), nb_lines=%d\n",
-                get_printable_string(textArea->text),
-                textArea->textId,
-                last_nb_lines);
-        */
-#endif  // BUILD_SCREENSHOTS
         // if more than available lines on screen
         if (nbLines > NB_MAX_LINES) {
             uint16_t len;
@@ -457,27 +436,14 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
         container->nbChildren++;
     }
     if (info->text2 != NULL) {
-        textArea            = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
-        textArea->textColor = WHITE;
-        textArea->text      = PIC(info->text2);
-#ifdef BUILD_SCREENSHOTS
-        textArea->textId = PIC(info->textId2);
-#endif  // BUILD_SCREENSHOTS
-        textArea->textAlignment  = CENTER;
-        textArea->fontId         = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
+        textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+        textArea->textColor     = WHITE;
+        textArea->text          = PIC(info->text2);
+        textArea->textAlignment = CENTER;
+        textArea->fontId        = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
         textArea->obj.area.width = AVAILABLE_WIDTH;
         uint16_t nbLines
             = nbgl_getTextNbLinesInWidth(textArea->fontId, textArea->text, AVAILABLE_WIDTH, true);
-#ifdef BUILD_SCREENSHOTS
-        /*
-        store_string_infos(textArea->textId, textArea->text, last_nb_lines, (last_nb_lines + 3)/4,
-        last_bold_state); fprintf(stdout, "Calling store_string_infos from
-        nbgl_layoutAddCenteredInfo, text2 =>%s<= (id=%d), nb_lines=%d\n",
-                get_printable_string(textArea->text),
-                textArea->textId,
-                last_nb_lines);
-        */
-#endif  // BUILD_SCREENSHOTS
         // if more than available lines on screen
         if (nbLines > (NB_MAX_LINES - 1)) {
             uint16_t len;

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -75,11 +75,7 @@ extern const char *get_ux_loc_string(uint32_t index);
 
 #ifdef BUILD_SCREENSHOTS
 char *get_printable_string(char *string);
-void  store_string_infos(uint16_t string_id,
-                         char    *text,
-                         uint16_t nb_lines,
-                         uint16_t nb_pages,
-                         bool     bold);
+void  store_string_infos(char *text, uint16_t nb_lines, uint16_t nb_pages, bool bold);
 #endif  // BUILD_SCREENSHOTS
 
 /**********************
@@ -380,10 +376,6 @@ static void draw_button(nbgl_button_t *obj, nbgl_obj_t *prevObj, bool computePos
     // get the text of the button from the callback if not NULL
     if (obj->onDrawCallback != NULL) {
         obj->text = obj->onDrawCallback(obj->token);
-#ifdef BUILD_SCREENSHOTS
-        // Store  the last string index used
-        obj->textId = last_string_id;
-#endif  // BUILD_SCREENSHOTS
     }
     else {
         if (obj->localized == true) {
@@ -404,18 +396,6 @@ static void draw_button(nbgl_button_t *obj, nbgl_obj_t *prevObj, bool computePos
         else {
             rectArea.x0 = obj->obj.area.x0 + (obj->obj.area.width - textWidth) / 2;
         }
-#ifdef BUILD_SCREENSHOTS
-        store_string_infos(
-            obj->textId, text, last_nb_lines, (last_nb_lines + 3) / 4, last_bold_state);
-        if (verbose) {
-            fprintf(stdout,
-                    "Inside draw_button(), text =>%s<= (id=%d), textWidth=%d, nb_lines=%d\n",
-                    get_printable_string(text),
-                    obj->textId,
-                    textWidth,
-                    last_nb_lines);
-        }
-#endif  // BUILD_SCREENSHOTS
         LOG_DEBUG(OBJ_LOGGER, "draw_button(), text = %s\n", text);
         rectArea.y0
             = obj->obj.area.y0 + (obj->obj.area.height - nbgl_getFontHeight(obj->fontId)) / 2;
@@ -880,10 +860,6 @@ static void draw_textArea(nbgl_text_area_t *obj, nbgl_obj_t *prevObj, bool compu
     // get the text of the button from the callback if not NULL
     if (obj->onDrawCallback != NULL) {
         obj->text = obj->onDrawCallback(obj->token);
-#ifdef BUILD_SCREENSHOTS
-        // Store  the last string index used
-        obj->textId = last_string_id;
-#endif  // BUILD_SCREENSHOTS
     }
     else {
         if (obj->localized == true) {
@@ -891,38 +867,11 @@ static void draw_textArea(nbgl_text_area_t *obj, nbgl_obj_t *prevObj, bool compu
             obj->text = get_ux_loc_string(obj->textId);
 #endif  // HAVE_LANGUAGE_PACK
         }
-#ifdef BUILD_SCREENSHOTS
-        else {
-            if (!obj->textId) {
-                // Store  the last string index used
-                obj->textId = last_string_id;
-            }
-        }
-#endif  // BUILD_SCREENSHOTS
     }
     text = obj->text;
     if (text == NULL) {
         return;
     }
-
-#ifdef BUILD_SCREENSHOTS
-    if (verbose) {
-        fprintf(stdout,
-                "Inside draw_textArea(), wrapping=%d, autoHideLongLine = %d, nbMaxLines = %d, "
-                "nb_lines=%d, x0=%d, y0=%d, width=%d, height=%d,\ntext =>%s<= "
-                "(ID=%d)\n",
-                obj->wrapping,
-                obj->autoHideLongLine,
-                obj->nbMaxLines,
-                nbgl_getTextNbLinesInWidth(fontId, text, obj->obj.area.width, obj->wrapping),
-                obj->obj.area.x0,
-                obj->obj.area.y0,
-                obj->obj.area.width,
-                obj->obj.area.height,
-                get_printable_string(text),
-                obj->textId);
-    }
-#endif  // BUILD_SCREENSHOTS
 
     LOG_DEBUG(
         OBJ_LOGGER,
@@ -971,7 +920,7 @@ static void draw_textArea(nbgl_text_area_t *obj, nbgl_obj_t *prevObj, bool compu
     if (obj->autoHideLongLine == true) {
 #ifdef BUILD_SCREENSHOTS
         nbgl_getTextNbLinesInWidth(fontId, text, obj->obj.area.width, obj->wrapping);
-        store_string_infos(obj->textId, text, last_nb_lines, last_nb_pages, last_bold_state);
+        store_string_infos(text, last_nb_lines, last_nb_pages, last_bold_state);
 #endif  // BUILD_SCREENSHOTS
         textWidth = nbgl_getSingleLineTextWidth(fontId, text);
         if (textWidth > obj->obj.area.width) {
@@ -1000,7 +949,7 @@ static void draw_textArea(nbgl_text_area_t *obj, nbgl_obj_t *prevObj, bool compu
     // get nb lines in the given width (depending of wrapping)
     nbLines = nbgl_getTextNbLinesInWidth(fontId, text, obj->obj.area.width, obj->wrapping);
 #ifdef BUILD_SCREENSHOTS
-    store_string_infos(obj->textId, text, last_nb_lines, last_nb_pages, last_bold_state);
+    store_string_infos(text, last_nb_lines, last_nb_pages, last_bold_state);
 #endif  // BUILD_SCREENSHOTS
     // saturate nb lines if nbMaxLines is greater than 0
     if ((obj->nbMaxLines > 0) && (obj->nbMaxLines < nbLines)) {

--- a/lib_nbgl/src/nbgl_step.c
+++ b/lib_nbgl/src/nbgl_step.c
@@ -44,10 +44,6 @@ typedef struct TextContext_s {
     const char *txtStart;       ///< pointer on the start point of text (first page)
     const char *nextPageStart;  ///< pointer on the start point of text at the next page
     const char *subTxtStart;    ///< pointer on the start point of sub-text (first page)
-#ifdef BUILD_SCREENSHOTS
-    uint16_t txtId;     ///< text ID (can be 0)
-    uint16_t subTxtId;  ///< subtext ID (can be 0)
-#endif                  // BUILD_SCREENSHOTS
 
     nbgl_stepPosition_t pos;  ///< position of the step within a flow (used for navigation arrows)
     nbgl_stepButtonCallback_t onActionCallback;  ///< function called when key actions done on this
@@ -100,11 +96,7 @@ extern bool     last_bold_state;
 /**********************
  *  PROTOTYPES
  **********************/
-void store_string_infos(uint16_t string_id,
-                        char    *text,
-                        uint16_t nb_lines,
-                        uint16_t nb_pages_,
-                        bool     bold);
+void store_string_infos(char *text, uint16_t nb_lines, uint16_t nb_pages_, bool bold);
 
 #endif  // BUILD_SCREENSHOTS
 
@@ -419,14 +411,10 @@ static void menuListActionCallback(nbgl_layout_t *layout, nbgl_buttonEvent_t eve
 nbgl_step_t nbgl_stepDrawText(nbgl_stepPosition_t               pos,
                               nbgl_stepButtonCallback_t         onActionCallback,
                               nbgl_screenTickerConfiguration_t *ticker,
-#ifdef BUILD_SCREENSHOTS
-                              uint16_t txtId,
-                              uint16_t subTxtId,
-#endif  // BUILD_SCREENSHOTS
-                              const char                     *text,
-                              const char                     *subText,
-                              nbgl_contentCenteredInfoStyle_t style,
-                              bool                            modal)
+                              const char                       *text,
+                              const char                       *subText,
+                              nbgl_contentCenteredInfoStyle_t   style,
+                              bool                              modal)
 {
     StepContext_t *ctx = getFreeContext(TEXT_STEP, modal);
     if (!ctx) {
@@ -445,7 +433,7 @@ nbgl_step_t nbgl_stepDrawText(nbgl_stepPosition_t               pos,
         ctx->textContext.nbPages = nbgl_getTextNbPagesInWidth(
             BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp, text, NB_MAX_LINES, AVAILABLE_WIDTH);
 #ifdef BUILD_SCREENSHOTS
-        store_string_infos(txtId, text, last_nb_lines, last_nb_pages, last_bold_state);
+        store_string_infos(text, last_nb_lines, last_nb_pages, last_bold_state);
 #endif  // BUILD_SCREENSHOTS
     }
     else {
@@ -453,14 +441,14 @@ nbgl_step_t nbgl_stepDrawText(nbgl_stepPosition_t               pos,
         // Call this function to get correct nb_lines/nb_pages for text field.
         nbgl_getTextNbPagesInWidth(
             BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp, text, NB_MAX_LINES, AVAILABLE_WIDTH);
-        store_string_infos(txtId, text, last_nb_lines, last_nb_pages, last_bold_state);
+        store_string_infos(text, last_nb_lines, last_nb_pages, last_bold_state);
 #endif  // BUILD_SCREENSHOTS
         // NB_MAX_LINES-1 because first line is for main text
         ctx->textContext.nbPages = nbgl_getTextNbPagesInWidth(
             BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp, subText, NB_MAX_LINES - 1, AVAILABLE_WIDTH);
 #ifdef BUILD_SCREENSHOTS
         // If subTxtid is not valid, we'll use txtId for nb_lines/nb_pages values
-        store_string_infos(subTxtId, subText, last_nb_lines, last_nb_pages, last_bold_state);
+        store_string_infos(subText, last_nb_lines, last_nb_pages, last_bold_state);
 #endif  // BUILD_SCREENSHOTS
     }
     LOG_DEBUG(STEP_LOGGER,
@@ -474,10 +462,6 @@ nbgl_step_t nbgl_stepDrawText(nbgl_stepPosition_t               pos,
     }
     ctx->textContext.txtStart    = text;
     ctx->textContext.subTxtStart = subText;
-#ifdef BUILD_SCREENSHOTS
-    ctx->textContext.txtId    = txtId;
-    ctx->textContext.subTxtId = subTxtId;
-#endif  // BUILD_SCREENSHOTS
     // keep only direction part of position
     ctx->textContext.pos   = pos & (RIGHT_ARROW | LEFT_ARROW);
     ctx->textContext.style = style;
@@ -568,10 +552,7 @@ nbgl_step_t nbgl_stepDrawMenuList(nbgl_stepMenuListCallback_t       onActionCall
     ctx->menuListContext.list.nbChoices      = list->nbChoices;
     ctx->menuListContext.list.selectedChoice = list->selectedChoice;
     ctx->menuListContext.list.callback       = list->callback;
-#ifdef BUILD_SCREENSHOTS
-    ctx->menuListContext.list.getStringID = list->getStringID;
-#endif  // BUILD_SCREENSHOTS
-    ctx->menuListContext.selectedCallback = onActionCallback;
+    ctx->menuListContext.selectedCallback    = onActionCallback;
 
     displayMenuList(ctx);
 

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -343,7 +343,7 @@ static void homeCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
     displayHomePage(pos);
 }
 
-static void choiceCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
+static void genericChoiceCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
 {
     UNUSED(stepCtx);
     nbgl_stepPosition_t pos;
@@ -700,7 +700,7 @@ static void displayChoicePage(nbgl_stepPosition_t pos)
         context.stepCallback = onChoiceReject;
     }
 
-    drawStep(pos, icon, text, subText, choiceCallback);
+    drawStep(pos, icon, text, subText, genericChoiceCallback);
     nbgl_refresh();
 }
 


### PR DESCRIPTION
## Description

The goal of this PR is to clean-up unused string id propagation when generating screenshots.
The string ids are now directly retrieved from the strings.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [*] Other (for changes that might not fit in any category)
