### PR TITLE
Fix case when multi-pages text contains '\n' at page break

### DIFF
--- a/lib_nbgl/src/nbgl_step.c
+++ b/lib_nbgl/src/nbgl_step.c
@@ -251,6 +251,10 @@ static void displayTextPage(StepContext_t *ctx, uint8_t textPage)
             BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp, txt, AVAILABLE_WIDTH, nbLines, &len, true);
         // memorize next position to save processing
         ctx->textContext.nextPageStart = txt + len;
+        // if the next char is '\n', skip it to avoid starting with an empty line
+        if (*ctx->textContext.nextPageStart == '\n') {
+            ctx->textContext.nextPageStart++;
+        }
     }
     else {
         ctx->textContext.nextPageStart = NULL;


### PR DESCRIPTION
## Description

The goal of this PR is to fix case when multi-pages text contains '\n' at page break, creating a non expected empty line as the first line of the next page.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
