### PR TITLE
Fix missing lines in long tag/values, with no "More" button

### DIFF
--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -49,7 +49,11 @@ extern "C" {
 /**
  *  @brief maximum number of lines for value field in review pages
  */
-#define NB_MAX_LINES_IN_REVIEW 9
+#ifdef TARGET_STAX
+#define NB_MAX_LINES_IN_REVIEW 11
+#else  // TARGET_STAX
+#define NB_MAX_LINES_IN_REVIEW 10
+#endif  // TARGET_STAX
 
 /**
  *  @brief maximum number of simultaneously displayed pairs in review pages.

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1888,6 +1888,7 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                           nbPai
     while (nbPairsInPage < nbPairs) {
         const nbgl_layoutTagValue_t *pair;
         nbgl_font_id_e               value_font;
+        uint16_t                     nbLines;
 
         // margin between pairs
         // 12 or 24 px between each tag/value pair
@@ -1939,7 +1940,10 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                           nbPai
         // value height
         currentHeight += nbgl_getTextHeightInWidth(
             value_font, pair->value, AVAILABLE_WIDTH, tagValueList->wrapping);
-        if (currentHeight >= TAG_VALUE_AREA_HEIGHT) {
+        // nb lines for value
+        nbLines = nbgl_getTextNbLinesInWidth(
+            value_font, pair->value, AVAILABLE_WIDTH, tagValueList->wrapping);
+        if ((currentHeight >= TAG_VALUE_AREA_HEIGHT) || (nbLines > NB_MAX_LINES_IN_REVIEW)) {
             if (nbPairsInPage == 0) {
                 // Pair too long to fit in a single screen
                 // It will be the only one of the page and has a specific display behavior


### PR DESCRIPTION
## Description

The goal of this PR is to fix missing lines in long tag/values, with no "More" button
In some specific cases, if the value field is too long to fit in the max number of lines, but not tto long to fit in the max available height, the text will be presented in shortened version (with "..."), but without "More" button enabling to see full value in a modal screen.

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
