### PR TITLE
Incrementing spinner Use Case when called multiple times

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -85,6 +85,8 @@ extern "C" {
 
 #endif  // HAVE_SE_TOUCH
 
+#define SPINNER_FIXED 0xFF  ///< position to use for a "fixed" spinner
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -655,7 +657,14 @@ int nbgl_layoutAddProgressIndicator(nbgl_layout_t *layout,
                                     bool           withBack,
                                     uint8_t        backToken,
                                     tune_index_e   tuneId);
-int nbgl_layoutAddSpinner(nbgl_layout_t *layout, const char *text, const char *subText, bool fixed);
+int nbgl_layoutAddSpinner(nbgl_layout_t *layout,
+                          const char    *text,
+                          const char    *subText,
+                          uint8_t        initPosition);
+int nbgl_layoutUpdateSpinner(nbgl_layout_t *layout,
+                             const char    *text,
+                             const char    *subText,
+                             uint8_t        position);
 int nbgl_layoutAddSwipe(nbgl_layout_t *layout,
                         uint16_t       swipesMask,
                         const char    *text,

--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -166,6 +166,9 @@ extern "C" {
 // max number of pages when nbgl_page_indicator_t uses dashes (above, it uses n / nb_pages)
 #define NB_MAX_PAGES_WITH_DASHES 6
 
+// number of spinner positions
+#define NB_SPINNER_POSITIONS 4
+
 /**********************
  *      TYPEDEFS
  **********************/

--- a/lib_nbgl/include/nbgl_page.h
+++ b/lib_nbgl/include/nbgl_page.h
@@ -212,7 +212,7 @@ nbgl_page_t *nbgl_pageDrawLedgerInfo(nbgl_layoutTouchCallback_t              onA
                                      const nbgl_screenTickerConfiguration_t *ticker,
                                      const char                             *text,
                                      int                                     tapActionToken);
-nbgl_page_t *nbgl_pageDrawSpinner(nbgl_layoutTouchCallback_t onActionCallback, const char *text);
+nbgl_page_t *nbgl_pageDrawSpinner(const char *text, uint8_t initPosition);
 nbgl_page_t *nbgl_pageDrawInfo(nbgl_layoutTouchCallback_t              onActionCallback,
                                const nbgl_screenTickerConfiguration_t *ticker,
                                const nbgl_pageInfoDescription_t       *info);

--- a/lib_nbgl/src/nbgl_page.c
+++ b/lib_nbgl/src/nbgl_page.c
@@ -292,25 +292,21 @@ nbgl_page_t *nbgl_pageDrawLedgerInfo(nbgl_layoutTouchCallback_t              onA
  * @brief draw a spinner page with the given parameters. The spinner will "rotate" automatically
  * every 800 ms
  *
- * @param onActionCallback common callback for all actions on this page (unused, so set to NULL)
  * @param text text to use under spinner
+ * @param initPosition if set to any value expect @ref SPINNER_FIXED, it will be used as the init
+ * position of the spinner
  * @return the page context (or NULL if error)
  */
-nbgl_page_t *nbgl_pageDrawSpinner(nbgl_layoutTouchCallback_t onActionCallback, const char *text)
+nbgl_page_t *nbgl_pageDrawSpinner(const char *text, uint8_t initPosition)
 {
-    nbgl_layoutDescription_t layoutDescription;
+    nbgl_layoutDescription_t layoutDescription = {0};
     nbgl_layout_t           *layout;
 
-    layoutDescription.modal          = false;
     layoutDescription.withLeftBorder = true;
 
-    layoutDescription.onActionCallback = onActionCallback;
-    layoutDescription.tapActionText    = NULL;
+    layout = nbgl_layoutGet(&layoutDescription);
 
-    layoutDescription.ticker.tickerCallback = NULL;
-    layout                                  = nbgl_layoutGet(&layoutDescription);
-
-    nbgl_layoutAddSpinner(layout, text, NULL, false);
+    nbgl_layoutAddSpinner(layout, text, NULL, initPosition);
 
     nbgl_layoutDraw(layout);
 


### PR DESCRIPTION
## Description

The goal of this PR is to implement the ability to call nbgl_useCaseSpinner() several time in a raw. It enables to "turn" the corner, for example when used in some steps of a long mono-process, preventing the automatic update.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
