### PR TITLE
Add W3C customized fields (URL, ProviderMsg)

### DIFF
--- a/lib_nbgl/doc/nbgl_use_case.dox
+++ b/lib_nbgl/doc/nbgl_use_case.dox
@@ -508,8 +508,10 @@ static void onReviewResult(bool confirm) {
 }
 
 void staticReview(void) {
-  warningDesc.predefinedSet = (1 << W3C_LOSING_SWAP_WARN) | (1 << BLIND_SIGNING_WARN);
-  warningDesc.reportProvider = "Blockaid";
+  warningDesc.predefinedSet   = (1 << W3C_LOSING_SWAP_WARN) | (1 << BLIND_SIGNING_WARN);
+  warningDesc.reportProvider  = "Blockaid";
+  warningDesc.providerMessage = "Losing swap";
+  warningDesc.reportUrl       = "url.com/od24xz";
 
   // static review, providing the whole list of pairs
   nbgl_useCaseReviewWithWarning(TYPE_TRANSACTION, // type of operation
@@ -519,7 +521,7 @@ void staticReview(void) {
                                 NULL,                               // sub-title of the first page
                                 "Sign transaction to\nsend coin?",  // title of the last page
                                 NULL,                               // no tip-box in first page of review
-                                warningDesc,                        // description of warning causes
+                                &warningDesc,                       // description of warning causes
                                 onReviewResult);                    // callback on result of the review
 }
 @endcode
@@ -621,7 +623,7 @@ void staticReview(void) {
                                 NULL,                               // sub-title of the first page
                                 "Sign transaction to\nsend coin?",  // title of the last page
                                 NULL,                               // no tip-box in first page of review
-                                warningDesc,                        // description of warning causes
+                                &warningDesc,                       // description of warning causes
                                 onReviewResult);                    // callback on result of the review
 }
 @endcode

--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -254,7 +254,9 @@ typedef enum {
 typedef struct {
     uint32_t predefinedSet;  ///< bitfield of pre-defined warnings, to be taken in @ref
                              ///< nbgl_warningType_t set it to 0 if not using pre-defined warnings
-    const char *reportProvider;  ///< name of the security report provider, used in some strings
+    const char *reportProvider;   ///< name of the security report provider, used in some strings
+    const char *reportUrl;        ///< URL of the report, used in some strings
+    const char *providerMessage;  ///< Dedicated provider message. Default one will be used if NULL
     const nbgl_warningDetails_t
         *introDetails;  ///< details displayed when top-right button is touched in intro page
                         ///< (before review) if using pre-defined configuration, set to NULL,

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -284,7 +284,7 @@ static const SecurityReportItem_t securityReportItems[NB_WARNING_TYPES] = {
                               .subText = "Web3 Checks could not verify this transaction."           },
     [W3C_LOSING_SWAP_WARN] = {.icon    = &ROUND_WARN_ICON,
                               .text    = "Risk detected",
-                              .subText = "Web3 Checks found a risk:\nLosing swap"                   },
+                              .subText = "This transaction was scanned as risky by Web3 Checks."    },
     [W3C_THREAT_DETECTED_WARN]
     = {.icon    = &ROUND_WARN_ICON,
                               .text    = "Threat detected",
@@ -1890,8 +1890,18 @@ static void displaySecurityReport(uint32_t set)
         for (i = 0; i < NB_WARNING_TYPES; i++) {
             if (reviewWithWarnCtx.warning->predefinedSet & (1 << i)) {
                 nbgl_layoutBar_t bar;
+                if ((i == BLIND_SIGNING_WARN)
+                    || (reviewWithWarnCtx.warning->providerMessage == NULL)) {
+                    bar.subText = securityReportItems[i].subText;
+                }
+                else {
+                    snprintf(tmpString,
+                             W3C_DESCRIPTION_MAX_LEN,
+                             "Web3 Checks found a risk:\n%s.",
+                             reviewWithWarnCtx.warning->providerMessage);
+                    bar.subText = tmpString;
+                }
                 bar.text      = securityReportItems[i].text;
-                bar.subText   = securityReportItems[i].subText;
                 bar.iconRight = &PUSH_ICON;
                 bar.iconLeft  = securityReportItems[i].icon;
                 bar.token     = FIRST_WARN_BAR_TOKEN + i;
@@ -1957,8 +1967,8 @@ static void displaySecurityReport(uint32_t set)
         if (reviewWithWarnCtx.isIntro) {
 #ifdef NBGL_QRCODE
             // display a QR Code if in intro
-            nbgl_layoutQRCode_t qrCode = {.url      = "url.com/od24xz",
-                                          .text1    = "url.com/od24xz",
+            nbgl_layoutQRCode_t qrCode = {.url      = reviewWithWarnCtx.warning->reportUrl,
+                                          .text1    = reviewWithWarnCtx.warning->reportUrl,
                                           .text2    = tmpString,
                                           .centered = true,
                                           .offsetY  = 0};
@@ -1976,13 +1986,19 @@ static void displaySecurityReport(uint32_t set)
             nbgl_contentCenter_t info = {0};
             info.icon                 = &C_Warning_64px;
             info.title                = "Threat detected";
-            info.smallTitle           = "Known drainer contract";
             info.description          = tmpString;
+            if (reviewWithWarnCtx.warning->providerMessage != NULL) {
+                info.smallTitle = reviewWithWarnCtx.warning->providerMessage;
+            }
+            else {
+                info.smallTitle = "Known drainer contract";
+            }
             snprintf(tmpString,
                      W3C_DESCRIPTION_MAX_LEN,
-                     "This transaction was scanned as malicious by Web3 Checks.\n\nView full %s "
-                     "report:\nurl.com/od24xz",
-                     provider);
+                     "This transaction was scanned as malicious by Web3 Checks.\n\n"
+                     "View full %s report:\n%s",
+                     provider,
+                     reviewWithWarnCtx.warning->reportUrl);
             nbgl_layoutAddContentCenter(reviewWithWarnCtx.modalLayout, &info);
             footerDesc.emptySpace.height = MEDIUM_CENTERING_HEADER;
             headerDesc.separationLine    = false;
@@ -1992,8 +2008,8 @@ static void displaySecurityReport(uint32_t set)
         if (reviewWithWarnCtx.isIntro) {
 #ifdef NBGL_QRCODE
             // display a QR Code if in intro
-            nbgl_layoutQRCode_t qrCode = {.url      = "url.com/od24xz",
-                                          .text1    = "url.com/od24xz",
+            nbgl_layoutQRCode_t qrCode = {.url      = reviewWithWarnCtx.warning->reportUrl,
+                                          .text1    = reviewWithWarnCtx.warning->reportUrl,
                                           .text2    = tmpString,
                                           .centered = true,
                                           .offsetY  = 0};
@@ -2011,13 +2027,19 @@ static void displaySecurityReport(uint32_t set)
             nbgl_contentCenter_t info = {0};
             info.icon                 = &C_Warning_64px;
             info.title                = "Risk detected";
-            info.smallTitle           = "Losing swap";
             info.description          = tmpString;
+            if (reviewWithWarnCtx.warning->providerMessage != NULL) {
+                info.smallTitle = reviewWithWarnCtx.warning->providerMessage;
+            }
+            else {
+                info.smallTitle = "Losing swap";
+            }
             snprintf(tmpString,
                      W3C_DESCRIPTION_MAX_LEN,
                      "This transaction was scanned as risky by Web3 Checks.\n\n"
-                     "View full %s report:\\nurl.com/od24xz",
-                     provider);
+                     "View full %s report:\n%s",
+                     provider,
+                     reviewWithWarnCtx.warning->reportUrl);
             nbgl_layoutAddContentCenter(reviewWithWarnCtx.modalLayout, &info);
             footerDesc.emptySpace.height = MEDIUM_CENTERING_HEADER;
             headerDesc.separationLine    = false;
@@ -2144,15 +2166,39 @@ static void displayInitialWarning(void)
             info.description
                 = "An issue prevented Web3 Checks from running.\nGet help: ledger.com/e11";
         }
+        else if (reviewWithWarnCtx.warning->predefinedSet == (1 << W3C_LOSING_SWAP_WARN)) {
+            info.title       = "Risk detected";
+            info.description = "This transaction was scanned as ricky by Web3 Checks.";
+            if (reviewWithWarnCtx.warning->providerMessage != NULL) {
+                info.smallTitle = reviewWithWarnCtx.warning->providerMessage;
+            }
+            else {
+                info.smallTitle = "Losing swap";
+            }
+        }
         else if (reviewWithWarnCtx.warning->predefinedSet == (1 << W3C_THREAT_DETECTED_WARN)) {
             info.title       = "Threat detected";
-            info.smallTitle  = "Known drainer contract";
             info.description = "This transaction was scanned as malicious by Web3 Checks.";
+            if (reviewWithWarnCtx.warning->providerMessage != NULL) {
+                info.smallTitle = reviewWithWarnCtx.warning->providerMessage;
+            }
+            else {
+                info.smallTitle = "Known drainer contract";
+            }
         }
         else {
+            // Case with Several warnings (e.g. Blind + W3C)
             info.title = "Dangerous transaction";
-            info.description
-                = "This transaction cannot be fully decoded, and was not verified by Web3 Checks.";
+            if (reviewWithWarnCtx.warning->predefinedSet & (1 << W3C_ISSUE_WARN)) {
+                info.description
+                    = "This transaction cannot be fully decoded, and was not verified by Web3 "
+                      "Checks.";
+            }
+            else {
+                info.description
+                    = "This transaction cannot be fully decoded, and was marked as risky by Web3 "
+                      "Checks.";
+            }
         }
         nbgl_layoutAddContentCenter(reviewWithWarnCtx.layoutCtx, &info);
     }


### PR DESCRIPTION
## Description

Add support for customized fields:
- `reportUrl`
- `providerMessage`

Handle thesee fields in the different Warning Screens
Update the doc accordingly
