### PR TITLE
Make the info list property in nbgl_tipBox_t non-const

### DIFF
--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -184,7 +184,7 @@ typedef struct {
     const char *modalTitle;   ///< title given to modal window displayed when tip-box is touched
     nbgl_contentType_t type;  ///< type of page content in the following union
     union {
-        const nbgl_contentInfoList_t infos;  ///< infos pairs displayed in modal.
+        nbgl_contentInfoList_t infos;  ///< infos pairs displayed in modal.
     };
 } nbgl_tipBox_t;
 


### PR DESCRIPTION
## Description

To make it easier to use, since it wasn't a pointer to a struct, but rather the struct itself.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)