### PR TITLE
Fix wrong text shortening in some corner cases ("..." being longer than 2 chars)

### DIFF
--- a/unit-tests/lib_nbgl/test_nbgl_fonts.c
+++ b/unit-tests/lib_nbgl/test_nbgl_fonts.c
@@ -117,6 +117,10 @@ static void test_get_length(void **state __attribute__((unused)))
     nbgl_textWrapOnNbLines(BAGL_FONT_INTER_SEMIBOLD_24px, textToWrap, 156, 2);
     assert_string_equal(textToWrap, "bonjourtuaimestr les ...");
 
+    strcpy(textToWrap, "that will overflow the screen size multiple times");
+    nbgl_textWrapOnNbLines(BAGL_FONT_INTER_REGULAR_24px, textToWrap, 352, 1);
+    assert_string_equal(textToWrap, "that will overflow the screen...");
+
     nbgl_textReduceOnNbLines(BAGL_FONT_INTER_SEMIBOLD_24px,
                              "bc1pkdcufjh6dxjaEZFZEFZFGGEaa05hudxqgfffggghhhhhhffffffff5fhspfmZAFEZ"
                              "Fwmp8g92gq8ZEGFZEcv4g",


### PR DESCRIPTION
## Description

The goal of this PR is to fix text shortening (nbgl_textWrapOnNbLines()) in some corner cases ("..." being longer than 2 chars)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
