### PR TITLE
Stax: Rename experimental Stax display defines

### DIFF
--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -310,13 +310,13 @@
 #define SYSCALL_nbgl_wait_pipeline_ID 0x00fa0011
 #endif
 
-#ifdef HAVE_DISPLAY_FAST_MODE
+#ifdef HAVE_STAX_DISPLAY_FAST_MODE
 #define SYSCALL_nbgl_screen_update_temperature_ID 0x01fa0011
-#endif  // HAVE_DISPLAY_FAST_MODE
+#endif  // HAVE_STAX_DISPLAY_FAST_MODE
 
-#ifdef HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#ifdef HAVE_STAX_CONFIG_DISPLAY_FAST_MODE
 #define SYSCALL_nbgl_screen_config_fast_mode_ID 0x00fa0012
-#endif  // HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#endif  // HAVE_STAX_CONFIG_DISPLAY_FAST_MODE
 #endif  // HAVE_NBGL
 
 #ifdef HAVE_BACKGROUND_IMG

--- a/lib_nbgl/include/nbgl_screen.h
+++ b/lib_nbgl/include/nbgl_screen.h
@@ -73,13 +73,13 @@ typedef struct PACKED__ nbgl_screen_s {
 void nbgl_screen_reinit(void);
 void nbgl_wait_pipeline(void);
 
-#ifdef HAVE_DISPLAY_FAST_MODE
+#ifdef HAVE_STAX_DISPLAY_FAST_MODE
 void nbgl_screen_update_temperature(uint8_t temp_degrees);
-#endif  // HAVE_DISPLAY_FAST_MODE
+#endif  // HAVE_STAX_DISPLAY_FAST_MODE
 
-#ifdef HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#ifdef HAVE_STAX_CONFIG_DISPLAY_FAST_MODE
 void nbgl_screen_config_fast_mode(uint8_t fast_mode_setting);
-#endif  // HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#endif  // HAVE_STAX_CONFIG_DISPLAY_FAST_MODE
 
 void        nbgl_screenRedraw(void);
 nbgl_obj_t *nbgl_screenGetAt(uint8_t screenIndex);

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -204,7 +204,7 @@ void nbgl_wait_pipeline(void)
 }
 #endif  // HAVE_SE_EINK_DISPLAY
 
-#ifdef HAVE_DISPLAY_FAST_MODE
+#ifdef HAVE_STAX_DISPLAY_FAST_MODE
 void nbgl_screen_update_temperature(uint8_t temp_degrees)
 {
     unsigned int parameters[1];
@@ -212,16 +212,16 @@ void nbgl_screen_update_temperature(uint8_t temp_degrees)
     SVC_Call(SYSCALL_nbgl_screen_update_temperature_ID, parameters);
     return;
 }
-#endif  // HAVE_DISPLAY_FAST_MODE
+#endif  // HAVE_STAX_DISPLAY_FAST_MODE
 
-#ifdef HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#ifdef HAVE_STAX_CONFIG_DISPLAY_FAST_MODE
 void nbgl_screen_config_fast_mode(uint8_t fast_mode_setting)
 {
     unsigned int parameters[1];
     parameters[0] = (unsigned int) fast_mode_setting;
     SVC_Call(SYSCALL_nbgl_screen_config_fast_mode_ID, parameters);
 }
-#endif  // HAVE_CONFIGURABLE_DISPLAY_FAST_MODE
+#endif  // HAVE_STAX_CONFIG_DISPLAY_FAST_MODE
 
 #endif
 


### PR DESCRIPTION
Rename defines for experimental display features on Stax.

- `HAVE_DISPLAY_FAST_MODE` -> `HAVE_STAX_DISPLAY_FAST_MODE`
- `HAVE_CONFIGURABLE_DISPLAY_FAST_MODE` -> `HAVE_STAX_CONFIG_DISPLAY_FAST_MODE`

## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
