### PR TITLE
cx_aes_siv: Add new function to reset AES hw copro

### DIFF
--- a/include/cx_stubs.h
+++ b/include/cx_stubs.h
@@ -145,3 +145,4 @@
 #define _NR_cx_cmac_start                        0x8d
 #define _NR_cx_cmac_update                       0x8e
 #define _NR_cx_cmac_finish                       0x8f
+#define _NR_cx_aes_siv_reset                     0x90

--- a/include/ox_aes.h
+++ b/include/ox_aes.h
@@ -99,7 +99,7 @@ cx_aes_set_key_hw(const cx_aes_key_t *key PLENGTH(sizeof(cx_aes_key_t)), uint32_
 /**
  * @brief   Resets the AES context.
  */
-SYSCALL void cx_aes_reset_hw(void);
+SYSCALL cx_err_t cx_aes_reset_hw(void);
 
 /**
  * @brief   Encrypts or decrypts a block with AES.

--- a/lib_cxng/cx.export
+++ b/lib_cxng/cx.export
@@ -148,3 +148,4 @@ cx_cipher_reset
 cx_cmac_start
 cx_cmac_update
 cx_cmac_finish
+cx_aes_siv_reset

--- a/lib_cxng/include/lcx_aes_siv.h
+++ b/lib_cxng/include/lcx_aes_siv.h
@@ -56,6 +56,17 @@ typedef struct _cx_aes_siv_context {
 WARN_UNUSED_RESULT cx_err_t cx_aes_siv_init(cx_aes_siv_context_t *ctx);
 
 /**
+ * @brief   Reset the AES-SIV context and HW used.
+ * @details The cipher context must be initialized beforehand.
+ *          This function must be called after calls to #cx_aes_siv_finish or
+ *          #cx_aes_siv_update.
+ *
+ * @param[in] ctx Pointer to the AES-SIV context.
+ * @return        Error code.
+ */
+WARN_UNUSED_RESULT cx_err_t cx_aes_siv_reset(cx_aes_siv_context_t *ctx);
+
+/**
  * @brief   Sets the key to compute AES-SIV.
  *
  * @details The size of the key is twice the size of

--- a/lib_cxng/src/cx_aes.c
+++ b/lib_cxng/src/cx_aes.c
@@ -28,21 +28,24 @@ cx_err_t cx_aes_init_key_no_throw(const uint8_t *raw_key, size_t key_len, cx_aes
 cx_err_t cx_aes_enc_block(const cx_aes_key_t *key, const uint8_t *inblock, uint8_t *outblock)
 {
     cx_err_t error;
+    cx_err_t err_reset = CX_INTERNAL_ERROR;
     CX_CHECK(cx_aes_set_key_hw(key, CX_ENCRYPT));
     CX_CHECK(cx_aes_block_hw(inblock, outblock));
-    cx_aes_reset_hw();
 end:
-    return error;
+    err_reset = cx_aes_reset_hw();
+    return error == CX_OK ? err_reset : error;
 }
 
 cx_err_t cx_aes_dec_block(const cx_aes_key_t *key, const uint8_t *inblock, uint8_t *outblock)
 {
     cx_err_t error;
+    cx_err_t err_reset = CX_INTERNAL_ERROR;
+    CX_CHECK(cx_aes_set_key_hw(key, CX_ENCRYPT));
     CX_CHECK(cx_aes_set_key_hw(key, CX_DECRYPT));
     CX_CHECK(cx_aes_block_hw(inblock, outblock));
-    cx_aes_reset_hw();
 end:
-    return error;
+    err_reset = cx_aes_reset_hw();
+    return error == CX_OK ? err_reset : error;
 }
 
 cx_err_t cx_aes_iv_no_throw(const cx_aes_key_t *key,

--- a/lib_cxng/src/cx_cipher.h
+++ b/lib_cxng/src/cx_cipher.h
@@ -31,7 +31,7 @@ extern const cx_cipher_info_t cx_aes_256_info;
 /** HW support */
 WARN_UNUSED_RESULT cx_err_t cx_aes_set_key_hw(const cx_aes_key_t *keys, uint32_t mode);
 WARN_UNUSED_RESULT cx_err_t cx_aes_block_hw(const uint8_t *inblock, uint8_t *outblock);
-void                        cx_aes_reset_hw(void);
+WARN_UNUSED_RESULT cx_err_t cx_aes_reset_hw(void);
 #endif  // HAVE_AES
 
 #endif /* CX_CIPHER_H */

--- a/src/cx_stubs.S
+++ b/src/cx_stubs.S
@@ -160,6 +160,7 @@ CX_TRAMPOLINE _NR_cx_cipher_reset                          cx_cipher_reset
 CX_TRAMPOLINE _NR_cx_cmac_start                            cx_cmac_start
 CX_TRAMPOLINE _NR_cx_cmac_update                           cx_cmac_update
 CX_TRAMPOLINE _NR_cx_cmac_finish                           cx_cmac_finish
+CX_TRAMPOLINE _NR_cx_aes_siv_reset                         cx_aes_siv_reset
 
 .thumb_func
 cx_trampoline_helper:

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -252,11 +252,11 @@ cx_err_t cx_aes_set_key_hw(const cx_aes_key_t *keys, uint32_t mode)
     return SVC_cx_call(SYSCALL_cx_aes_set_key_hw_ID, parameters);
 }
 
-void cx_aes_reset_hw(void)
+cx_err_t cx_aes_reset_hw(void)
 {
     unsigned int parameters[2];
     parameters[1] = 0;
-    SVC_cx_call(SYSCALL_cx_aes_reset_hw_ID, parameters);
+    return SVC_cx_call(SYSCALL_cx_aes_reset_hw_ID, parameters);
 }
 
 cx_err_t cx_aes_block_hw(const unsigned char *inblock, unsigned char *outblock)


### PR DESCRIPTION
## Description

Add new AES SIV function to reset the AES copro.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
