### PR TITLE
Use current PR branch when compiling C SDK

### DIFF
--- a/.github/workflows/build_rust_sdk.yml
+++ b/.github/workflows/build_rust_sdk.yml
@@ -18,7 +18,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                 path: c_sdk
-                ref: master
             - name: Clone Rust SDK
               uses: actions/checkout@v4
               with:


### PR DESCRIPTION
## Description

When compiling the Rust SDK, use the PR branch of the C SDK (and not the master branch as it will not test the PR modifications).

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
