### PR TITLE
Automatic computation of number of items per settings page

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -67,6 +67,16 @@ extern "C" {
 
 #define NB_MAX_LINES NB_MAX_LINES_IN_DETAILS
 
+#ifdef TARGET_STAX
+#define PRE_TEXT_MARGIN     32
+#define TEXT_SUBTEXT_MARGIN 16
+#define POST_SUBTEXT_MARGIN 28
+#else  // TARGET_STAX
+#define PRE_TEXT_MARGIN     28
+#define TEXT_SUBTEXT_MARGIN 14
+#define POST_SUBTEXT_MARGIN 26
+#endif  // TARGET_STAX
+
 #else  // HAVE_SE_TOUCH
 // 7 pixels on each side
 #define AVAILABLE_WIDTH (SCREEN_WIDTH - 2 * 7)

--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -64,6 +64,11 @@ extern "C" {
 #define TAG_VALUE_AREA_HEIGHT (SCREEN_HEIGHT - SMALL_CENTERING_HEADER - SIMPLE_FOOTER_HEIGHT)
 
 /**
+ *  @brief height available for infos pairs display
+ */
+#define INFOS_AREA_HEIGHT (SCREEN_HEIGHT - TOUCHABLE_HEADER_BAR_HEIGHT)
+
+/**
  *  @brief Default strings used in the Home tagline
  */
 #define TAGLINE_PART1 "This app enables signing\ntransactions on the"
@@ -303,6 +308,22 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                           nbPai
                                          const nbgl_contentTagValueList_t *tagValueList,
                                          uint8_t                           startIndex,
                                          bool                             *requireSpecificDisplay);
+uint8_t nbgl_useCaseGetNbInfosInPage(uint8_t                       nbInfos,
+                                     const nbgl_contentInfoList_t *infosList,
+                                     uint8_t                       startIndex,
+                                     bool                          withNav);
+uint8_t nbgl_useCaseGetNbSwitchesInPage(uint8_t                           nbSwitches,
+                                        const nbgl_contentSwitchesList_t *switchesList,
+                                        uint8_t                           startIndex,
+                                        bool                              withNav);
+uint8_t nbgl_useCaseGetNbBarsInPage(uint8_t                       nbBars,
+                                    const nbgl_contentBarsList_t *barsList,
+                                    uint8_t                       startIndex,
+                                    bool                          withNav);
+uint8_t nbgl_useCaseGetNbChoicesInPage(uint8_t                          nbChoices,
+                                       const nbgl_contentRadioChoice_t *choicesList,
+                                       uint8_t                          startIndex,
+                                       bool                             withNav);
 uint8_t nbgl_useCaseGetNbPagesForTagValueList(const nbgl_contentTagValueList_t *tagValueList);
 
 // use case drawing

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1212,20 +1212,16 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     if (text != NULL) {
         textArea = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
 
-        textArea->textColor     = BLACK;
-        textArea->text          = PIC(text);
-        textArea->textAlignment = MID_LEFT;
-        textArea->fontId        = SMALL_BOLD_FONT;
-        textArea->style         = NO_STYLE;
-        textArea->wrapping      = true;
-        textArea->obj.alignment = NO_ALIGNMENT;
-#ifdef TARGET_STAX
-        textArea->obj.alignmentMarginY = 32;
-#else   // TARGET_STAX
-        textArea->obj.alignmentMarginY           = 28;
-#endif  // TARGET_STAX
-        textArea->obj.area.width  = container->obj.area.width;
-        textArea->obj.area.height = nbgl_getTextHeightInWidth(
+        textArea->textColor            = BLACK;
+        textArea->text                 = PIC(text);
+        textArea->textAlignment        = MID_LEFT;
+        textArea->fontId               = SMALL_BOLD_FONT;
+        textArea->style                = NO_STYLE;
+        textArea->wrapping             = true;
+        textArea->obj.alignment        = NO_ALIGNMENT;
+        textArea->obj.alignmentMarginY = PRE_TEXT_MARGIN;
+        textArea->obj.area.width       = container->obj.area.width;
+        textArea->obj.area.height      = nbgl_getTextHeightInWidth(
             textArea->fontId, textArea->text, textArea->obj.area.width, textArea->wrapping);
         fullHeight += textArea->obj.area.height + textArea->obj.alignmentMarginY;
         container->children[container->nbChildren] = (nbgl_obj_t *) textArea;
@@ -1246,13 +1242,8 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
         subTextArea->textAlignment   = MID_LEFT;
         subTextArea->obj.alignment   = NO_ALIGNMENT;
         if (text != NULL) {
-#ifdef TARGET_STAX
-            subTextArea->obj.alignmentMarginY = 16;
-            fullHeight += 28;  // under the subText
-#else                          // TARGET_STAX
-            subTextArea->obj.alignmentMarginY = 14;
-            fullHeight += 26;  // under the subText
-#endif                         // TARGET_STAX
+            subTextArea->obj.alignmentMarginY = TEXT_SUBTEXT_MARGIN;
+            fullHeight += POST_SUBTEXT_MARGIN;  // under the subText
         }
         else {
 #ifdef TARGET_STAX
@@ -1268,11 +1259,7 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
         fullHeight += subTextArea->obj.area.height + subTextArea->obj.alignmentMarginY;
     }
     else {
-#ifdef TARGET_STAX
-        fullHeight += 32;
-#else   // TARGET_STAX
-        fullHeight += 28;
-#endif  // TARGET_STAX
+        fullHeight += PRE_TEXT_MARGIN;
     }
     container->obj.area.height      = fullHeight;
     container->layout               = VERTICAL;


### PR DESCRIPTION
## Description

The goal of this PR is to enable automatic computation of number of items per settings page, to optimize this number and avoid static values

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

