### PR TITLE
Small fix in nulber of lines computed for Nano, in some cases with '\f'

### DIFF
--- a/lib_nbgl/include/nbgl_flow.h
+++ b/lib_nbgl/include/nbgl_flow.h
@@ -47,9 +47,8 @@ typedef struct nbgl_stepDesc_s {
     const char         *subText;   ///< sub-text to display in step (NULL most of the time)
     const nbgl_icon_details_t *icon;  ///< icon to display in step (text must be single-page)
 #ifdef HAVE_LANGUAGE_PACK
-    UX_LOC_STRINGS_INDEX textId;     ///< text Id to display in step
-    UX_LOC_STRINGS_INDEX subTextId;  ///< subText Id to display in step (NULL most of the time)
-#endif                               // HAVE_LANGUAGE_PACK
+    UX_LOC_STRINGS_INDEX textId;  ///< text Id to display in step
+#endif                            // HAVE_LANGUAGE_PACK
 } nbgl_stepDesc_t;
 
 typedef nbgl_stepDesc_t nbgl_pageContent_t;

--- a/lib_nbgl/src/nbgl_fonts.c
+++ b/lib_nbgl/src/nbgl_fonts.c
@@ -752,24 +752,12 @@ uint16_t nbgl_getTextNbLinesInWidth(nbgl_font_id_e fontId,
         // if \f, exit loop
         if (unicode == '\f') {
 #ifdef BUILD_SCREENSHOTS
-            // Continue parsing the string, to find the real nb_lines & nb_pages!
             ++last_nb_pages;
-#ifdef SCREEN_SIZE_NANO
-            if (width != 0) {
-#endif  // SCREEN_SIZE_NANO
-                ++nbLines;
-#ifdef SCREEN_SIZE_NANO
-            }
-#endif  // SCREEN_SIZE_NANO
             if (last_nb_lines < nbLines) {
                 last_nb_lines = nbLines;
             }
-            nbLines = 0;
-            width   = 0;
-            continue;
-#else   // BUILD_SCREENSHOTS
-            break;
 #endif  // BUILD_SCREENSHOTS
+            break;
         }
         // if \n, increment the number of lines
         else if (unicode == '\n') {

--- a/lib_nbgl/src/nbgl_layout_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_nanos.c
@@ -223,8 +223,6 @@ int nbgl_layoutAddText(nbgl_layout_t                  *layout,
     nbgl_text_area_t      *textArea;
     uint16_t               fullHeight = 0;
 
-    UNUSED(subText);
-
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddText():\n");
     if (layout == NULL) {
         return -1;

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -75,7 +75,7 @@ extern const char *get_ux_loc_string(uint32_t index);
 
 #ifdef BUILD_SCREENSHOTS
 char *get_printable_string(char *string);
-void  store_string_infos(char *text, uint16_t nb_lines, uint16_t nb_pages, bool bold);
+void  store_string_infos(const char *text, uint16_t nb_lines, uint16_t nb_pages, bool bold);
 #endif  // BUILD_SCREENSHOTS
 
 /**********************

--- a/lib_nbgl/src/nbgl_step.c
+++ b/lib_nbgl/src/nbgl_step.c
@@ -96,7 +96,7 @@ extern bool     last_bold_state;
 /**********************
  *  PROTOTYPES
  **********************/
-void store_string_infos(char *text, uint16_t nb_lines, uint16_t nb_pages_, bool bold);
+void store_string_infos(const char *text, uint16_t nb_lines, uint16_t nb_pages_, bool bold);
 
 #endif  // BUILD_SCREENSHOTS
 
@@ -229,11 +229,6 @@ static nbgl_layoutNavIndication_t getNavigationInfo(nbgl_stepPosition_t pos,
 static void displayTextPage(StepContext_t *ctx, uint8_t textPage)
 {
     const char *txt;
-
-#ifdef BUILD_SCREENSHOTS
-    // We already took care of updating those strings info
-    last_string_id = 0;
-#endif  // BUILD_SCREENSHOTS
 
     // if move backward or first page
     if (textPage <= ctx->textContext.currentPage) {


### PR DESCRIPTION
## Description

The goal of this PR is to fix the computed number of lines for Nano, in some cases with '\f', for screenshots generation.
And also some cosmetic fixes

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
