### PR TITLE
Enable using a top-right icon in progress & back header

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -413,12 +413,14 @@ typedef struct {
             tune_index_e tuneId;  ///< when back key is pressed
         } backAndText;            ///< if type is @ref HEADER_BACK_AND_TEXT
         struct {
-            uint8_t      activePage;
-            uint8_t      nbPages;
-            bool         withBack;
-            uint8_t      token;   ///< when optional back key is pressed
-            tune_index_e tuneId;  ///< when optional back key is pressed
-        } progressAndBack;        ///< if type is @ref HEADER_BACK_AND_PROGRESS
+            const nbgl_icon_details_t *actionIcon;  ///< right button icon
+            uint8_t                    activePage;
+            uint8_t                    nbPages;
+            bool                       withBack;
+            uint8_t                    token;        ///< when optional back key is pressed
+            uint8_t                    actionToken;  ///< when optional right button is pressed
+            tune_index_e               tuneId;       ///< when optional back key is pressed
+        } progressAndBack;                           ///< if type is @ref HEADER_BACK_AND_PROGRESS
         struct {
             const char *text;
         } title;  ///< if type is @ref HEADER_TITLE


### PR DESCRIPTION
## Description

In order to support some screens in Figma for Clear signing on Stax, it is useful to enable, in NBGL layout layer, to use a touchable icon in top-right position in the screen, in the header.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
