### PR TITLE
Make cx_math_is_zero run in constant time

### DIFF
--- a/lib_cxng/include/lcx_math.h
+++ b/lib_cxng/include/lcx_math.h
@@ -568,13 +568,11 @@ DEPRECATED static inline void cx_math_next_prime(uint8_t *r, uint32_t len)
  */
 static inline bool cx_math_is_zero(const uint8_t *a, size_t len)
 {
-    uint32_t i;
-    for (i = 0; i < len; i++) {
-        if (a[i] != 0) {
-            return 0;
-        }
+    uint8_t acc = 0;  // accumulate all the bytes in order to run in constant time
+    for (size_t i = 0; i < len; i++) {
+        acc |= a[i];
     }
-    return 1;
+    return acc == 0;
 }
 
 #endif  // HAVE_MATH


### PR DESCRIPTION
## Description

The current implementation `cx_math_is_zero` does not run in constant time, but it's not documented; this could lead to vulnerabilities if used in cryptographic code in apps.

This PR replaces it with a constant time implementation to avoid any such risks.

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
