### PR TITLE
Add a syscall to check recovery mode

### DIFF
--- a/include/os_ux.h
+++ b/include/os_ux.h
@@ -100,3 +100,5 @@ SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX) void os_dashboard_mbx(uint32_t cmd
 SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX) void os_ux_set_global(uint8_t  param_type,
                                                                     uint8_t *param,
                                                                     size_t   param_len);
+SYSCALL PERMISSION(APPLICATION_FLAG_BOLOS_UX)
+bolos_bool_t os_ux_mode_is_recovery(void);

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -198,8 +198,9 @@
 #define SYSCALL_os_pki_get_info_ID         0x040000ac
 #endif  // HAVE_LEDGER_PKI
 
-#define SYSCALL_os_dashboard_mbx_ID 0x02000150
-#define SYSCALL_os_ux_set_global_ID 0x03000151
+#define SYSCALL_os_dashboard_mbx_ID       0x02000150
+#define SYSCALL_os_ux_set_global_ID       0x03000151
+#define SYSCALL_os_ux_mode_is_recovery_ID 0x00000153
 
 #ifdef HAVE_CUSTOM_CA_DETAILS_IN_SETTINGS
 #define SYSCALL_CERT_get_ID   0x01000CA0

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1601,6 +1601,13 @@ void os_ux_set_global(uint8_t param_type, uint8_t *param, size_t param_len)
     SVC_Call(SYSCALL_os_ux_set_global_ID, parameters);
 }
 
+bolos_bool_t os_ux_mode_is_recovery(void)
+{
+    unsigned int parameters[2];
+    parameters[1] = 0;
+    return (bolos_bool_t) SVC_Call(SYSCALL_os_ux_mode_is_recovery_ID, parameters);
+}
+
 void os_lib_call(unsigned int *call_parameters)
 {
     unsigned int parameters[2];


### PR DESCRIPTION
## Description

This PR adds a new UX syscall to determine if the device is in recovery mode.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes
New syscall (UX)
