### PR TITLE
NBGL Nano: Check onActionCallback validity

### DIFF
--- a/lib_nbgl/src/nbgl_step.c
+++ b/lib_nbgl/src/nbgl_step.c
@@ -309,7 +309,9 @@ static void actionCallback(nbgl_layout_t *layout, nbgl_buttonEvent_t event)
         }
         else if ((ctx->textContext.pos == LAST_STEP)
                  || (ctx->textContext.pos == NEITHER_FIRST_NOR_LAST_STEP)) {
-            ctx->textContext.onActionCallback((nbgl_step_t) ctx, event);
+            if (ctx->textContext.onActionCallback != NULL) {
+                ctx->textContext.onActionCallback((nbgl_step_t) ctx, event);
+            }
         }
     }
     else if (event == BUTTON_RIGHT_PRESSED) {
@@ -319,11 +321,15 @@ static void actionCallback(nbgl_layout_t *layout, nbgl_buttonEvent_t event)
         }
         else if ((ctx->textContext.pos == FIRST_STEP)
                  || (ctx->textContext.pos == NEITHER_FIRST_NOR_LAST_STEP)) {
-            ctx->textContext.onActionCallback((nbgl_step_t) ctx, event);
+            if (ctx->textContext.onActionCallback != NULL) {
+                ctx->textContext.onActionCallback((nbgl_step_t) ctx, event);
+            }
         }
     }
     else if (event == BUTTON_BOTH_PRESSED) {
-        ctx->textContext.onActionCallback((nbgl_step_t) ctx, event);
+        if (ctx->textContext.onActionCallback != NULL) {
+            ctx->textContext.onActionCallback((nbgl_step_t) ctx, event);
+        }
     }
 }
 


### PR DESCRIPTION


## Description

In nbgl_step.c `actionCallback`, `onActionCallback` was called without being checked, leading to crash if the callback is NULL. This commit adds the relevant checks.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

