### PR TITLE
No UI/UX when calling an app in lib mode

### DIFF
--- a/lib_standard_app/main.c
+++ b/lib_standard_app/main.c
@@ -128,10 +128,6 @@ WEAK void library_app_main(libargs_t *args)
 
                         common_app_init();
 
-#ifdef HAVE_NBGL
-                        nbgl_useCaseSpinner("Signing");
-#endif  // HAVE_NBGL
-
                         app_main();
                     }
                     break;


### PR DESCRIPTION
## Description

When calling an app as a lib, using NBGL or BAGL is not allowed and can make the app crash.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

