### PR TITLE
Remove old usb hack

### DIFF
--- a/lib_stusb_impl/usbd_impl.c
+++ b/lib_stusb_impl/usbd_impl.c
@@ -933,15 +933,6 @@ uint8_t *USBD_HID_GetReportDescriptor_impl(uint16_t *len)
     switch (USBD_Device.request.wIndex & 0xFF) {
 #ifdef HAVE_IO_U2F
         case U2F_INTF:
-
-            // very dirty work due to lack of callback when USB_HID_Init is called
-            USBD_LL_OpenEP(&USBD_Device, U2F_EPIN_ADDR, USBD_EP_TYPE_INTR, U2F_EPIN_SIZE);
-
-            USBD_LL_OpenEP(&USBD_Device, U2F_EPOUT_ADDR, USBD_EP_TYPE_INTR, U2F_EPOUT_SIZE);
-
-            /* Prepare Out endpoint to receive 1st packet */
-            USBD_LL_PrepareReceive(&USBD_Device, U2F_EPOUT_ADDR, U2F_EPOUT_SIZE);
-
             *len = sizeof(HID_ReportDesc_fido);
             return (uint8_t *) HID_ReportDesc_fido;
 #endif  // HAVE_IO_U2F


### PR DESCRIPTION
## Description

Don't re-configure u2f endpoints every time the host sends a GetDescriptor

(cherry picked from commit c49427fe2abe36667d81b2c8996dfe1961128ffa)

Next tag on API_LEVEL_18 will be: `v18.4.1`

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
