### PR TITLE
Enable bling warning indication for reviews, to warn user in some cases.

### DIFF
--- a/lib_nbgl/include/nbgl_page.h
+++ b/lib_nbgl/include/nbgl_page.h
@@ -55,7 +55,10 @@ typedef struct nbgl_pageContent_s {
     uint8_t titleToken;   ///< if isTouchableTitle set to true, this is the token used when touching
                           ///< title
     tune_index_e tuneId;  ///< if not @ref NBGL_NO_TUNE, a tune will be played when title is touched
-    nbgl_contentType_t type;  ///< type of page content in the following union
+    uint8_t      topRightToken;  ///< token used when top-right button (if not NULL) is touched
+    const nbgl_icon_details_t *topRightIcon;  ///< a buffer containing the 32px/40px icon for icon
+                                              ///< on top-right of screen (no button if NULL)
+    nbgl_contentType_t type;                  ///< type of page content in the following union
     union {
         nbgl_contentCenteredInfo_t    centeredInfo;     ///< @ref CENTERED_INFO type
         nbgl_contentInfoLongPress_t   infoLongPress;    ///< @ref INFO_LONG_PRESS type

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -37,9 +37,6 @@
 // used by container
 #define NB_MAX_CONTAINER_CHILDREN 20
 
-// used by screen
-#define NB_MAX_SCREEN_CHILDREN 7
-
 #define TAG_VALUE_ICON_WIDTH 32
 
 #ifdef TARGET_STAX
@@ -755,9 +752,11 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description)
     layout->container->obj.area.height = SCREEN_HEIGHT;
     layout->container->layout          = VERTICAL;
     layout->container->children = nbgl_containerPoolGet(NB_MAX_CONTAINER_CHILDREN, layout->layer);
+    // by default, if no header, main container is aligned on top-left
+    layout->container->obj.alignment = TOP_LEFT;
     // main container is always the second object, leaving space for header
-    layout->children[1] = (nbgl_obj_t *) layout->container;
-    layout->nbChildren  = 2;
+    layout->children[MAIN_CONTAINER_INDEX] = (nbgl_obj_t *) layout->container;
+    layout->nbChildren                     = NB_MAX_SCREEN_CHILDREN;
 
     // if a tap text is defined, make the container tapable and display this text in gray
     if (description->tapActionText != NULL) {
@@ -877,8 +876,7 @@ int nbgl_layoutAddTopRightButton(nbgl_layout_t             *layout,
     button->obj.alignment        = TOP_RIGHT;
 
     // add to screen
-    layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t *) button;
-    layoutInt->nbChildren++;
+    layoutInt->children[TOP_RIGHT_BUTTON_INDEX] = (nbgl_obj_t *) button;
 
     return 0;
 }
@@ -2486,10 +2484,12 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
         layoutInt->headerContainer->nbChildren++;
     }
     // header must be the first child
-    layoutInt->children[0] = (nbgl_obj_t *) layoutInt->headerContainer;
+    layoutInt->children[HEADER_INDEX] = (nbgl_obj_t *) layoutInt->headerContainer;
 
     // subtract header height from main container height
     layoutInt->container->obj.area.height -= layoutInt->headerContainer->obj.area.height;
+    layoutInt->container->obj.alignTo   = (nbgl_obj_t *) layoutInt->headerContainer;
+    layoutInt->container->obj.alignment = BOTTOM_LEFT;
 
     layoutInt->headerType = headerDesc->type;
 
@@ -2920,8 +2920,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
         layoutInt->footerContainer->nbChildren++;
     }
 
-    layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t *) layoutInt->footerContainer;
-    layoutInt->nbChildren++;
+    layoutInt->children[FOOTER_INDEX] = (nbgl_obj_t *) layoutInt->footerContainer;
 
     // subtract footer height from main container height
     layoutInt->container->obj.area.height -= layoutInt->footerContainer->obj.area.height;
@@ -3054,9 +3053,8 @@ int nbgl_layoutDraw(nbgl_layout_t *layoutParam)
     }
     if (layout->withLeftBorder == true) {
         // draw now the line
-        nbgl_line_t *line                    = createLeftVerticalLine(layout->layer);
-        layout->children[layout->nbChildren] = (nbgl_obj_t *) line;
-        layout->nbChildren++;
+        nbgl_line_t *line                   = createLeftVerticalLine(layout->layer);
+        layout->children[LEFT_BORDER_INDEX] = (nbgl_obj_t *) line;
     }
     nbgl_screenRedraw();
 

--- a/lib_nbgl/src/nbgl_layout_internal.h
+++ b/lib_nbgl/src/nbgl_layout_internal.h
@@ -51,6 +51,16 @@ typedef enum {
     NB_SWIPE_USAGE
 } nbgl_swipe_usage_t;
 
+// used by screen (top level)
+enum {
+    HEADER_INDEX = 0,  // For header container
+    TOP_RIGHT_BUTTON_INDEX,
+    MAIN_CONTAINER_INDEX,
+    LEFT_BORDER_INDEX,
+    FOOTER_INDEX,
+    NB_MAX_SCREEN_CHILDREN
+};
+
 /**
  * @brief Structure containing all information about the current layout.
  * @note It shall not be used externally

--- a/lib_nbgl/src/nbgl_layout_keyboard.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard.c
@@ -497,8 +497,7 @@ int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInf
     layoutInt->footerContainer->nbChildren  = 1;
 
     // add footer to layout children
-    layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t *) layoutInt->footerContainer;
-    layoutInt->nbChildren++;
+    layoutInt->children[FOOTER_INDEX] = (nbgl_obj_t *) layoutInt->footerContainer;
 
     // subtract footer height from main container height
     layoutInt->container->obj.area.height -= layoutInt->footerContainer->obj.area.height;

--- a/lib_nbgl/src/nbgl_layout_keypad.c
+++ b/lib_nbgl/src/nbgl_layout_keypad.c
@@ -102,8 +102,7 @@ int nbgl_layoutAddKeypad(nbgl_layout_t *layout, keyboardCallback_t callback, boo
     layoutInt->footerContainer->nbChildren++;
 
     // add to layout children
-    layoutInt->children[layoutInt->nbChildren] = (nbgl_obj_t *) layoutInt->footerContainer;
-    layoutInt->nbChildren++;
+    layoutInt->children[FOOTER_INDEX] = (nbgl_obj_t *) layoutInt->footerContainer;
 
     // subtract footer height from main container height
     layoutInt->container->obj.area.height -= layoutInt->footerContainer->obj.area.height;

--- a/lib_nbgl/src/nbgl_page.c
+++ b/lib_nbgl/src/nbgl_page.c
@@ -41,6 +41,10 @@ static void addContent(nbgl_pageContent_t *content,
                                           .backAndText.text   = content->title};
         nbgl_layoutAddHeader(layout, &headerDesc);
     }
+    if (content->topRightIcon != NULL) {
+        nbgl_layoutAddTopRightButton(
+            layout, content->topRightIcon, content->topRightToken, content->tuneId);
+    }
     switch (content->type) {
         case INFO_LONG_PRESS: {
             nbgl_layoutCenteredInfo_t centeredInfo;


### PR DESCRIPTION
## Description

The goal of this PR is to enable bling warning indication for reviews, to warn user in some cases.
A warning button is displayed on top-right of the first and last pages of the review, and when touched a modal warning text is displayed.
It can be activated by adding `| BLIND OPERATION` to operationType param of review.  
It enables for example the modal screen presented in https://ledgerhq.atlassian.net/browse/B2CA-1667

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
