### PR TITLE
App params: Allow empty icon when computing app params

### DIFF
--- a/Makefile.app_params
+++ b/Makefile.app_params
@@ -86,7 +86,11 @@ ICONHEX := $(shell $(ICONHEX_CMD) && cat $(ICON_HEX_FILE) && rm -f $(ICON_HEX_FI
 else
 ICONHEX := $(shell $(ICONHEX_CMD))
 endif
+
+ifneq ($(ICONHEX),)
 APP_INSTALL_PARAMS += --icon $(ICONHEX)
+endif
+
 APP_INSTALL_PARAMS += $(foreach curve, $(CURVE_APP_LOAD_PARAMS), --curve $(curve))
 APP_INSTALL_PARAMS += $(foreach path, $(PATH_APP_LOAD_PARAMS), --path $(path))
 ifneq ($(PATH_SLIP21_APP_LOAD_PARAMS),)


### PR DESCRIPTION
## Description

Apps params computation did not allow an empty icon.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

