### PR TITLE
Display QR Code title different from URL in alias

### DIFF
--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -137,6 +137,8 @@ typedef struct {
     const char *fullValue;    ///< full string of the value when used as an alias
     const char *explanation;  ///< string displayed in gray, explaing where the alias comes from
                               ///< only used if aliasType is @ref NO_ALIAS_TYPE
+    const char *title;  ///< if not NULL and aliasType is @ref QR_CODE_ALIAS, is used as title of
+                        ///< the QR Code
     nbgl_contentValueAliasType_t aliasType;  ///< type of alias
 } nbgl_contentValueExt_t;
 

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1165,11 +1165,12 @@ static void displayFullValuePage(const char                   *backText,
     // add either QR Code or full value text
     if (extension->aliasType == QR_CODE_ALIAS) {
 #ifdef NBGL_QRCODE
-        nbgl_layoutQRCode_t qrCode = {.url      = extension->fullValue,
-                                      .text1    = extension->fullValue,
-                                      .text2    = extension->explanation,
-                                      .centered = true,
-                                      .offsetY  = 0};
+        nbgl_layoutQRCode_t qrCode
+            = {.url      = extension->fullValue,
+               .text1    = (extension->title != NULL) ? extension->title : extension->fullValue,
+               .text2    = extension->explanation,
+               .centered = true,
+               .offsetY  = 0};
 
         nbgl_layoutAddQRCode(genericContext.modalLayout, &qrCode);
 #endif  // NBGL_QRCODE


### PR DESCRIPTION
## Description

The goal of this PR is to display QR Code title different from QR Code URL in alias

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
