### PR TITLE
Remove language dependency from NBGL

### DIFF
--- a/lib_nbgl/include/nbgl_fonts.h
+++ b/lib_nbgl/include/nbgl_fonts.h
@@ -15,12 +15,19 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include "nbgl_types.h"
+#ifdef HAVE_LANGUAGE_PACK
+#include "ux_loc_nbgl.h"
+#endif  // HAVE_LANGUAGE_PACK
 
 /*********************
  *      DEFINES
  *********************/
 #define PIC_CHAR(x) ((const nbgl_font_character_t *) PIC(x))
 #define PIC_BMP(x)  ((uint8_t const *) PIC(x))
+
+#ifndef HAVE_LANGUAGE_PACK
+#define LANGUAGE_PACK void
+#endif  // HAVE_LANGUAGE_PACK
 
 /**
  * @brief fonts nicknames to be used for various wallet size targets (non-Nano)
@@ -212,9 +219,7 @@ uint32_t nbgl_popUnicodeChar(const uint8_t **text, uint16_t *text_length, bool *
 nbgl_unicode_ctx_t                  *nbgl_getUnicodeFont(nbgl_font_id_e font_id);
 const nbgl_font_unicode_character_t *nbgl_getUnicodeFontCharacter(uint32_t unicode);
 uint32_t                             nbgl_getUnicodeFontCharacterByteCount(void);
-#ifdef HAVE_LANGUAGE_PACK
-void nbgl_refreshUnicodeFont(void);
-#endif
+void                                 nbgl_refreshUnicodeFont(const LANGUAGE_PACK *lp);
 #endif  // HAVE_UNICODE_SUPPORT
 
 /**********************

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -393,18 +393,15 @@ typedef char *(*onTextDrawCallback_t)(uint8_t token);
  *
  */
 typedef struct PACKED__ nbgl_button_s {
-    nbgl_obj_t obj;              ///< common part
-    color_t    innerColor;       ///< color set inside of the button
-    color_t    borderColor;      ///< color set to button's border
-    color_t    foregroundColor;  ///< color set to '1' bits in icon, and text. '0' are set to
-                                 ///< innerColor color.
-    nbgl_radius_t  radius;       ///< radius of the corners, must be a multiple of 4.
-    nbgl_font_id_e fontId;       ///< id of the font to use, if any
-    bool        localized;  ///< if set to true, means the following 'text' field is considered as a
-    const char *text;       ///< single line UTF-8 text (NULL terminated)
-#ifdef HAVE_LANGUAGE_PACK
-    UX_LOC_STRINGS_INDEX textId;          ///< id of the text single line UTF-8 text
-#endif                                    // HAVE_LANGUAGE_PACK
+    nbgl_obj_t obj;                  ///< common part
+    color_t    innerColor;           ///< color set inside of the button
+    color_t    borderColor;          ///< color set to button's border
+    color_t    foregroundColor;      ///< color set to '1' bits in icon, and text. '0' are set to
+                                     ///< innerColor color.
+    nbgl_radius_t        radius;     ///< radius of the corners, must be a multiple of 4.
+    nbgl_font_id_e       fontId;     ///< id of the font to use, if any
+    bool                 localized;  ///< unused, kept for compatibility
+    const char          *text;       ///< single line UTF-8 text (NULL terminated)
     onTextDrawCallback_t onDrawCallback;  ///< function called if not NULL, with above token as
                                           ///< parameter to get the text of the button
     uint8_t                    token;     ///< token to use as param of onDrawCallback
@@ -421,7 +418,6 @@ typedef struct PACKED__ nbgl_text_area_s {
     nbgl_aligment_t textAlignment;  ///< alignment of text within the area
     nbgl_style_t    style;          ///< to define the style of border
     nbgl_font_id_e  fontId;         ///< id of the font to use
-    bool            localized;      ///< if set to true, use textId instead of text
     bool autoHideLongLine;  ///< if set to true, replace beginning of line by ... to keep it single
                             ///< line
     bool    wrapping;       ///< if set to true, break lines on ' ' when possible
@@ -429,9 +425,6 @@ typedef struct PACKED__ nbgl_text_area_s {
                          ///< stop display here
     const char *text;    ///< ASCII text to draw (NULL terminated). Can be NULL.
     uint16_t    len;     ///< number of bytes to write (if 0, max number of chars or strlen is used)
-#ifdef HAVE_LANGUAGE_PACK
-    UX_LOC_STRINGS_INDEX textId;  ///< id of the  UTF-8 text
-#endif                            // HAVE_LANGUAGE_PACK
     onTextDrawCallback_t
             onDrawCallback;  ///< function called if not NULL to get the text of the text area
     uint8_t token;           ///< token to use as param of onDrawCallback

--- a/lib_nbgl/src/nbgl_draw.c
+++ b/lib_nbgl/src/nbgl_draw.c
@@ -546,6 +546,9 @@ nbgl_font_id_e nbgl_drawText(const nbgl_area_t *area,
     int16_t            x = area->x0;
     nbgl_area_t        rectArea;
     const nbgl_font_t *font = nbgl_getFont(fontId);
+#ifdef HAVE_UNICODE_SUPPORT
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
+#endif  // HAVE_UNICODE_SUPPORT
 
     LOG_DEBUG(DRAW_LOGGER,
               "nbgl_drawText: x0 = %d, y0 = %d, w = %d, h = %d, fontColor = %d, "
@@ -557,10 +560,6 @@ nbgl_font_id_e nbgl_drawText(const nbgl_area_t *area,
               fontColor,
               area->backgroundColor,
               text);
-
-#ifdef HAVE_UNICODE_SUPPORT
-    nbgl_unicode_ctx_t *unicode_ctx = nbgl_getUnicodeFont(fontId);
-#endif  // HAVE_UNICODE_SUPPORT
 
     rectArea.backgroundColor = area->backgroundColor;
     rectArea.bpp             = (nbgl_bpp_t) font->bpp;
@@ -583,6 +582,9 @@ nbgl_font_id_e nbgl_drawText(const nbgl_area_t *area,
 
         if (is_unicode) {
 #ifdef HAVE_UNICODE_SUPPORT
+            if (unicode_ctx == NULL) {
+                unicode_ctx = nbgl_getUnicodeFont(fontId);
+            }
             const nbgl_font_unicode_character_t *unicodeCharacter
                 = nbgl_getUnicodeFontCharacter(unicode);
             // if not supported char, go to next one

--- a/lib_nbgl/src/nbgl_fonts.c
+++ b/lib_nbgl/src/nbgl_fonts.c
@@ -40,9 +40,9 @@ static nbgl_unicode_ctx_t unicodeCtx = {0};
  *      VARIABLES
  **********************/
 
-#if defined(HAVE_LANGUAGE_PACK)
-extern const LANGUAGE_PACK *language_pack;
-#endif  // defined(HAVE_LANGUAGE_PACK)
+#ifdef HAVE_LANGUAGE_PACK
+static const LANGUAGE_PACK *language_pack;
+#endif  // HAVE_LANGUAGE_PACK
 
 #if defined(BOLOS_OS_UPGRADER_APP)
 #ifdef SCREEN_SIZE_WALLET
@@ -248,15 +248,15 @@ static uint16_t getTextWidth(nbgl_font_id_e fontId,
     uint16_t           max_width  = 0;
     const nbgl_font_t *font       = nbgl_getFont(fontId);
     uint16_t           textLen    = MIN(strlen(text), maxLen);
+#ifdef HAVE_UNICODE_SUPPORT
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
+#endif  // HAVE_UNICODE_SUPPORT
 
 #ifdef BUILD_SCREENSHOTS
     last_bold_state      = fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;  // True if Bold
     bool next_bold_state = last_bold_state;
 #endif  // BUILD_SCREENSHOTS
 
-#ifdef HAVE_UNICODE_SUPPORT
-    nbgl_getUnicodeFont(fontId);
-#endif  // HAVE_UNICODE_SUPPORT
     // end loop text len is NULL (max reached)
     while (textLen) {
         uint8_t  char_width;
@@ -264,6 +264,11 @@ static uint16_t getTextWidth(nbgl_font_id_e fontId,
         bool     is_unicode;
 
         unicode = nbgl_popUnicodeChar((const uint8_t **) &text, &textLen, &is_unicode);
+#ifdef HAVE_UNICODE_SUPPORT
+        if (is_unicode && !unicode_ctx) {
+            unicode_ctx = nbgl_getUnicodeFont(fontId);
+        }
+#endif
         if (unicode == '\n') {
             if (breakOnLineEnd) {
                 break;
@@ -277,7 +282,7 @@ static uint16_t getTextWidth(nbgl_font_id_e fontId,
             if (fontId == BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp) {  // switch to bold
                 fontId = BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
 #ifdef BUILD_SCREENSHOTS
@@ -287,7 +292,7 @@ static uint16_t getTextWidth(nbgl_font_id_e fontId,
             else if (fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp) {  // switch to regular
                 fontId = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
 #ifdef BUILD_SCREENSHOTS
@@ -370,12 +375,16 @@ uint8_t nbgl_getCharWidth(nbgl_font_id_e fontId, const char *text)
     uint32_t           unicode;
     bool               is_unicode;
     uint16_t           textLen = 4;  // max len for a char
-
 #ifdef HAVE_UNICODE_SUPPORT
-    nbgl_getUnicodeFont(fontId);
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
 
     unicode = nbgl_popUnicodeChar((const uint8_t **) &text, &textLen, &is_unicode);
+#ifdef HAVE_UNICODE_SUPPORT
+    if (is_unicode && !unicode_ctx) {
+        unicode_ctx = nbgl_getUnicodeFont(fontId);
+    }
+#endif
 
     return getCharWidth(font, unicode, is_unicode);
 }
@@ -480,9 +489,8 @@ void nbgl_getTextMaxLenAndWidth(nbgl_font_id_e fontId,
     const nbgl_font_t *font               = nbgl_getFont(fontId);
     uint16_t           textLen            = nbgl_getTextLength(text);
     uint32_t           lenAtLastDelimiter = 0, widthAtlastDelimiter = 0;
-
 #ifdef HAVE_UNICODE_SUPPORT
-    nbgl_getUnicodeFont(fontId);
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
 
     *width = 0;
@@ -494,6 +502,11 @@ void nbgl_getTextMaxLenAndWidth(nbgl_font_id_e fontId,
         uint16_t curTextLen = textLen;
 
         unicode = nbgl_popUnicodeChar((const uint8_t **) &text, &textLen, &is_unicode);
+#ifdef HAVE_UNICODE_SUPPORT
+        if (is_unicode && !unicode_ctx) {
+            unicode_ctx = nbgl_getUnicodeFont(fontId);
+        }
+#endif
         // if \f or \n, exit loop
         if ((unicode == '\f') || (unicode == '\n')) {
             *len += curTextLen - textLen;
@@ -504,14 +517,14 @@ void nbgl_getTextMaxLenAndWidth(nbgl_font_id_e fontId,
             if (fontId == BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp) {  // switch to bold
                 fontId = BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
             }
             else if (fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp) {  // switch to regular
                 fontId = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
             }
@@ -570,9 +583,8 @@ bool nbgl_getTextMaxLenInNbLines(nbgl_font_id_e fontId,
     uint32_t           lenAtLastDelimiter = 0;
     const char        *origText           = text;
     const char        *previousText;
-
 #ifdef HAVE_UNICODE_SUPPORT
-    nbgl_getUnicodeFont(fontId);
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
 
     while ((textLen) && (maxNbLines > 0)) {
@@ -582,6 +594,11 @@ bool nbgl_getTextMaxLenInNbLines(nbgl_font_id_e fontId,
 
         previousText = text;
         unicode      = nbgl_popUnicodeChar((const uint8_t **) &text, &textLen, &is_unicode);
+#ifdef HAVE_UNICODE_SUPPORT
+        if (is_unicode && !unicode_ctx) {
+            unicode_ctx = nbgl_getUnicodeFont(fontId);
+        }
+#endif
         // memorize cursors at last found delimiter
         if ((wrapping == true) && (IS_WORD_DELIM(unicode))) {
             lastDelimiter      = text;
@@ -604,14 +621,14 @@ bool nbgl_getTextMaxLenInNbLines(nbgl_font_id_e fontId,
             if (fontId == BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp) {  // switch to bold
                 fontId = BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
             }
             else if (fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp) {  // switch to regular
                 fontId = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
             }
@@ -723,6 +740,9 @@ uint16_t nbgl_getTextNbLinesInWidth(nbgl_font_id_e fontId,
     const char *lastDelimiter      = NULL;
     uint32_t    lenAtLastDelimiter = 0;
     const char *prevText           = NULL;
+#ifdef HAVE_UNICODE_SUPPORT
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
+#endif  // HAVE_UNICODE_SUPPORT
 
 #ifdef BUILD_SCREENSHOTS
     hard_caesura         = false;
@@ -732,9 +752,6 @@ uint16_t nbgl_getTextNbLinesInWidth(nbgl_font_id_e fontId,
     bool next_bold_state = last_bold_state;
 #endif  // BUILD_SCREENSHOTS
 
-#ifdef HAVE_UNICODE_SUPPORT
-    nbgl_getUnicodeFont(fontId);
-#endif  // HAVE_UNICODE_SUPPORT
     // end loop when a '\0' is uncountered
     while (textLen) {
         uint8_t  char_width;
@@ -744,6 +761,11 @@ uint16_t nbgl_getTextNbLinesInWidth(nbgl_font_id_e fontId,
         // memorize the last char
         prevText = text;
         unicode  = nbgl_popUnicodeChar((const uint8_t **) &text, &textLen, &is_unicode);
+#ifdef HAVE_UNICODE_SUPPORT
+        if (is_unicode && !unicode_ctx) {
+            unicode_ctx = nbgl_getUnicodeFont(fontId);
+        }
+#endif
 
         // memorize cursors at last found space
         if ((wrapping == true) && (IS_WORD_DELIM(unicode))) {
@@ -778,7 +800,7 @@ uint16_t nbgl_getTextNbLinesInWidth(nbgl_font_id_e fontId,
             if (fontId == BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp) {  // switch to bold
                 fontId = BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
 #ifdef BUILD_SCREENSHOTS
@@ -788,7 +810,7 @@ uint16_t nbgl_getTextNbLinesInWidth(nbgl_font_id_e fontId,
             else if (fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp) {  // switch to regular
                 fontId = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
 #ifdef BUILD_SCREENSHOTS
@@ -869,6 +891,9 @@ uint8_t nbgl_getTextNbPagesInWidth(nbgl_font_id_e fontId,
     const char        *lastDelimiter      = NULL;
     uint32_t           lenAtLastDelimiter = 0;
     const char        *prevText           = NULL;
+#ifdef HAVE_UNICODE_SUPPORT
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
+#endif  // HAVE_UNICODE_SUPPORT
 
 #ifdef BUILD_SCREENSHOTS
     last_nb_lines        = nbLines;
@@ -876,9 +901,6 @@ uint8_t nbgl_getTextNbPagesInWidth(nbgl_font_id_e fontId,
     last_bold_state      = fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;  // True if Bold
     bool next_bold_state = last_bold_state;
 #endif  // BUILD_SCREENSHOTS
-#ifdef HAVE_UNICODE_SUPPORT
-    nbgl_getUnicodeFont(fontId);
-#endif  // HAVE_UNICODE_SUPPORT
     // end loop when a '\0' is uncountered
     while (textLen) {
         uint8_t  char_width;
@@ -888,6 +910,11 @@ uint8_t nbgl_getTextNbPagesInWidth(nbgl_font_id_e fontId,
         // memorize the last char
         prevText = text;
         unicode  = nbgl_popUnicodeChar((const uint8_t **) &text, &textLen, &is_unicode);
+#ifdef HAVE_UNICODE_SUPPORT
+        if (is_unicode && !unicode_ctx) {
+            unicode_ctx = nbgl_getUnicodeFont(fontId);
+        }
+#endif
 
         // memorize cursors at last found space
         if (IS_WORD_DELIM(unicode)) {
@@ -935,7 +962,7 @@ uint8_t nbgl_getTextNbPagesInWidth(nbgl_font_id_e fontId,
             if (fontId == BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp) {  // switch to bold
                 fontId = BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
 #ifdef BUILD_SCREENSHOTS
@@ -945,7 +972,7 @@ uint8_t nbgl_getTextNbPagesInWidth(nbgl_font_id_e fontId,
             else if (fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp) {  // switch to regular
                 fontId = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                nbgl_getUnicodeFont(fontId);
+                unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                 font = nbgl_getFont(fontId);
 #ifdef BUILD_SCREENSHOTS
@@ -1043,10 +1070,9 @@ void nbgl_textWrapOnNbLines(nbgl_font_id_e fontId, char *text, uint16_t maxWidth
     char              *lastDelimiter      = NULL;
     uint32_t           lenAtLastDelimiter = 0;
     char              *prevText           = NULL;
-
 #ifdef HAVE_UNICODE_SUPPORT
-    nbgl_getUnicodeFont(fontId);
-#endif
+    nbgl_unicode_ctx_t *unicode_ctx = NULL;
+#endif  // HAVE_UNICODE_SUPPORT
 
     while (*text) {
         uint8_t  char_width;
@@ -1065,7 +1091,11 @@ void nbgl_textWrapOnNbLines(nbgl_font_id_e fontId, char *text, uint16_t maxWidth
             lastDelimiter = NULL;
             continue;
         }
-
+#ifdef HAVE_UNICODE_SUPPORT
+        if (is_unicode && !unicode_ctx) {
+            unicode_ctx = nbgl_getUnicodeFont(fontId);
+        }
+#endif
         char_width = getCharWidth(font, unicode, is_unicode);
         if (char_width == 0) {
             continue;
@@ -1295,9 +1325,11 @@ uint32_t nbgl_getUnicodeFontCharacterByteCount(void)
  * to be sure that the current unicodeCtx variable will be set again at next @ref
  * nbgl_getUnicodeFont() call
  *
+ * @param lp new language pack to apply
  */
-void nbgl_refreshUnicodeFont(void)
+void nbgl_refreshUnicodeFont(const LANGUAGE_PACK *lp)
 {
+    language_pack         = lp;
     unicodeCtx.font       = NULL;
     unicodeCtx.characters = NULL;
 }

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -117,6 +117,7 @@ static uint8_t nbTouchableControls = 0;
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+extern const char *get_ux_loc_string(uint32_t index);
 
 #ifdef HAVE_FAST_HOLD_TO_APPROVE
 // Unit step in % of touchable progress bar
@@ -987,7 +988,6 @@ int nbgl_layoutAddSwipe(nbgl_layout_t *layout,
     if (text) {
         // create 'tap to continue' text area
         layoutInt->tapText                  = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, 0);
-        layoutInt->tapText->localized       = false;
         layoutInt->tapText->text            = PIC(text);
         layoutInt->tapText->textColor       = DARK_GRAY;
         layoutInt->tapText->fontId          = SMALL_REGULAR_FONT;
@@ -1491,9 +1491,8 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
 
         // init text area for this choice
         if (choices->localized == true) {
-            textArea->localized = true;
 #ifdef HAVE_LANGUAGE_PACK
-            textArea->textId = choices->nameIds[i];
+            textArea->text = get_ux_loc_string(choices->nameIds[i]);
 #endif  // HAVE_LANGUAGE_PACK
         }
         else {

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -366,13 +366,6 @@ static void draw_button(nbgl_button_t *obj, nbgl_obj_t *prevObj, bool computePos
     if (obj->onDrawCallback != NULL) {
         obj->text = obj->onDrawCallback(obj->token);
     }
-    else {
-        if (obj->localized == true) {
-#if defined(HAVE_LANGUAGE_PACK)
-            obj->text = get_ux_loc_string(obj->textId);
-#endif  // HAVE_LANGUAGE_PACK
-        }
-    }
     text = obj->text;
     // draw the text (right of the icon, with 8 pixels between them)
     if (text != NULL) {
@@ -865,13 +858,6 @@ static void draw_textArea(nbgl_text_area_t *obj, nbgl_obj_t *prevObj, bool compu
     // get the text of the button from the callback if not NULL
     if (obj->onDrawCallback != NULL) {
         obj->text = obj->onDrawCallback(obj->token);
-    }
-    else {
-        if (obj->localized == true) {
-#if defined(HAVE_LANGUAGE_PACK)
-            obj->text = get_ux_loc_string(obj->textId);
-#endif  // HAVE_LANGUAGE_PACK
-        }
     }
     text = obj->text;
     if (text == NULL) {

--- a/lib_nbgl/src/nbgl_serialize.c
+++ b/lib_nbgl/src/nbgl_serialize.c
@@ -197,7 +197,7 @@ static void nbgl_serializeTextArea(nbgl_text_area_t *obj,
     nbgl_appendU8((uint8_t) obj->textAlignment, out, w_cnt, max_len);
     nbgl_appendU8((uint8_t) obj->style, out, w_cnt, max_len);
     nbgl_appendU8((uint8_t) obj->fontId, out, w_cnt, max_len);
-    nbgl_appendU8((uint8_t) obj->localized, out, w_cnt, max_len);
+    nbgl_appendU8(0, out, w_cnt, max_len);
     nbgl_appendU8((uint8_t) obj->autoHideLongLine, out, w_cnt, max_len);
     nbgl_appendU16((uint16_t) obj->len, out, w_cnt, max_len);
 
@@ -272,7 +272,7 @@ static void nbgl_serializeButton(nbgl_button_t *obj, uint8_t *out, size_t *w_cnt
     nbgl_appendU8((uint8_t) obj->foregroundColor, out, w_cnt, max_len);
     nbgl_appendU8((uint8_t) obj->radius, out, w_cnt, max_len);
     nbgl_appendU8((uint8_t) obj->fontId, out, w_cnt, max_len);
-    nbgl_appendU8((uint8_t) obj->localized, out, w_cnt, max_len);
+    nbgl_appendU8(0, out, w_cnt, max_len);
     nbgl_serializeText(PIC(obj->text), 0, out, w_cnt, max_len);
     nbgl_serializeIcon(PIC(obj->icon), out, w_cnt, max_len);
 }

--- a/unit-tests/lib_nbgl/CMakeLists.txt
+++ b/unit-tests/lib_nbgl/CMakeLists.txt
@@ -77,8 +77,8 @@ add_library(nbgl_screen SHARED ../../lib_nbgl/src/nbgl_screen.c)
 add_library(nbgl_obj SHARED ../../lib_nbgl/src/nbgl_obj.c)
 
 target_link_libraries(test_nbgl_fonts PUBLIC cmocka gcov nbgl_fonts nbgl_stubs)
-target_link_libraries(test_nbgl_obj_pool PUBLIC cmocka gcov nbgl_obj_pool nbgl_stubs)
-target_link_libraries(test_nbgl_screen PUBLIC cmocka gcov nbgl_screen nbgl_obj_pool nbgl_stubs)
+target_link_libraries(test_nbgl_obj_pool PUBLIC cmocka gcov nbgl_obj_pool)
+target_link_libraries(test_nbgl_screen PUBLIC cmocka gcov nbgl_screen nbgl_obj_pool)
 target_link_libraries(test_nbgl_obj PUBLIC cmocka gcov nbgl_obj nbgl_screen nbgl_obj_pool nbgl_fonts nbgl_stubs)
 
 add_test(test_nbgl_fonts test_nbgl_fonts)

--- a/unit-tests/lib_nbgl/nbgl_stubs.c
+++ b/unit-tests/lib_nbgl/nbgl_stubs.c
@@ -50,6 +50,7 @@ void fetch_language_packs(void)
         fclose(fptr);
 
         language_pack = (LANGUAGE_PACK *) source;
+        nbgl_refreshUnicodeFont(language_pack);
     }
 }
 

--- a/unit-tests/lib_nbgl/test_nbgl_screen.c
+++ b/unit-tests/lib_nbgl/test_nbgl_screen.c
@@ -15,6 +15,11 @@
 
 unsigned long gLogger = 0;
 
+void *pic(void *addr)
+{
+    return addr;
+}
+
 void mainExit(int exitCode)
 {
     exit(exitCode);


### PR DESCRIPTION
## Description

The goal of this PR is to remove the dependency existing between NBGL and languages:
- ids used to identify localized strings
- Global language_pack variable used in Fonts management library

This is a first necessary step to use NBGL as a common library for OS and Apps.

It only breaks compatibility with the OS (removed field in some objects, and nbgl_refreshUnicodeFont() prototype changed)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [*] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

