### PR TITLE
Fweo 1215 removed app product id switching

### DIFF
--- a/lib_stusb_impl/usbd_impl.c
+++ b/lib_stusb_impl/usbd_impl.c
@@ -758,11 +758,7 @@ static uint8_t const USBD_DeviceDesc[]= {
   USB_MAX_EP0_SIZE,           /* bMaxPacketSize */
   LOBYTE(USBD_VID),           /* idVendor */
   HIBYTE(USBD_VID),           /* idVendor */
-#if defined(HAVE_VID_PID_PROBER) || defined(HAVE_LEGACY_PID)
   LOBYTE(USBD_PID),           /* idProduct */
-#else  // HAVE_VID_PID_PROBER || defined(HAVE_LEGACY_PID)
-  LOBYTE(USBD_PID),
-#endif // HAVE_VID_PID_PROBER || HAVE_LEGACY_PID
   HIBYTE(USBD_PID),           /* idProduct */
 
   // Change this ID to make windows WINUSB/WEBUSB reenumerate when the

--- a/lib_stusb_impl/usbd_impl.c
+++ b/lib_stusb_impl/usbd_impl.c
@@ -761,25 +761,9 @@ static uint8_t const USBD_DeviceDesc[]= {
 #if defined(HAVE_VID_PID_PROBER) || defined(HAVE_LEGACY_PID)
   LOBYTE(USBD_PID),           /* idProduct */
 #else  // HAVE_VID_PID_PROBER || defined(HAVE_LEGACY_PID)
-  LOBYTE(USBD_PID
-#ifndef HAVE_USB_HIDKBD
-    | 0x01
-#else
-    | 0x02
-#endif
-#ifdef HAVE_IO_U2F
-    | 0x04
-#endif // HAVE_IO_U2F
-#ifdef HAVE_USB_CLASS_CCID
-    | 0x08
-#endif // HAVE_USB_CLASS_CCID
-#ifdef HAVE_WEBUSB
-    | 0x10
-#endif // HAVE_WEBUSB
-  ),
+  LOBYTE(USBD_PID),
 #endif // HAVE_VID_PID_PROBER || HAVE_LEGACY_PID
   HIBYTE(USBD_PID),           /* idProduct */
-
 
   // Change this ID to make windows WINUSB/WEBUSB reenumerate when the
   // descriptor changes and the PID/VID are not changed.


### PR DESCRIPTION
## Description

This PR aims to fix the VID switching when applications are started. The VID differ from dashboard and running app.
(And mention any links to an issue [docs](https://ledgerhq.atlassian.net/browse/FWEO-1215))

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
