### PR TITLE
fix: Set debug level compatible with -frwpi

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -59,7 +59,7 @@ endif
 ifneq ($(DEBUG),0)
 OPTI_LVL  = -Og
 OPTI_ALVL = $(OPTI_LVL)
-DBG_LVL   = -g3
+DBG_LVL   = -g1
 else
 OPTI_LVL  = -Oz
 OPTI_ALVL = -Os # assembler does not handle -Oz, use -Os instead


### PR DESCRIPTION
## Description

While trying to do a debug build of the boilerplate-app I stumbled upon the following BUG:
```bash
02eb8803afed:/workspaces/app-boilerplate# make -B -j COIN=BOL BOLOS_SDK=$NANOX_SDK DEBUG=1
Prepare directories
[GLYPH] Compiling...
[CC]   build/nanox/gen_src/glyphs.o
[CC]   build/nanox/obj/app/src/address.o
[CC]   build/nanox/obj/app/src/apdu/dispatcher.o
[CC]   build/nanox/obj/app/src/app_main.o
[CC]   build/nanox/obj/app/src/handler/get_app_name.o
[CC]   build/nanox/obj/app/src/handler/get_public_key.o
[CC]   build/nanox/obj/app/src/handler/get_version.o
[CC]   build/nanox/obj/app/src/handler/sign_tx.o
[CC]   build/nanox/obj/app/src/helper/send_reponse.o
[CC]   build/nanox/obj/app/src/transaction/deserialize.o
[CC]   build/nanox/obj/app/src/transaction/serialize.o
[CC]   build/nanox/obj/app/src/transaction/utils.o
[CC]   build/nanox/obj/app/src/ui/action/validate.o
[CC]   build/nanox/obj/app/src/ui/bagl_display.o
[CC]   build/nanox/obj/app/src/ui/menu_bagl.o
[CC]   build/nanox/obj/app/src/ui/menu_nbgl.o
[CC]   build/nanox/obj/app/src/ui/nbgl_display_address.o
[CC]   build/nanox/obj/app/src/ui/nbgl_display_transaction.o
[CC]   build/nanox/obj/sdk/lib_bagl/src/bagl.o
[CC]   build/nanox/obj/sdk/lib_bagl/src/bagl_animate.o
[CC]   build/nanox/obj/sdk/lib_bagl/src/bagl_fonts.o
[CC]   build/nanox/obj/sdk/lib_bagl/src/bagl_glyphs.o
[CC]   build/nanox/obj/sdk/lib_blewbxx/core/auto/ble_gap_aci.o
[CC]   build/nanox/obj/sdk/lib_blewbxx/core/auto/ble_gatt_aci.o
[CC]   build/nanox/obj/sdk/lib_blewbxx/core/auto/ble_hal_aci.o
[CC]   build/nanox/obj/sdk/lib_blewbxx/core/auto/ble_hci_le.o
[CC]   build/nanox/obj/sdk/lib_blewbxx/core/auto/ble_l2cap_aci.o
[CC]   build/nanox/obj/sdk/lib_blewbxx/core/template/osal.o
[CC]   build/nanox/obj/sdk/lib_blewbxx_impl/src/ledger_ble.o
[CC]   build/nanox/obj/sdk/lib_standard_app/base58.o
[CC]   build/nanox/obj/sdk/lib_standard_app/bip32.o
[CC]   build/nanox/obj/sdk/lib_standard_app/buffer.o
[CC]   build/nanox/obj/sdk/lib_standard_app/crypto_helpers.o
[CC]   build/nanox/obj/sdk/lib_standard_app/format.o
[CC]   build/nanox/obj/sdk/lib_standard_app/io.o
[CC]   build/nanox/obj/sdk/lib_standard_app/main.o
[CC]   build/nanox/obj/sdk/lib_standard_app/parser.o
/opt/nanox-secure-sdk/lib_standard_app/main.c:73:21: warning: variable 'e' set but not used [-Wunused-but-set-variable]
   73 |         CATCH_OTHER(e)
      |                     ^
[CC]   build/nanox/obj/sdk/lib_standard_app/read.o
1 warning generated.
[CC]   build/nanox/obj/sdk/lib_standard_app/swap_utils.o
[CC]   build/nanox/obj/sdk/lib_standard_app/varint.o
[CC]   build/nanox/obj/sdk/lib_standard_app/write.o
[CC]   build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_cmd.o
[CC]   build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_core.o
[CC]   build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Class/CCID/src/usbd_ccid_if.o
[CC]   build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.o
[CC]   build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Core/Src/usbd_core.o
[CC]   build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.o
[CC]   build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Core/Src/usbd_ioreq.o
[CC]   build/nanox/obj/sdk/lib_stusb/usbd_conf.o
[CC]   build/nanox/obj/sdk/lib_stusb_impl/u2f_impl.o
[CC]   build/nanox/obj/sdk/lib_stusb_impl/u2f_io.o
[CC]   build/nanox/obj/sdk/lib_stusb_impl/usbd_impl.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_flow_engine.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_bb.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_bn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_bnn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_bnnn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_nn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_nnbnn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_nnn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_nnnn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_pages.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_paging.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_paging_compute.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_pb.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_pbb.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_pbn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_pn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_pnn.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_layout_utils.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_legacy.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_menulist.o
[CC]   build/nanox/obj/sdk/lib_ux/src/ux_stack.o
[CC]   build/nanox/obj/sdk/src/app_metadata.o
[CC]   build/nanox/obj/sdk/src/checks.o
[CC]   build/nanox/obj/sdk/src/cx_hash_iovec.o
[AS]   build/nanox/obj/sdk/src/cx_stubs.o
[CC]   build/nanox/obj/sdk/src/cx_wrappers.o
[CC]   build/nanox/obj/sdk/src/ledger_assert.o
[CC]   build/nanox/obj/sdk/src/ledger_protocol.o
[CC]   build/nanox/obj/sdk/src/os.o
[CC]   build/nanox/obj/sdk/src/os_io_seproxyhal.o
[CC]   build/nanox/obj/sdk/src/os_io_task.o
[CC]   build/nanox/obj/sdk/src/os_io_usb.o
[CC]   build/nanox/obj/sdk/src/os_printf.o
[CC]   build/nanox/obj/sdk/src/pic.o
[CC]   build/nanox/obj/sdk/src/stack_protector.o
[AS]   build/nanox/obj/sdk/src/stack_protector_init.o
[AS]   build/nanox/obj/sdk/src/svc_call.o
[AS]   build/nanox/obj/sdk/src/svc_cx_call.o
[CC]   build/nanox/obj/sdk/src/syscalls.o
[LINK] build/nanox/bin/app.elf
ld.lld: error: build/nanox/obj/app/src/app_main.o:(.debug_info+0x8a): has non-ABS relocation R_ARM_SBREL32 against symbol 'G_context'
ld.lld: error: build/nanox/obj/app/src/ui/bagl_display.o:(.debug_info+0x32d): has non-ABS relocation R_ARM_SBREL32 against symbol 'g_validate_callback'
ld.lld: error: build/nanox/obj/sdk/lib_blewbxx_impl/src/ledger_ble.o:(.debug_info+0x134): has non-ABS relocation R_ARM_SBREL32 against symbol 'ledger_protocol_data'
ld.lld: error: build/nanox/obj/sdk/lib_standard_app/io.o:(.debug_info+0x8c): has non-ABS relocation R_ARM_SBREL32 against symbol 'G_io_seproxyhal_spi_buffer'
ld.lld: error: build/nanox/obj/sdk/lib_standard_app/main.o:(.debug_info+0x35): has non-ABS relocation R_ARM_SBREL32 against symbol 'G_ux'
ld.lld: error: build/nanox/obj/sdk/lib_stusb/STM32_USB_Device_Library/Core/Src/usbd_core.o:(.debug_info+0x35): has non-ABS relocation R_ARM_SBREL32 against symbol 'USBD_Device'
ld.lld: error: build/nanox/obj/sdk/lib_stusb/usbd_conf.o:(.debug_info+0x35): has non-ABS relocation R_ARM_SBREL32 against symbol 'ep_in_stall'
ld.lld: error: build/nanox/obj/sdk/src/ledger_assert.o:(.debug_info+0x1bf): has non-ABS relocation R_ARM_SBREL32 against symbol 'assert_buffer'
ld.lld: error: build/nanox/obj/sdk/src/ledger_protocol.o:(.debug_info+0xee): has non-ABS relocation R_ARM_SBREL32 against symbol 'ledger_protocol'
ld.lld: error: build/nanox/obj/sdk/src/os.o:(.debug_info+0x64): has non-ABS relocation R_ARM_SBREL32 against symbol 'G_io_apdu_buffer'
ld.lld: error: build/nanox/obj/sdk/src/os_io_seproxyhal.o:(.debug_info+0x7c): has non-ABS relocation R_ARM_SBREL32 against symbol 'G_io_app'
ld.lld: error: build/nanox/obj/sdk/src/os_io_task.o:(.debug_info+0x2d): has non-ABS relocation R_ARM_SBREL32 against symbol 'G_io_asynch_ux_callback'
ld.lld: error: build/nanox/obj/sdk/src/os_io_usb.o:(.debug_info+0x35): has non-ABS relocation R_ARM_SBREL32 against symbol 'G_io_usb_ep_buffer'
clang: error: ld.lld command failed with exit code 1 (use -v to see invocation)
make: *** [/opt/nanox-secure-sdk/Makefile.rules_generic:152: build/nanox/bin/app.elf] Error 1
```

I managed to repruce the issue with a minimalist example:
![image](https://github.com/user-attachments/assets/ae512fe6-4bb3-427b-a65d-5f0d216b6325)


It seems that clang/lld does not support -g3 with -frwpi when using global variables.

The llvm project has an open issue related to this: https://github.com/llvm/llvm-project/issues/89197

Bumping to -g1 allows to get a debug build with code information.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

