### PR TITLE
Add Return status to syscall for nvram

### DIFF
--- a/include/os_nvm.h
+++ b/include/os_nvm.h
@@ -23,7 +23,7 @@ SYSCALL void nvm_erase(void *dst_adr PLENGTH(len), unsigned int len);
 SUDOCALL void nvm_write_page(unsigned int page_adr, bool force);
 
 // erase a nvm page at given address, only callable by the privileged APIs
-SUDOCALL void nvm_erase_page(unsigned int page_adr);
+SUDOCALL unsigned int nvm_erase_page(unsigned int page_adr);
 
 // any application can wipe the global pin, global seed, user's keys
 // disabled for security reasons // SYSCALL                                       void

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1843,13 +1843,12 @@ void nvm_write_page(unsigned int page_adr, bool force)
     return;
 }
 
-void nvm_erase_page(unsigned int page_adr)
+unsigned int nvm_erase_page(unsigned int page_adr)
 {
     unsigned int parameters[2];
     parameters[0] = (unsigned int) page_adr;
     parameters[1] = 0;
-    SVC_Call(SYSCALL_nvm_erase_page_ID, parameters);
-    return;
+    return (unsigned int) SVC_Call(SYSCALL_nvm_erase_page_ID, parameters);
 }
 
 try_context_t *try_context_get(void)


### PR DESCRIPTION
## Description

This PR update syscall for nvram return status.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Return status code for one syscall.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
