### PR TITLE
Integrate HAVE_MCU_SERIAL_STORAGE flag code

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -185,8 +185,6 @@ ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME),TARGET_NANOX TARGET_NANOS2))
 DEFINES       += HAVE_SE_SCREEN
 # Button is directly connected to the SE
 DEFINES       += HAVE_SE_BUTTON
-# MCU serial is stored on board of the SE
-DEFINES       += HAVE_MCU_SERIAL_STORAGE
 DEFINES       += HAVE_FONTS
 DEFINES       += HAVE_INAPP_BLE_PAIRING
 DEFINES       += HAVE_BATTERY

--- a/include/os_id.h
+++ b/include/os_id.h
@@ -22,12 +22,10 @@ SYSCALL unsigned int os_flags(void);
 SYSCALL unsigned int os_version(unsigned char *version PLENGTH(maxlength), unsigned int maxlength);
 /* Grab the SE serial number */
 SYSCALL unsigned int os_serial(unsigned char *serial PLENGTH(maxlength), unsigned int maxlength);
-#ifdef HAVE_MCU_SERIAL_STORAGE
 /* Grab the SEPROXYHAL's MCU serial number */
 SYSCALL unsigned int os_seph_serial(unsigned char *serial PLENGTH(maxlength),
                                     unsigned int          maxlength);
-#endif  // HAVE_MCU_SERIAL_STORAGE
-        /* Grab the SEPROXYHAL's feature set */
+/* Grab the SEPROXYHAL's feature set */
 SYSCALL unsigned int os_seph_features(void);
 /* Grab the SEPROXYHAL's version */
 SYSCALL unsigned int os_seph_version(unsigned char *version PLENGTH(maxlength),

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -237,9 +237,7 @@
 
 #define SYSCALL_os_standby_ID 0x0000d0d0
 
-#ifdef HAVE_MCU_SERIAL_STORAGE
 #define SYSCALL_os_seph_serial_ID 0x0200006d
-#endif  // HAVE_MCU_SERIAL_STORAGE
 
 #if defined(HAVE_LANGUAGE_PACK)
 #define SYSCALL_list_language_packs_ID 0x01000153

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1954,7 +1954,6 @@ bolos_err_t ENDORSEMENT_revoke_slot(ENDORSEMENT_revoke_id_t revoke_id)
 }
 #endif  // HAVE_BOLOS
 
-#ifdef HAVE_MCU_SERIAL_STORAGE
 unsigned int os_seph_serial(unsigned char *serial, unsigned int maxlength)
 {
     unsigned int parameters[2];
@@ -1962,7 +1961,6 @@ unsigned int os_seph_serial(unsigned char *serial, unsigned int maxlength)
     parameters[1] = (unsigned int) maxlength;
     return (unsigned int) SVC_Call(SYSCALL_os_seph_serial_ID, parameters);
 }
-#endif
 
 #ifdef HAVE_SE_SCREEN
 void screen_clear(void)


### PR DESCRIPTION
## Description

The goal of this PR is to Integrate and remove HAVE_MCU_SERIAL_STORAGE (always defined) flag.
This is a PR of code cleaning.
It is not planned to support products or flavors without this feature, so the flag is useless (it was defined only for Nanos but it was a mistake, because available on all products)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [*] Other (for changes that might not fit in any category)
