### PR TITLE
Align keypad keyboard screens

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -542,6 +542,7 @@ int nbgl_layoutAddTopRightButton(nbgl_layout_t             *layout,
 int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *barLayout);
 int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switchLayout);
 int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subText);
+int nbgl_layoutAddSubHeaderText(nbgl_layout_t *layout, const char *text);
 int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoice_t *choices);
 int nbgl_layoutAddQRCode(nbgl_layout_t *layout, const nbgl_layoutQRCode_t *info);
 int nbgl_layoutAddChoiceButtons(nbgl_layout_t *layout, const nbgl_layoutChoiceButtons_t *info);

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1109,6 +1109,47 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
 }
 
 /**
+ * @brief Creates an area with given text in small regular font, under the header
+ *
+ * @param layout the current layout
+ * @param text main text in small regular font
+ * @return height of the control if OK
+ */
+int nbgl_layoutAddSubHeaderText(nbgl_layout_t *layout, const char *text)
+{
+    nbgl_layoutInternal_t *layoutInt = (nbgl_layoutInternal_t *) layout;
+    nbgl_text_area_t      *textArea;
+
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutAddSubHeaderText():\n");
+    if (layout == NULL) {
+        return -1;
+    }
+    textArea = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
+
+    textArea->textColor            = BLACK;
+    textArea->text                 = PIC(text);
+    textArea->textAlignment        = MID_LEFT;
+    textArea->fontId               = SMALL_REGULAR_FONT;
+    textArea->style                = NO_STYLE;
+    textArea->wrapping             = true;
+    textArea->obj.alignment        = NO_ALIGNMENT;
+    textArea->obj.alignmentMarginX = BORDER_MARGIN;
+    textArea->obj.area.width       = AVAILABLE_WIDTH;
+    textArea->obj.area.height      = nbgl_getTextHeightInWidth(
+        textArea->fontId, textArea->text, textArea->obj.area.width, textArea->wrapping);
+#ifdef TARGET_STAX
+    textArea->obj.area.height += 2 * 24;
+#else   // TARGET_STAX
+    textArea->obj.area.height += 2 * 28;
+#endif  // TARGET_STAX
+
+    // set this new obj as child of main container
+    layoutAddObject(layoutInt, (nbgl_obj_t *) textArea);
+
+    return textArea->obj.area.height;
+}
+
+/**
  * @brief Creates an area with given text in 32px font (in Black)
  *
  * @param layout the current layout
@@ -1280,11 +1321,8 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
         container->obj.alignTo          = (nbgl_obj_t *) NULL;
 
         // init button for this choice
-        button->activeColor = BLACK;
-        button->borderColor = LIGHT_GRAY;
-#ifdef TARGET_STAX
-        button->obj.alignmentMarginX = 4;
-#endif  // TARGET_STAX
+        button->activeColor    = BLACK;
+        button->borderColor    = LIGHT_GRAY;
         button->obj.alignTo    = (nbgl_obj_t *) container;
         button->obj.alignment  = MID_RIGHT;
         button->state          = OFF_STATE;
@@ -1300,16 +1338,12 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
         else {
             textArea->text = PIC(choices->names[i]);
         }
-        textArea->textAlignment = MID_LEFT;
-#ifdef TARGET_STAX
-        textArea->obj.area.width = container->obj.area.width - 40 - 16;
-#else   // TARGET_STAX
-        textArea->obj.area.width = container->obj.area.width - 40;
-#endif  // TARGET_STAX
-        textArea->style         = NO_STYLE;
-        textArea->obj.alignment = MID_LEFT;
-        textArea->obj.alignTo   = (nbgl_obj_t *) container;
-        container->children[0]  = (nbgl_obj_t *) textArea;
+        textArea->textAlignment  = MID_LEFT;
+        textArea->obj.area.width = container->obj.area.width - RADIO_WIDTH;
+        textArea->style          = NO_STYLE;
+        textArea->obj.alignment  = MID_LEFT;
+        textArea->obj.alignTo    = (nbgl_obj_t *) container;
+        container->children[0]   = (nbgl_obj_t *) textArea;
 
         // whole container should be touchable
         container->obj.touchMask = (1 << TOUCHED);

--- a/lib_nbgl/src/nbgl_layout_keyboard.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard.c
@@ -493,7 +493,7 @@ int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInf
         keyboard->obj.area.height += KEYBOARD_KEY_HEIGHT;
     }
 #ifdef TARGET_STAX
-    keyboard->obj.alignmentMarginY = 58;
+    keyboard->obj.alignmentMarginY = 56;
 #endif  // TARGET_STAX
     keyboard->obj.alignment = BOTTOM_MIDDLE;
     keyboard->borderColor   = LIGHT_GRAY;

--- a/lib_nbgl/src/nbgl_layout_keypad.c
+++ b/lib_nbgl/src/nbgl_layout_keypad.c
@@ -455,7 +455,7 @@ int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
     // create gray line
     line                            = (nbgl_line_t *) nbgl_objPoolGet(LINE, layoutInt->layer);
     line->lineColor                 = LIGHT_GRAY;
-    line->obj.alignTo               = container->children[1];
+    line->obj.alignTo               = container->children[INPUT_INDEX];
     line->obj.alignment             = BOTTOM_MIDDLE;
     line->obj.area.width            = 288;
     line->obj.area.height           = 4;

--- a/lib_nbgl/src/nbgl_layout_keypad.c
+++ b/lib_nbgl/src/nbgl_layout_keypad.c
@@ -31,6 +31,13 @@
 #define DIGIT_ICON C_pin_24
 #endif  // TARGET_STAX
 
+enum {
+    TITLE_INDEX = 0,
+    INPUT_INDEX,
+    LINE_INDEX,
+    NB_CHILDREN
+};
+
 /**********************
  *      MACROS
  **********************/
@@ -342,14 +349,12 @@ int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
         return -1;
     }
     // create a container, to store both title and "digits" (and line on Stax)
-    container             = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
-    container->nbChildren = 2;
-#ifdef TARGET_STAX
-    container->nbChildren++;  // +1 for the line
-#endif                        // TARGET_STAX
+    container                 = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
+    container->nbChildren     = NB_CHILDREN;
     container->children       = nbgl_containerPoolGet(container->nbChildren, layoutInt->layer);
     container->obj.area.width = AVAILABLE_WIDTH;
-    container->obj.alignment  = CENTER;
+    container->obj.alignment  = TOP_MIDDLE;
+    container->obj.alignmentMarginY = 8;
 
     // create text area for title
     textArea                  = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
@@ -362,7 +367,7 @@ int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
     textArea->obj.area.width  = AVAILABLE_WIDTH;
     textArea->obj.area.height = nbgl_getTextHeightInWidth(
         textArea->fontId, textArea->text, textArea->obj.area.width, textArea->wrapping);
-    container->children[0] = (nbgl_obj_t *) textArea;
+    container->children[TITLE_INDEX] = (nbgl_obj_t *) textArea;
     container->obj.area.height += textArea->obj.area.height;
 
     if (hidden) {
@@ -391,12 +396,19 @@ int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
             = nbgl_containerPoolGet(digitsContainer->nbChildren, layoutInt->layer);
         // <space> pixels between each icon (knowing that the effective round are 18px large and the
         // icon 24px)
-        digitsContainer->obj.area.width  = nbDigits * DIGIT_ICON.width + (nbDigits - 1) * space;
+        digitsContainer->obj.area.width = nbDigits * DIGIT_ICON.width + (nbDigits - 1) * space;
+#ifdef TARGET_STAX
+        digitsContainer->obj.area.height = 44;
+#else   // TARGET_STAX
         digitsContainer->obj.area.height = 64;
+#endif  // TARGET_STAX
         // align at the bottom of title
         digitsContainer->obj.alignTo   = container->children[0];
         digitsContainer->obj.alignment = BOTTOM_MIDDLE;
-        container->children[1]         = (nbgl_obj_t *) digitsContainer;
+#ifdef TARGET_STAX
+        digitsContainer->obj.alignmentMarginY = 28;
+#endif  // TARGET_STAX
+        container->children[INPUT_INDEX] = (nbgl_obj_t *) digitsContainer;
         container->obj.area.height += digitsContainer->obj.area.height;
 
         // create children of the container, as images (empty circles)
@@ -427,9 +439,12 @@ int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
         textArea->obj.area.height  = nbgl_getFontLineHeight(textArea->fontId);
         textArea->autoHideLongLine = true;
         // align at the bottom of title
-        textArea->obj.alignTo   = container->children[0];
+        textArea->obj.alignTo   = container->children[TITLE_INDEX];
         textArea->obj.alignment = BOTTOM_MIDDLE;
-        container->children[1]  = (nbgl_obj_t *) textArea;
+#ifdef TARGET_STAX
+        textArea->obj.alignmentMarginY = 24;
+#endif  // TARGET_STAX
+        container->children[INPUT_INDEX] = (nbgl_obj_t *) textArea;
         container->obj.area.height += textArea->obj.area.height;
     }
 
@@ -438,17 +453,16 @@ int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
 #ifdef TARGET_STAX
     nbgl_line_t *line;
     // create gray line
-    line                       = (nbgl_line_t *) nbgl_objPoolGet(LINE, layoutInt->layer);
-    line->lineColor            = LIGHT_GRAY;
-    line->obj.alignmentMarginY = 0;
-    line->obj.alignTo          = container->children[1];
-    line->obj.alignment        = BOTTOM_MIDDLE;
-    line->obj.area.width       = 288;
-    line->obj.area.height      = 4;
-    line->direction            = HORIZONTAL;
-    line->thickness            = 2;
-    line->offset               = 2;
-    container->children[2]     = (nbgl_obj_t *) line;
+    line                            = (nbgl_line_t *) nbgl_objPoolGet(LINE, layoutInt->layer);
+    line->lineColor                 = LIGHT_GRAY;
+    line->obj.alignTo               = container->children[1];
+    line->obj.alignment             = BOTTOM_MIDDLE;
+    line->obj.area.width            = 288;
+    line->obj.area.height           = 4;
+    line->direction                 = HORIZONTAL;
+    line->thickness                 = 2;
+    line->offset                    = 2;
+    container->children[LINE_INDEX] = (nbgl_obj_t *) line;
 #endif  // TARGET_STAX
 
     // return height of the area

--- a/lib_nbgl/src/nbgl_layout_navigation.c
+++ b/lib_nbgl/src/nbgl_layout_navigation.c
@@ -148,14 +148,16 @@ void layoutNavigationPopulate(nbgl_container_t                 *navContainer,
     nbgl_button_t *button;
 
     if (navConfig->withExitKey) {
-        button                       = (nbgl_button_t *) nbgl_objPoolGet(BUTTON, layer);
-        button->innerColor           = WHITE;
-        button->borderColor          = BORDER_COLOR;
-        button->obj.area.width       = BUTTON_DIAMETER;
-        button->obj.area.height      = BUTTON_DIAMETER;
-        button->radius               = BUTTON_RADIUS;
-        button->icon                 = &CLOSE_ICON;
+        button                  = (nbgl_button_t *) nbgl_objPoolGet(BUTTON, layer);
+        button->innerColor      = WHITE;
+        button->borderColor     = BORDER_COLOR;
+        button->obj.area.width  = BUTTON_DIAMETER;
+        button->obj.area.height = BUTTON_DIAMETER;
+        button->radius          = BUTTON_RADIUS;
+        button->icon            = &CLOSE_ICON;
+#ifdef TARGET_FLEX
         button->obj.alignmentMarginX = (navConfig->nbPages > 1) ? 8 : 0;
+#endif  // TARGET_FLEX
 
         button->obj.alignment                     = (navConfig->nbPages > 1) ? MID_LEFT : CENTER;
         button->obj.touchMask                     = (1 << TOUCHED);

--- a/lib_nbgl/src/nbgl_page.c
+++ b/lib_nbgl/src/nbgl_page.c
@@ -47,6 +47,7 @@ static void addContent(nbgl_pageContent_t *content,
                                           .backAndText.tuneId = content->tuneId,
                                           .backAndText.text   = content->title};
         nbgl_layoutAddHeader(layout, &headerDesc);
+        headerAdded = true;
     }
     if (content->topRightIcon != NULL) {
         nbgl_layoutAddTopRightButton(

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -808,8 +808,6 @@ static bool genericContextPreparePageContent(const nbgl_content_t *p_content,
                     pageContent->type = CENTERED_INFO;
                     prepareReviewFirstPage(
                         &pageContent->centeredInfo, pair->valueIcon, pair->item, pair->value);
-                    // use "Swipe to continue" instead of "Swipe to review" for intermediate pages
-                    pageContent->centeredInfo.text3 = "Swipe to continue";
 
                     // Skip population of nbgl_contentTagValueList_t structure
                     p_tagValueList = NULL;
@@ -2924,9 +2922,10 @@ void nbgl_useCaseAddressReview(const char                       *address,
     memset(&addressConfirmationContext, 0, sizeof(addressConfirmationContext));
 
     // save context
-    onChoice  = choiceCallback;
-    navType   = GENERIC_NAV;
-    pageTitle = NULL;
+    onChoice                              = choiceCallback;
+    navType                               = GENERIC_NAV;
+    pageTitle                             = NULL;
+    bundleNavContext.review.operationType = TYPE_OPERATION;
 
     genericContext.genericContents.contentsList = localContentsList;
     genericContext.genericContents.nbContents   = (additionalTagValueList == NULL) ? 2 : 3;
@@ -2936,6 +2935,7 @@ void nbgl_useCaseAddressReview(const char                       *address,
     STARTING_CONTENT.type = CENTERED_INFO;
     prepareReviewFirstPage(
         &STARTING_CONTENT.content.centeredInfo, icon, reviewTitle, reviewSubTitle);
+    STARTING_CONTENT.content.centeredInfo.text3 = "Swipe to continue";
 
     // Then the address confirmation pages
     prepareAddressConfirmationPages(


### PR DESCRIPTION
## Description

The goal of this PR is to align keypad and keyboard pages design on Figma specifications on Stax & Flex.
It also includes a new layout function to display some tests just under the header in some OS pages

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
