### PR TITLE
Fix character loss in detail pairs with text wrapping enabled

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1053,8 +1053,8 @@ static void displayDetailsPage(uint8_t detailsPage, bool forceFullRefresh)
         currentPair.value = detailsContext.nextPageStart;
     }
     detailsContext.currentPage = detailsPage;
-    uint16_t nbLines
-        = nbgl_getTextNbLinesInWidth(SMALL_BOLD_FONT, currentPair.value, AVAILABLE_WIDTH, false);
+    uint16_t nbLines           = nbgl_getTextNbLinesInWidth(
+        SMALL_BOLD_FONT, currentPair.value, AVAILABLE_WIDTH, detailsContext.wrapping);
 
     if (nbLines > NB_MAX_LINES_IN_DETAILS) {
         uint16_t len;
@@ -1063,7 +1063,7 @@ static void displayDetailsPage(uint8_t detailsPage, bool forceFullRefresh)
                                     AVAILABLE_WIDTH,
                                     NB_MAX_LINES_IN_DETAILS,
                                     &len,
-                                    false);
+                                    detailsContext.wrapping);
         len -= 3;
         // memorize next position to save processing
         detailsContext.nextPageStart = currentPair.value + len;


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://github.com/LedgerHQ/ledger-secure-sdk/issues/749 by using the "wrapping" field of Details Context instead of forcing it to false by mistake, for calculation.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

