### PR TITLE
Full clang build for standard apps

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -55,18 +55,6 @@ else
 CFLAGS   += --sysroot="$(SYSROOT)"
 endif
 
-# optimization and debug levels
-ifneq ($(DEBUG),0)
-OPTI_LVL  = -Og
-OPTI_ALVL = $(OPTI_LVL)
-DBG_LVL   = -g3
-else
-OPTI_LVL  = -Oz
-OPTI_ALVL = -Os # assembler does not handle -Oz, use -Os instead
-DBG_LVL   = -g0
-endif
-
-CFLAGS   += $(OPTI_LVL) $(DBG_LVL)
 CFLAGS   += -fomit-frame-pointer -momit-leaf-frame-pointer
 
 CFLAGS   += -fno-common -mlittle-endian
@@ -91,9 +79,8 @@ CFLAGS   += -fropi
 CFLAGS   += -fno-jump-tables # avoid jump tables for switch to avoid problems with invalid PIC access
 CFLAGS   += -nostdlib -nodefaultlibs
 
-AFLAGS   += $(OPTI_ALVL) $(DBG_LVL) -fno-common
+AFLAGS   += -fno-common
 
-LDFLAGS  += $(OPTI_LVL) $(DBG_LVL)
 LDFLAGS  += -fomit-frame-pointer
 LDFLAGS  += -Wall
 LDFLAGS  += -fno-common -ffunction-sections -fdata-sections -fwhole-program

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -89,4 +89,25 @@ OBJECTS_DIR += $(sort $(dir $(OBJECT_FILES)))
 DEPEND_FILES = $(subst $(OBJ_DIR), $(DEP_DIR), $(addsuffix .d, $(basename $(OBJECT_FILES))))
 DEPEND_DIR += $(sort $(dir $(DEPEND_FILES)))
 
+# optimization and debug levels
+# this should be in Makefile.defines, but $(AS) is not yet defined at that point
+ifneq ($(DEBUG),0)
+    OPTI_LVL  = -Og
+    OPTI_ALVL = $(OPTI_LVL)
+    DBG_LVL   = -g3
+else
+    OPTI_LVL  = -Oz
+    ifeq ($(AS),$(CLANGPATH)clang)
+        OPTI_ALVL = $(OPTI_LVL)
+    else
+        # GCC assembler does not handle -Oz
+        OPTI_ALVL = -Os
+    endif
+    DBG_LVL   = -g0
+endif
+# at the beginning so they can be overridden by apps
+CFLAGS   := $(OPTI_LVL) $(DBG_LVL) $(CFLAGS)
+AFLAGS   := $(OPTI_ALVL) $(DBG_LVL) $(AFLAGS)
+LDFLAGS  := $(OPTI_LVL) $(DBG_LVL) $(LDFLAGS)
+
 include $(BOLOS_SDK)/Makefile.rules_generic

--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -218,8 +218,11 @@ APP_FLAGS_APP_LOAD_PARAMS = $(shell printf '0x%x' $$(( $(STANDARD_APP_FLAGS) + $
 #                         COMPILER SETTINGS                         #
 #####################################################################
 CC      := $(CLANGPATH)clang
-AS      := $(GCCPATH)arm-none-eabi-gcc
-LD      := $(GCCPATH)arm-none-eabi-gcc
+AS      := $(CLANGPATH)clang
+LD      := $(CLANGPATH)clang
+ifeq ($(AS),$(CLANGPATH)clang)
+    AFLAGS  += --target=arm-arm-none-eabi
+endif
 LDLIBS  += -lm -lgcc -lc
 
 #####################################################################

--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -221,7 +221,7 @@ CC      := $(CLANGPATH)clang
 AS      := $(CLANGPATH)clang
 LD      := $(CLANGPATH)clang
 ifeq ($(AS),$(CLANGPATH)clang)
-    AFLAGS  += --target=arm-arm-none-eabi
+    AFLAGS  += --target=arm-arm-none-eabi -Wno-unused-command-line-argument
 endif
 LDLIBS  += -lm -lgcc -lc
 


### PR DESCRIPTION
## Description

Now only uses clang for all steps of the build instead of the assembly of .S files and binary linking being delegated to GCC.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)