### PR TITLE
Fix bad page indicator display when more than 9 pages

### DIFF
--- a/lib_nbgl/src/nbgl_layout_navigation.c
+++ b/lib_nbgl/src/nbgl_layout_navigation.c
@@ -199,15 +199,15 @@ void layoutNavigationPopulate(nbgl_container_t                 *navContainer,
     if (navConfig->withPageIndicator) {
         if (navConfig->visibleIndicator) {
             nbgl_text_area_t *textArea = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layer);
+            uint16_t          marginX  = (NAV_BUTTON_WIDTH - CHEVRON_NEXT_ICON.width) / 2;
 
             SPRINTF(navText, "%d of %d", navConfig->activePage + 1, navConfig->nbPages);
 
             textArea->textColor = DARK_GRAY;
-#ifdef TARGET_STAX
-            textArea->obj.area.width = 109;
-#else   // TARGET_STAX
-            textArea->obj.area.width = 89;
-#endif  // TARGET_STAX
+            // the max width is the width of the whole container, but not overriding the < and >
+            // icons
+            textArea->obj.area.width
+                = navContainer->obj.area.width - (2 * (marginX + CHEVRON_NEXT_ICON.width));
             textArea->text                               = navText;
             textArea->fontId                             = SMALL_REGULAR_FONT;
             textArea->obj.area.height                    = NAV_BUTTON_HEIGHT;


### PR DESCRIPTION
## Description

The goal of this PR is to fix a bug impacting page indicator display ("<i> of <N>") when using more than 9 pages. 
In this case the width of the text area is not suffisiant and the indicator is broken on 2 lines.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
