### PR TITLE
Fix Progress Bar issue in long-press when releasing

### DIFF
--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -350,7 +350,7 @@ typedef struct PACKED__ nbgl_progress_bar_s {
     nbgl_obj_t obj;            // common part
     bool       withBorder;     ///< if set to true, a border in black surround the whole object
     uint8_t    state;          ///< state of the progress, in % (from 0 to 100).
-    uint8_t    previousState;  ///< previous state of the progress, in % (from 0 to 100).
+    bool       partialRedraw;  ///< set to true to redraw only partially the object (update state).
     uint16_t   previousWidth;
     color_t    foregroundColor;  ///< color of the inner progress bar and border (if applicable)
 } nbgl_progress_bar_t;

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -334,7 +334,7 @@ static void longTouchCallback(nbgl_obj_t            *obj,
 
         // Update progress bar state
         if (new_state != progressBar->state) {
-            progressBar->previousState = progressBar->state;
+            progressBar->partialRedraw = true;
             progressBar->state         = new_state;
 
             nbgl_objDraw((nbgl_obj_t *) progressBar);
@@ -355,7 +355,8 @@ static void longTouchCallback(nbgl_obj_t            *obj,
     else if ((eventType == TOUCH_RELEASED) || (eventType == OUT_OF_TOUCH)
              || (eventType == SWIPED_LEFT) || (eventType == SWIPED_RIGHT)) {
         nbgl_wait_pipeline();
-        progressBar->state = 0;
+        progressBar->partialRedraw = true;
+        progressBar->state         = 0;
         nbgl_objDraw((nbgl_obj_t *) progressBar);
         nbgl_refreshSpecialWithPostRefresh(BLACK_AND_WHITE_REFRESH, POST_REFRESH_FORCE_POWER_OFF);
     }

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -10,6 +10,7 @@
 #include "nbgl_front.h"
 #include "nbgl_screen.h"
 #include "nbgl_debug.h"
+#include "nbgl_touch.h"
 #include "os_pic.h"
 #include "os_io.h"
 #include "os_task.h"
@@ -363,7 +364,13 @@ int nbgl_screenPush(nbgl_obj_t                           ***elements,
                 // update previous topOfStack
                 topOfStack->next                  = &screenStack[screenIndex];
                 screenStack[screenIndex].previous = topOfStack;
-                // new top of stack
+#ifdef HAVE_SE_TOUCH
+                nbgl_touchStatePosition_t touchStatePosition = {.state = RELEASED, .x = 0, .y = 0};
+                // make a fake touch release for the current top-of-stack to avoid issue
+                // (for example in long-touch press)
+                nbgl_touchHandler(&touchStatePosition, 0);
+#endif  // HAVE_SE_TOUCH
+        // new top of stack
                 topOfStack       = &screenStack[screenIndex];
                 topOfStack->next = NULL;
                 break;


### PR DESCRIPTION
## Description

The goal is to fix a potential issue when using long-press button.
If the touch is releasead when the first "step" is drawn, this step is not deleted in the progress bar

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
