### PR TITLE
Minor fixes in infos-list with alias display (touchable area, icon, tune)

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -922,16 +922,17 @@ static int addText(nbgl_layout_t *layout,
         container->nbChildren++;
         if (withAlias == true) {
             nbgl_image_t *image = (nbgl_image_t *) nbgl_objPoolGet(IMAGE, layoutInt->layer);
-            layoutObj_t  *obj
-                = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) image, token, TUNE_TAP_CASUAL);
+            // the whole container is touchable
+            layoutObj_t *obj
+                = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) container, token, TUNE_TAP_CASUAL);
             obj->index                  = index;
             image->foregroundColor      = BLACK;
-            image->buffer               = &MINI_PUSH_ICON;
+            image->buffer               = &PUSH_ICON;
             image->obj.alignment        = RIGHT_TOP;
             image->obj.alignmentMarginX = 12;
             image->obj.alignTo          = (nbgl_obj_t *) textArea;
-            image->obj.touchMask        = (1 << TOUCHED);
-            image->obj.touchId          = VALUE_BUTTON_1_ID + index;
+            container->obj.touchMask    = (1 << TOUCHED);
+            container->obj.touchId      = VALUE_BUTTON_1_ID + index;
 
             container->children[container->nbChildren] = (nbgl_obj_t *) image;
             container->nbChildren++;

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1248,7 +1248,8 @@ static void displayTipBoxModal(void)
                                          .infosList.infoExtensions = tipBoxInfoList.infoExtensions,
                                          .infosList.token          = INFO_ALIAS_TOKEN,
                                          .title                    = tipBoxModalTitle,
-                                         .titleToken               = QUIT_TOKEN};
+                                         .titleToken               = QUIT_TOKEN,
+                                         .tuneId                   = TUNE_TAP_CASUAL};
 
     if (modalPageContext != NULL) {
         nbgl_pageRelease(modalPageContext);


### PR DESCRIPTION
## Description

The goal of this PR is to fix minor issues in infos-list with alias display:
- whole row as touchable area
- chevron icon
- tune when coming back from info list

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
