### PR TITLE
Fix BOLOS_UX_IO_RESET message when app boots

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -418,7 +418,15 @@ void io_seproxyhal_init(void)
     // Warn UX layer of io reset to avoid unwanted pin lock
     memset(&G_ux_params, 0, sizeof(G_ux_params));
     G_ux_params.ux_id = BOLOS_UX_IO_RESET;
-    os_ux(&G_ux_params);
+
+    // If the app has just been booted from the UX, multiple os_ux calls may be necessary
+    // to ensure UX layer has take the BOLOS_UX_IO_RESET instruction into account.
+    for (uint8_t i = 0; i < 2; i++) {
+        os_ux(&G_ux_params);
+        if (os_sched_last_status(TASK_BOLOS_UX) == BOLOS_UX_OK) {
+            break;
+        }
+    }
 #endif
 
     // wipe the io structure before it's used


### PR DESCRIPTION
- The `BOLOS_UX_IO_RESET` allows to avoid unwanted PIN lock when USB layer is reinited
- A defect in the OS make the very first `os_ux` message ignored

Re-send the message allows to ensure the BOLOS_UX_IO_RESET message is received by the UX layer.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)