### PR TITLE
Fix error when setting `DISABLE_STANDARD_USB = 1` in standard app Makefile - cherry pick API_LEVEL_21

### DIFF
--- a/lib_standard_app/main.c
+++ b/lib_standard_app/main.c
@@ -46,8 +46,10 @@ WEAK void common_app_init(void)
 
     io_seproxyhal_init();
 
+#ifdef HAVE_IO_USB
     USB_power(0);
     USB_power(1);
+#endif
 
 #ifdef HAVE_BLE
     BLE_power(0, NULL);
@@ -83,7 +85,9 @@ WEAK void standalone_app_main(void)
             // - the NanoX goes on battery power and display the lock screen
             // - the user plug the NanoX instead of entering its pin
             // - the device is frozen, battery should be removed
+#ifdef HAVE_IO_USB
             USB_power(0);
+#endif
 #ifdef HAVE_BLE
             BLE_power(0, NULL);
 #endif


### PR DESCRIPTION
## Description

#808

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)