### PR TITLE
Fix FWEO-1175 - QR code template must be aligned with design with truncated addresses

### DIFF
--- a/lib_nbgl/include/nbgl_fonts.h
+++ b/lib_nbgl/include/nbgl_fonts.h
@@ -196,6 +196,12 @@ bool     nbgl_getTextMaxLenInNbLines(nbgl_font_id_e fontId,
                                      uint16_t      *len,
                                      bool           wrapping);
 void nbgl_textWrapOnNbLines(nbgl_font_id_e fontId, char *text, uint16_t maxWidth, uint8_t nbLines);
+void nbgl_textReduceOnNbLines(nbgl_font_id_e fontId,
+                              const char    *origText,
+                              uint16_t       maxWidth,
+                              uint8_t        nbLines,
+                              char          *reducedText,
+                              uint16_t       reducedTextLen);
 uint8_t nbgl_getTextNbPagesInWidth(nbgl_font_id_e fontId,
                                    const char    *text,
                                    uint8_t        nbLinesPerPage,

--- a/lib_nbgl/src/nbgl_fonts.c
+++ b/lib_nbgl/src/nbgl_fonts.c
@@ -1129,6 +1129,88 @@ void nbgl_textWrapOnNbLines(nbgl_font_id_e fontId, char *text, uint16_t maxWidth
     }
 }
 
+/**
+ * @brief Create a reduced version of given ASCII text to wrap it on the given max width (in
+ * pixels), in the given nbLines.
+ *
+ * @note the number of line must be odd
+ *
+ * @param fontId font ID
+ * @param text (input) ASCII string, must be single line
+ * @param maxWidth maximum width in pixels
+ * @param nbLines (input) number of lines to reduce the text to. The middle of the text is replaced
+ * by ...
+ * @param reducedText (output) reduced text
+ * @param reducedTextLen (input) max size of reduced text
+ *
+ */
+void nbgl_textReduceOnNbLines(nbgl_font_id_e fontId,
+                              const char    *origText,
+                              uint16_t       maxWidth,
+                              uint8_t        nbLines,
+                              char          *reducedText,
+                              uint16_t       reducedTextLen)
+{
+    const nbgl_font_t *font           = nbgl_getFont(fontId);
+    uint16_t           textLen        = strlen(origText);
+    uint16_t           width          = 0;
+    uint8_t            currentNbLines = 1;
+    uint32_t           i = 0, j = 0;
+    const uint16_t     halfWidth = (maxWidth - nbgl_getTextWidth(fontId, " ... ")) / 2;
+
+    if ((nbLines & 0x1) == 0) {
+        LOG_FATAL(MISC_LOGGER, "nbgl_textReduceOnNbLines: the number of line must be odd\n");
+        return;
+    }
+    while ((i < textLen) && (j < reducedTextLen)) {
+        uint8_t char_width;
+        char    curChar;
+
+        curChar = origText[i];
+
+        char_width = getCharWidth(font, curChar, false);
+        if (char_width == 0) {
+            reducedText[j] = curChar;
+            j++;
+            i++;
+            continue;
+        }
+
+        // if the width is about to exceed maxWidth, increment number of lines
+        if ((width + char_width) > maxWidth) {
+            currentNbLines++;
+            // reset width for next line
+            width = 0;
+            continue;
+        }
+        else if ((currentNbLines == ((nbLines / 2) + 1)) && ((width + char_width) > halfWidth)) {
+            uint32_t halfFullWidth = (nbLines / 2) * maxWidth + halfWidth;
+            uint32_t countDown     = textLen;
+            // if this if the central line, we have to insert the '...' in the middle of it
+            reducedText[j - 1] = '.';
+            reducedText[j]     = '.';
+            reducedText[j + 1] = '.';
+            // then start from the end
+            width = 0;
+            while (width < halfFullWidth) {
+                countDown--;
+                curChar    = origText[countDown];
+                char_width = getCharWidth(font, curChar, false);
+                width += char_width;
+            }
+            memcpy(&reducedText[j + 2], &origText[countDown + 1], textLen - countDown + 1);
+            return;
+        }
+        else {
+            reducedText[j] = curChar;
+            j++;
+            i++;
+        }
+        width += char_width;
+    }
+    reducedText[j] = '\0';
+}
+
 #ifdef HAVE_UNICODE_SUPPORT
 /**
  * @brief Get the font entry for the given font id (sparse font array support)

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -1043,6 +1043,8 @@ static void draw_qrCode(nbgl_qrcode_t *obj, nbgl_obj_t *prevObj, bool computePos
     if (objDrawingDisabled) {
         return;
     }
+    // be sure to align vertical position on multiple of 4
+    obj->obj.area.y0 &= ~0x3;
     LOG_DEBUG(OBJ_LOGGER,
               "draw_qrCode(), x0 = %d, y0 = %d, width = %d, height = %d, text = %s\n",
               obj->obj.area.x0,
@@ -1460,19 +1462,23 @@ static void extendRefreshArea(nbgl_area_t *area)
 
     // if obj top-left is on left of current top-left corner, move top-left corner
     if (area->x0 < refreshArea.x0) {
-        refreshArea.x0 = area->x0;
+        // No negative coordinates
+        refreshArea.x0 = MAX(0, area->x0);
     }
     // if obj bottom-right is on right of current bottom-right corner, move bottom-right corner
     if (((area->x0 + area->width) > x1) || (refreshArea.width == 0)) {
-        x1 = area->x0 + area->width;
+        // Not beyond width
+        x1 = MIN(SCREEN_WIDTH, area->x0 + area->width);
     }
     // if obj top-left is on top of current top-left corner, move top-left corner
     if (area->y0 < refreshArea.y0) {
-        refreshArea.y0 = area->y0;
+        // No negative coordinates
+        refreshArea.y0 = MAX(0, area->y0);
     }
     // if obj bottom-right is on bottom of current bottom-right corner, move bottom-right corner
     if (((area->y0 + area->height) > y1) || (refreshArea.height == 0)) {
-        y1 = area->y0 + area->height;
+        // Not beyond height
+        y1 = MIN(SCREEN_HEIGHT, area->y0 + area->height);
     }
 
     // sanity check

--- a/unit-tests/lib_nbgl/test_nbgl_fonts.c
+++ b/unit-tests/lib_nbgl/test_nbgl_fonts.c
@@ -12,6 +12,13 @@
 
 void fetch_language_packs(void);
 
+static bool fatal_reached = false;
+
+void mainExit(int exitCode)
+{
+    fatal_reached = true;
+}
+
 #ifdef HAVE_SE_TOUCH
 static void test_get_length(void **state __attribute__((unused)))
 {
@@ -93,7 +100,7 @@ static void test_get_length(void **state __attribute__((unused)))
     assert_int_equal(len, 5);
     assert_int_equal(width, 45);
 
-    char textToWrap[32] = "toto";
+    char textToWrap[128] = "toto";
     nbgl_textWrapOnNbLines(BAGL_FONT_INTER_SEMIBOLD_24px, textToWrap, 156, 2);
     assert_string_equal(textToWrap, "toto");
 
@@ -104,6 +111,17 @@ static void test_get_length(void **state __attribute__((unused)))
     strcpy(textToWrap, "bonjourtuaimestr les mois");
     nbgl_textWrapOnNbLines(BAGL_FONT_INTER_SEMIBOLD_24px, textToWrap, 156, 2);
     assert_string_equal(textToWrap, "bonjourtuaimestr les...");
+
+    nbgl_textReduceOnNbLines(BAGL_FONT_INTER_SEMIBOLD_24px,
+                             "bc1pkdcufjh6dxjaEZFZEFZFGGEaa05hudxqgfffggghhhhhhffffffff5fhspfmZAFEZ"
+                             "Fwmp8g92gq8ZEGFZEcv4g",
+                             416,
+                             3,
+                             textToWrap,
+                             128);
+    assert_string_equal(
+        textToWrap,
+        "bc1pkdcufjh6dxjaEZFZEFZFGGEaa05hudxqgfffg...hffffffff5fhspfmZAFEZFwmp8g92gq8ZEGFZEcv4g");
 
     nbLines
         = nbgl_getTextNbLinesInWidth(BAGL_FONT_INTER_MEDIUM_32px, "AB WWWWWWWW WWW W", 200, true);


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledgerhq.atlassian.net/browse/FWEO-1175, by using a reduced version of the address displayed under the QR Code, on 3 lines

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
