### PR TITLE
Fix too long text shortening in details

### DIFF
--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -50,9 +50,9 @@ extern "C" {
  *  @brief maximum number of lines for value field in review pages
  */
 #ifdef TARGET_STAX
-#define NB_MAX_LINES_IN_REVIEW 11
-#else  // TARGET_STAX
 #define NB_MAX_LINES_IN_REVIEW 10
+#else  // TARGET_STAX
+#define NB_MAX_LINES_IN_REVIEW 9
 #endif  // TARGET_STAX
 
 /**

--- a/lib_nbgl/src/nbgl_fonts.c
+++ b/lib_nbgl/src/nbgl_fonts.c
@@ -608,6 +608,10 @@ bool nbgl_getTextMaxLenInNbLines(nbgl_font_id_e fontId,
         // if \n, reset width
         if (unicode == '\n') {
             maxNbLines--;
+            // if last line is reached, let's rewind before carriage return
+            if (maxNbLines == 0) {
+                text--;
+            }
             width = 0;
             continue;
         }

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1051,7 +1051,7 @@ static const char *getDetailsPageAt(uint8_t detailsPage)
                                         AVAILABLE_WIDTH,
                                         NB_MAX_LINES_IN_DETAILS,
                                         &len,
-                                        false);
+                                        detailsContext.wrapping);
             len -= 3;
             currentChar = currentChar + len;
         }


### PR DESCRIPTION
## Description

The goal of this PR is to fix 2 issues with two long "value" fields in reviews:
- In case of a "Skippable" review, the last line of value may be out of the area
- In the "Details" view, the last line may be wrongly cut (at "...") if ending with a '\n'

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
