### PR TITLE
Update Stax and Flex USB descriptors

### DIFF
--- a/lib_stusb_impl/usbd_impl.c
+++ b/lib_stusb_impl/usbd_impl.c
@@ -232,8 +232,15 @@ static uint8_t const USBD_PRODUCT_FS_STRING[] = {
 #define USBD_PID                      0x0007
 #endif // HAVE_LEGACY_PID
 static uint8_t const USBD_PRODUCT_FS_STRING[] = {
-  4*2+2,
+  11*2+2,
   USB_DESC_TYPE_STRING,
+  'L', 0,
+  'e', 0,
+  'd', 0,
+  'g', 0,
+  'e', 0,
+  'r', 0,
+  ' ', 0,
   'F', 0,
   'l', 0,
   'e', 0,


### PR DESCRIPTION
- With WebUSB, the device is listed as: `<manufacturer> <product name>`
- With WebHID, the device is listed as: `<product name>`

For Stax and Flex, it's necessary that the device is always listed as "Ledger Stax"/"Ledger Flex".

In order to achieve this (for Stax/Flex only):
- Manufacturer is set to empty string
- "Ledger" is added to product name

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
