### PR TITLE
Fix aes cipher portability issue

### DIFF
--- a/include/ox_aes.h
+++ b/include/ox_aes.h
@@ -76,8 +76,8 @@
  * @details Such container should be initialized with #cx_aes_init_key_no_throw.
  */
 struct cx_aes_key_s {
-    size_t  size;      ///< key size
-    uint8_t keys[32];  ///< key value
+    uint32_t size;      ///< key size
+    uint8_t  keys[32];  ///< key value
 };
 /** Convenience type. See #cx_aes_key_s. */
 typedef struct cx_aes_key_s cx_aes_key_t;

--- a/lib_cxng/include/lcx_cipher.h
+++ b/lib_cxng/include/lcx_cipher.h
@@ -42,8 +42,8 @@ typedef enum {
 
 /** Generic key structure */
 typedef struct {
-    unsigned int  size;
-    unsigned char keys[32];
+    uint32_t size;
+    uint8_t  keys[32];
 } cipher_key_t;
 
 /** Base cipher information */


### PR DESCRIPTION
## Description

Use types that are arch-independent to avoid 32/64 bit portability issues.
Some unit-tests running on x86 64-bit with sanitizers enabled fails.

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
