### PR TITLE
Fix partially erased top right icon on level 22

### DIFF
--- a/lib_nbgl/src/nbgl_layout_internal.h
+++ b/lib_nbgl/src/nbgl_layout_internal.h
@@ -54,8 +54,8 @@ typedef enum {
 // used by screen (top level)
 enum {
     HEADER_INDEX = 0,  // For header container
-    TOP_RIGHT_BUTTON_INDEX,
     MAIN_CONTAINER_INDEX,
+    TOP_RIGHT_BUTTON_INDEX,
     FOOTER_INDEX,
     UP_FOOTER_INDEX,
     LEFT_BORDER_INDEX,


### PR DESCRIPTION
## Description

The goal of this PR is to fix partially erased top right icon on API level 22

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
