### PR TITLE
[clean] Replace deprecated #defines with their replacements

### DIFF
--- a/src/checks.c
+++ b/src/checks.c
@@ -154,7 +154,7 @@ void ui_audited_choice(bool choice)
 void ui_audited_init(void)
 {
     auditChoiceMade = false;
-    nbgl_useCaseChoice(&C_warning64px,
+    nbgl_useCaseChoice(&C_Warning_64px,
                        "Pending Ledger review",
                        "This app has not been\nreviewed by Ledger",
                        "Open",

--- a/src/ledger_assert.c
+++ b/src/ledger_assert.c
@@ -137,7 +137,7 @@ void __attribute__((noreturn)) assert_display_exit(void)
 #if defined(TARGET_NANOS) || defined(TARGET_NANOX) || defined(TARGET_NANOS2)
 #define ICON_APP_WARNING C_icon_warning
 #elif defined(TARGET_STAX) || defined(TARGET_FLEX)
-#define ICON_APP_WARNING C_round_warning_64px
+#define ICON_APP_WARNING C_Important_Circle_64px
 #endif
 
     nbgl_useCaseChoice(


### PR DESCRIPTION
## Description

Some `#define` has been deprecated, but they are still used in the code, leading to compilation warnings (already on `API_LEVEL_19`).

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
