### PR TITLE
FWEO-1214 make alphabet letters bold again lnsp lnx

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keyboard_nanos.c
+++ b/lib_nbgl/src/nbgl_obj_keyboard_nanos.c
@@ -103,14 +103,14 @@ static void keyboardDrawChar(int16_t x0, int8_t y0, bool inverted, const char *c
     nbgl_area_t rectArea;
 
     rectArea.backgroundColor = inverted ? WHITE : BLACK;
-    rectArea.width           = nbgl_getCharWidth(BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp, charPtr);
+    rectArea.width           = nbgl_getCharWidth(BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp, charPtr);
     rectArea.height          = 12;
     rectArea.bpp             = NBGL_BPP_1;
     // center
     rectArea.x0 = x0 + (KEYBOARD_KEY_WIDTH - rectArea.width) / 2;
     rectArea.y0 = y0 + (KEYBOARD_KEY_HEIGHT - rectArea.height) / 2 - 3;
     nbgl_drawText(
-        &rectArea, charPtr, 1, BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp, inverted ? BLACK : WHITE);
+        &rectArea, charPtr, 1, BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp, inverted ? BLACK : WHITE);
 }
 
 static void keyboardDrawCommon(nbgl_keyboard_t *keyboard)


### PR DESCRIPTION
## Description

This PR aims to make the alphabet letter bold again during the onboarding stages of nanos.
[(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
](https://ledgerhq.atlassian.net/browse/FWEO-1214)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
