### PR TITLE
Add dynamic memory allocator

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,6 +29,8 @@ jobs:
           STAX=1 cmake -Bbuild -H. && make -C build && CTEST_OUTPUT_ON_FAILURE=1 make -C build test
           cd ../app_storage/
           cmake -Bbuild -H. && make -C build && make -C build test
+          cd ../lib_alloc/
+          cmake -Bbuild -H. && make -C build && make -C build test
 
       - name: Generate code coverage
         run: |
@@ -37,6 +39,8 @@ jobs:
           cd ../lib_nbgl/
           ../gen_coverage.sh
           cd ../app_storage/
+          ../gen_coverage.sh
+          cd ../lib_alloc/
           ../gen_coverage.sh
 
       - uses: actions/upload-artifact@v4

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -27,6 +27,11 @@ else
     NBGL_INCLUDE_PATH := lib_nbgl
 endif
 
+# include dynamic memory allocator, if asked (temporary flag)
+ifeq ($(ENABLE_DYNAMIC_ALLOC), 1)
+  SDK_SOURCE_PATH += lib_alloc
+endif
+
 define uniq =
   $(eval seen :=)
   $(foreach _,$1,$(if $(filter $_,${seen}),,$(eval seen += $_)))

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -825,6 +825,8 @@ WARN_LOGFILE           =
 
 INPUT                  = \
                          doc \
+                         lib_alloc \
+                         lib_alloc/doc \
                          lib_cxng/doc \
                          lib_cxng/include \
                          lib_cxng/src \

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -13,6 +13,10 @@ The @subpage ble_mainpage page contains all information necessary to interact wi
 
 The @subpage cxng_mainpage page contains all information necessary to understand Cryptographic Library
 
+@section mem_presentation Dynamic Memory Allocator Interface
+
+The @subpage mem_alloc_mainpage page contains all information necessary to interact with Dynamic Memory Allocator.
+
 @section nbgl_presentation Screen drawing API
 
 The @subpage nbgl_mainpage page contains all information necessary to understand the Graphical Library for

--- a/include/errors.h
+++ b/include/errors.h
@@ -150,5 +150,6 @@ enum sdk_generic_identifiers {
 #define EXCEPTION_IO_STATE    0x11  // keep original value // SWO_MUI_UNK_15
 #define EXCEPTION_CXPORT      0x12  // keep original value // SWO_MUI_UNK_16
 #define EXCEPTION_SYSTEM      0x13  // keep original value // SWO_MUI_UNK_17
+#define EXCEPTION_CORRUPT     0x14
 
 #endif  // ERRORS_H

--- a/lib_alloc/doc/mainpage.dox
+++ b/lib_alloc/doc/mainpage.dox
@@ -1,0 +1,21 @@
+/** @page mem_alloc_mainpage Dynamic memory allocator
+
+@section mem_alloc_mainpage_intro Introduction
+
+This page describes the Dynamic Memory Allocator available for Applications.
+
+Basically, this allocator behaves like any memory allocator in usual OS. The main difference is that it can be instantiated, thanks to
+its initialization function: @ref mem_init()
+
+This function takes as parameters
+
+- a pointer to a buffer that will be used both as context for the Allocator and for dynamic chunks,
+- and the size of this buffer
+
+It returns a memory context (@ref mem_ctx_t) that will be used by other functions
+
+Then, chunks can be allocated with @ref mem_alloc() and released with @ref mem_free()
+
+Both of these function take the memory context as first parameter.
+
+*/

--- a/lib_alloc/mem_alloc.c
+++ b/lib_alloc/mem_alloc.c
@@ -1,0 +1,403 @@
+/**
+ * @file mem_alloc.c
+ * @brief Dynamic memory allocation implementation
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include <stdio.h>
+#include <string.h>
+#include "exceptions.h"
+#include "errors.h"
+#include "os_helpers.h"
+#include "os_print.h"
+#include "os_utils.h"
+#include "mem_alloc.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+// sizeof of header for a allocated chunk
+#define ALLOC_CHUNK_HEADER_SIZE 4
+// sizeof of header for a free chunk
+#define FREE_CHUNK_HEADER_SIZE  8
+// Alignment for payload size
+#define PAYLOAD_ALIGNEMENT      4
+// size of heap header
+#define HEAP_HEADER_SIZE        (sizeof(heap_t) + PAYLOAD_ALIGNEMENT)
+
+// 16 segments enable using up to 64kBytes for Heap, so way too much
+#define NUM_SEG_LISTS 16
+
+#define GET_PTR(_heap, index) \
+    ((header_t *) (((uint8_t *) _heap) + PAYLOAD_ALIGNEMENT + ((index) << 3)))
+#define GET_IDX(_heap, _ptr) \
+    ((((uint8_t *) (_ptr)) - ((uint8_t *) _heap) - PAYLOAD_ALIGNEMENT) >> 3)
+#define GET_PREV(_heap, _ptr) \
+    ((header_t *) (((uint8_t *) _heap) + PAYLOAD_ALIGNEMENT + ((_ptr)->fprev << 3)))
+#define GET_NEXT(_heap, _ptr) \
+    ((header_t *) (((uint8_t *) _heap) + PAYLOAD_ALIGNEMENT + ((_ptr)->fnext << 3)))
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef struct header_s {
+    uint16_t size : 15;
+    uint16_t allocated : 1;
+
+    uint16_t phys_prev;  ///< physical previous chunk
+
+    uint16_t fprev;  ///< previous free chunk in the same segment
+    uint16_t fnext;  ///< next free chunk in the same segment
+} header_t;
+
+// Segregated free list bucket sizes:
+// 0: 16-31 bytes
+// 1: 32-63 bytes
+// n: 2^n-(2^(n+1)-1) bytes
+// ....
+typedef struct {
+    void    *end;
+    size_t   nb_segs;  ///< actual number of used segments
+    uint16_t free_segments[NUM_SEG_LISTS];
+} heap_t;
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *   LOCAL FUNCTIONS
+ **********************/
+// This function returns the index into the array segregated explicit free lists
+// corresponding to the given size.
+// For 2^n <= size < 2^(n+1), this function returns n.
+static inline int seglist_index(heap_t *heap, size_t size)
+{
+    size_t seg = 32 - __builtin_clz(size);
+    if (seg >= heap->nb_segs) {
+        seg = heap->nb_segs - 1;
+    }
+    return seg;
+}
+
+// remove item from linked list
+static inline void list_remove(heap_t *heap, uint16_t *first_free, uint16_t elem)
+{
+    header_t *elem_ptr = GET_PTR(heap, elem);
+    // if was the first, set a new first
+    if (*first_free == elem) {
+        *first_free = elem_ptr->fnext;
+        // if the current first was not alone
+        if (*first_free) {
+            GET_PTR(heap, *first_free)->fprev = 0;
+        }
+        return;
+    }
+    // link previous to following, if existing previous
+    if (elem_ptr->fprev) {
+        GET_PREV(heap, elem_ptr)->fnext = elem_ptr->fnext;
+    }
+    // link following to previous, if existing following
+    if (elem_ptr->fnext) {
+        GET_NEXT(heap, elem_ptr)->fprev = elem_ptr->fprev;
+    }
+}
+
+// add item in LIFO
+static inline void list_push(heap_t *heap, header_t *header)
+{
+    uint8_t  seg_index = seglist_index(heap, header->size);
+    uint16_t first_idx = heap->free_segments[seg_index];
+    // if it's already the first item, nothing to do
+    if (first_idx == GET_IDX(heap, header)) {
+        return;
+    }
+    // link this new first to following (previous first)
+    header->fnext     = first_idx;
+    header->fprev     = 0;
+    header->allocated = 0;
+    // link following (previous first) to new first
+    if (first_idx != 0) {
+        header_t *first = GET_PTR(heap, first_idx);
+        first->fprev    = GET_IDX(heap, header);
+    }
+    // replace new first
+    heap->free_segments[seg_index] = GET_IDX(heap, header);
+}
+
+// ensure the chunk is valid
+static inline void ensure_chunk_valid(heap_t *heap, header_t *header)
+{
+    uint8_t *block = (uint8_t *) header;
+    // ensure size is valid (multiple of pointers) and minimal size of 4 pointers)
+    if ((header->size & (PAYLOAD_ALIGNEMENT - 1)) || (header->size < FREE_CHUNK_HEADER_SIZE)
+        || ((block + header->size) > (uint8_t *) heap->end)) {
+        PRINTF("invalid size: header->size  = %d!\n", header->size);
+        THROW(EXCEPTION_CORRUPT);
+    }
+    //  ensure phys_prev is valid
+    if (header->phys_prev != 0) {
+        header_t *prev = GET_PTR(heap, header->phys_prev);
+        block          = (uint8_t *) heap;
+        if (((uint8_t *) prev < &block[HEAP_HEADER_SIZE]) || ((void *) prev > heap->end)) {
+            PRINTF("corrupted prev_chunk\n");
+            THROW(EXCEPTION_CORRUPT);
+        }
+        // ensure that next of prev is current
+        if ((((uint8_t *) prev) + prev->size) != (uint8_t *) header) {
+            PRINTF("corrupted prev_chunk\n");
+            THROW(EXCEPTION_CORRUPT);
+        }
+    }
+}
+
+// coalesce the two given chunks
+static header_t *coalesce(heap_t *heap, header_t *header, header_t *neighbour)
+{
+    uint16_t neighbour_idx = GET_IDX(heap, neighbour);
+    ensure_chunk_valid(heap, neighbour);
+
+    // if not allocated, coalesce
+    if (!neighbour->allocated) {
+        // remove this neighbour from its free list
+        list_remove(
+            heap, &heap->free_segments[seglist_index(heap, neighbour->size)], neighbour_idx);
+        // link the current next physical chunk (if existing) to this new chunk
+        header_t *next;
+        if (header < neighbour) {
+            next = (header_t *) (((uint8_t *) neighbour) + neighbour->size);
+            if ((void *) next < heap->end) {
+                next->phys_prev = GET_IDX(heap, header);
+            }
+            header->size += neighbour->size;
+        }
+        else {
+            next            = (header_t *) (((uint8_t *) header) + header->size);
+            next->phys_prev = neighbour_idx;
+            neighbour->size += header->size;
+            header = neighbour;
+        }
+    }
+    return header;
+}
+
+static bool parse_callback(void *data, uint8_t *addr, bool allocated, size_t size)
+{
+    mem_stat_t *stat = (mem_stat_t *) data;
+
+    UNUSED(addr);
+    // error reached
+    if (size == 0) {
+        return true;
+    }
+    stat->nb_chunks++;
+    if (allocated) {
+        stat->nb_allocated++;
+        stat->allocated_size += size;
+    }
+    else {
+        stat->free_size += size;
+    }
+    stat->total_size += size;
+
+    return false;
+}
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+/**
+ * @brief initializes the heap for this allocator
+ *
+ * @param heap_start address of the heap to use
+ * @param heap_size size in bytes of the heap to use
+ * @return the context to use for further calls
+ */
+mem_ctx_t mem_init(void *heap_start, size_t heap_size)
+{
+    heap_t *heap = (heap_t *) heap_start;
+
+    heap->end = ((uint8_t *) heap_start) + heap_size;
+
+    // compute number of segments
+    heap->nb_segs = 32 - __builtin_clz(heap_size);
+    memset(heap->free_segments, 0, heap->nb_segs * sizeof(uint16_t));
+
+    // initiate free chunk LIFO with the whole heap as a free chunk
+    header_t *first_free  = (header_t *) (((uint8_t *) heap) + HEAP_HEADER_SIZE);
+    first_free->size      = heap_size - HEAP_HEADER_SIZE;
+    first_free->phys_prev = 0;
+    list_push(heap, first_free);
+
+    return (mem_ctx_t) heap_start;
+}
+
+/**
+ * @brief allocates a buffer of the given size, if possible
+ * @note this buffer should be free later with @ref mem_free
+ *
+ * @param ctx allocator context (returned by @ref mem_init())
+ * @param nb_bytes size in bytes of the buffer to allocate
+ * @return either a valid address if successful, or NULL if failed
+ */
+void *mem_alloc(mem_ctx_t ctx, size_t nb_bytes)
+{
+    heap_t *heap = (heap_t *) ctx;
+    size_t  seg;
+    // Adjust size to include header and satisfy alignment requirements, etc.
+    nb_bytes += PAYLOAD_ALIGNEMENT - 1;
+    nb_bytes &= ~(PAYLOAD_ALIGNEMENT - 1);
+
+    // if nb_bytes = 8N + 4, just add 4 for header
+    if (nb_bytes & PAYLOAD_ALIGNEMENT) {
+        nb_bytes += ALLOC_CHUNK_HEADER_SIZE;  // for header (size +  prev_chunk)
+    }
+    else {
+        // if nb_bytes = 8N, add 8 for header + unused footer
+        nb_bytes += ALLOC_CHUNK_HEADER_SIZE + PAYLOAD_ALIGNEMENT;
+    }
+
+    // get the segment sure to be holding this size
+    // if nb_bytes == 2^n , all chunks in [2^n: 2^(n+1)[ are ok
+    // if nb_bytes > 2^n , all chunks in [2^(n+1): 2^(n+2)[ are ok
+    seg = seglist_index(heap, nb_bytes);
+    if ((nb_bytes > (size_t) (1 << seg)) && (seg < (heap->nb_segs))) {
+        seg++;
+    }
+    // Loop through all increasing size segments
+    while (seg < heap->nb_segs) {
+        uint16_t chunk_idx = heap->free_segments[seg];
+        // if this segment is not empty, it must contain a big-enough chunk
+        if (chunk_idx != 0) {
+            header_t *header = GET_PTR(heap, chunk_idx);
+
+            //  ensure chunk is consistent
+            ensure_chunk_valid(heap, header);
+            // this block shall always be big enough
+            if (nb_bytes > header->size) {
+                // probably a big issue, maybe necessary to throw an exception
+                return NULL;
+            }
+            uint8_t *block = (uint8_t *) header;
+
+            // remove the block from the segregated list
+            list_remove(heap, &heap->free_segments[seg], chunk_idx);
+            // We could turn the excess bytes into a new free block
+            // the minimum size is the size of an empty chunk
+            if (header->size >= (nb_bytes + FREE_CHUNK_HEADER_SIZE)) {
+                header_t *new_free = (header_t *) &block[nb_bytes];
+                new_free->size     = header->size - nb_bytes;
+                // link this new chunk to previous (found) one
+                new_free->phys_prev = chunk_idx;
+                // link the current next physical chunk to this new chunk (if existing)
+                header_t *next = (header_t *) &block[header->size];
+                if ((void *) next < heap->end) {
+                    next->phys_prev = GET_IDX(heap, new_free);
+                }
+                list_push(heap, new_free);
+                // change size only if new chunk is created
+                header->size = nb_bytes;
+            }
+
+            // Update the chunk's header to set the allocated bit
+            header->allocated = 0x1;
+
+            // Return a pointer to the payload
+            return block + ALLOC_CHUNK_HEADER_SIZE;
+        }
+        // not found in current segment, let's try in bigger segment
+        seg++;
+    }
+    return NULL;
+}
+
+/**
+ * @brief frees the given buffer
+ *
+ * @param ctx allocator context (returned by @ref mem_init())
+ * @param ptr buffer previously allocated with @ref mem_alloc
+ */
+void mem_free(mem_ctx_t ctx, void *ptr)
+{
+    heap_t   *heap   = (heap_t *) ctx;
+    uint8_t  *block  = ((uint8_t *) ptr) - ALLOC_CHUNK_HEADER_SIZE;
+    header_t *header = (header_t *) block;
+
+    // ensure size is consistent
+    ensure_chunk_valid(heap, header);
+    // if not allocated, return
+    if (!header->allocated) {
+        return;
+    }
+    // try to coalesce with adjacent physical chunks (after and before)
+    // try with next physical chunk
+    if ((block + header->size) < (uint8_t *) heap->end) {
+        header = coalesce(heap, header, (header_t *) (block + header->size));
+    }
+    // try previous chunk
+    if (header->phys_prev != 0) {
+        header = coalesce(heap, header, GET_PTR(heap, header->phys_prev));
+    }
+
+    // free chunk and add it on top of free chunk LIFO
+    list_push(heap, header);
+}
+
+/**
+ * @brief parse the heap
+ *
+ * @param ctx allocator context (returned by @ref mem_init())
+ * @param ptr buffer previously allocated with @ref mem_alloc
+ * @param data context data, passed to given callback
+ */
+void mem_parse(mem_ctx_t ctx, mem_parse_callback_t callback, void *data)
+{
+    heap_t   *heap   = (heap_t *) ctx;
+    header_t *header = (header_t *) (((uint8_t *) heap) + HEAP_HEADER_SIZE);
+#ifdef DEBUG_FREE_SEGMENTS
+    for (size_t i = 0; i < heap->nb_segs; i++) {
+        if (heap->free_segments[i] != NULL) {
+            header_t *head      = heap->free_segments[i];
+            int       nb_elemts = 0;
+            while (head) {
+                nb_elemts++;
+                head = head->fnext;
+            }
+        }
+    }
+#endif  // DEBUG_FREE_SEGMENTS
+    while (header != NULL) {
+        uint8_t *block = (uint8_t *) header;
+        // break the loop if the callback returns true
+        if (callback(data, block, header->allocated, header->size)) {
+            return;
+        }
+        if (&block[header->size] < (uint8_t *) heap->end) {
+            header = (header_t *) &block[header->size];
+        }
+        else {
+            return;
+        }
+    }
+}
+
+/**
+ * @brief function used to get statistics (nb chunks, nb allocated chunks, total size)  about the
+ * heap
+ *
+ * @param ctx allocator context (returned by @ref mem_init())
+ * @param ptr buffer previously allocated with @ref mem_alloc
+ */
+void mem_stat(mem_ctx_t *ctx, mem_stat_t *stat)
+{
+    memset(stat, 0, sizeof(mem_stat_t));
+    stat->total_size = HEAP_HEADER_SIZE;
+    mem_parse(ctx, parse_callback, stat);
+}

--- a/lib_alloc/mem_alloc.h
+++ b/lib_alloc/mem_alloc.h
@@ -1,0 +1,67 @@
+/**
+ * @file mem_alloc.h
+ * @brief Dynamic memory allocation API
+ *
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+/**
+ * @brief type shared externally
+ *
+ */
+typedef void *mem_ctx_t;
+
+/**
+ * @brief function called for each chunk found in the heap.
+ *
+ * @param data context data, passed as argument of @ref mem_parse
+ * @param addr address of the chunk (as returned by @ref mem_alloc) if allocated
+ * @param allocated if true, means the chunk is allocated
+ * @param size size of the chunk, in bytes (including header & alignment bytes)
+ *
+ * @return shall return true to break parsing
+ *
+ */
+typedef bool (*mem_parse_callback_t)(void *data, uint8_t *addr, bool allocated, size_t size);
+
+/**
+ * @brief this structure, filled by @ref mem_stat
+ *
+ */
+typedef struct {
+    size_t total_size;        ///< total size of the heap (including allocator internal data)
+    size_t free_size;         ///< nb bytes free in the heap (be careful, it doesn't mean it can be
+                              ///< allocated in a single chunk)
+    size_t   allocated_size;  ///< nb bytes allocated in the heap (including headers)
+    uint32_t nb_chunks;       ///< total number of chunks
+    uint32_t nb_allocated;    ///< number of allocated chunks
+} mem_stat_t;
+
+/**********************
+ *      GLOBAL PROTOTYPES
+ **********************/
+
+mem_ctx_t mem_init(void *heap_start, size_t heap_size);
+void     *mem_alloc(mem_ctx_t ctx, size_t nb_bytes);
+void      mem_free(mem_ctx_t ctx, void *ptr);
+void      mem_parse(mem_ctx_t ctx, mem_parse_callback_t callback, void *dat);
+void      mem_stat(mem_ctx_t *ctx, mem_stat_t *stat);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/unit-tests/lib_alloc/CMakeLists.txt
+++ b/unit-tests/lib_alloc/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.10)
+
+if(${CMAKE_VERSION} VERSION_LESS 3.10)
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
+
+# project information
+project(unit_tests
+        VERSION 0.1
+	      DESCRIPTION "Unit tests for Dynamic Allocator"
+        LANGUAGES C)
+
+
+# guard against bad build-type strings
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+include(CTest)
+ENABLE_TESTING()
+
+# specify C standard
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED True)
+
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall ${DEFINES} -g -O0 --coverage")
+
+set(GCC_COVERAGE_LINK_FLAGS "--coverage -lgcov")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
+
+# guard against in-source builds
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
+endif()
+
+add_compile_definitions(TEST)
+
+include_directories(.)
+include_directories(../../target/stax/include)
+include_directories(../../include)
+include_directories(../../lib_alloc)
+
+add_executable(test_mem_alloc test_mem_alloc.c ../../lib_alloc/mem_alloc.c)
+
+target_link_libraries(test_mem_alloc PUBLIC cmocka gcov)
+
+target_link_options(
+  test_mem_alloc
+  PRIVATE
+  -Wl,--wrap=os_longjmp
+)
+
+add_test(test_mem_alloc test_mem_alloc)

--- a/unit-tests/lib_alloc/README.md
+++ b/unit-tests/lib_alloc/README.md
@@ -1,0 +1,36 @@
+# Dynamic Allocator Unit tests
+
+## Prerequisite
+
+Be sure to have installed:
+
+- CMake >= 3.10
+- CMocka >= 1.1.5
+
+and for code coverage generation:
+
+- lcov >= 1.14
+
+## Overview
+
+In `unit-tests` folder, compile with:
+
+```
+cmake -Bbuild -H. && make -C build
+```
+
+and run tests with:
+
+```
+CTEST_OUTPUT_ON_FAILURE=1 make -C build test
+```
+
+## Generate code coverage
+
+Just execute in `unit-tests` folder
+
+```
+../gen_coverage.sh
+```
+
+it will output `coverage.total` and `coverage/` folder with HTML details (in `coverage/index.html`).

--- a/unit-tests/lib_alloc/test_mem_alloc.c
+++ b/unit-tests/lib_alloc/test_mem_alloc.c
@@ -1,0 +1,207 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "mem_alloc.h"
+#include "errors.h"
+
+#define UNUSED(x) (void) x
+
+static uint32_t malloc_buffer[4096 + 0x90];
+static uint32_t malloc_buffer_size;
+bool            display_parse = false;
+
+jmp_buf buffer_jmp_testing;
+
+static unsigned int throw_value;
+
+// Wrapper function for throw
+void __wrap_os_longjmp(unsigned int error_code)
+{
+    throw_value = error_code;
+    longjmp(buffer_jmp_testing, 1);
+}
+
+unsigned int get_throw_value(void)
+{
+    return throw_value;
+}
+
+static void assert_state(mem_ctx_t ctx, uint32_t nb_chunks, uint32_t nb_allocs)
+{
+    mem_stat_t mapping;
+    mem_stat(ctx, &mapping);
+    assert_int_equal(mapping.nb_chunks, nb_chunks);
+    assert_int_equal(mapping.nb_allocated, nb_allocs);
+    assert_int_equal(mapping.total_size, malloc_buffer_size);
+}
+
+static void test_alloc(void **state __attribute__((unused)))
+{
+    malloc_buffer_size = sizeof(malloc_buffer);
+    mem_ctx_t ctx      = mem_init(malloc_buffer, malloc_buffer_size);
+
+    // assert only one big empty chunk
+    assert_state(ctx, 1, 0);
+
+    char *chunk1 = mem_alloc(ctx, 12);
+    assert_non_null(chunk1);
+    assert_state(ctx, 2, 1);
+    char *chunk2 = mem_alloc(ctx, 120);
+    assert_non_null(chunk2);
+    assert_state(ctx, 3, 2);
+
+    mem_free(ctx, chunk1);
+    // expect 3 chunks and 1 allocated
+    assert_state(ctx, 3, 1);
+
+    chunk1 = mem_alloc(ctx, 12);
+    assert_non_null(chunk1);
+    // expect 3 chunks and 2 allocated
+    assert_state(ctx, 3, 2);
+
+    mem_free(ctx, chunk2);
+    // expect 2 chunks and 1 allocated (because coalesce)
+    assert_state(ctx, 2, 1);
+
+    mem_free(ctx, chunk1);
+    assert_state(ctx, 1, 0);
+
+    // ask too much and expect NULL
+    chunk1 = mem_alloc(ctx, 1 << 14);
+    assert_null(chunk1);
+}
+
+static void test_corrupt_invalid(void **state __attribute__((unused)))
+{
+    uint32_t throw_raised_code = 0;
+
+    memset(buffer_jmp_testing, 0, sizeof(jmp_buf));
+    malloc_buffer_size = sizeof(malloc_buffer);
+    mem_ctx_t ctx      = mem_init(malloc_buffer, malloc_buffer_size);
+
+    // assert only one big empty chunk
+    assert_state(ctx, 1, 0);
+
+    char *chunk1 = mem_alloc(ctx, 12);
+    assert_non_null(chunk1);
+    char *chunk2 = mem_alloc(ctx, 120);
+    assert_non_null(chunk2);
+    assert_state(ctx, 3, 2);
+
+    // overflow of first chunk to destroy second chunk header with invalid size
+    memset(&chunk1[12], 0xAA, 20);
+    if (setjmp(buffer_jmp_testing) == 0) {
+        mem_free(ctx, chunk2);
+    }
+    else {
+        throw_raised_code = get_throw_value();
+    }
+
+    assert_int_equal(throw_raised_code, EXCEPTION_CORRUPT);
+}
+
+static void test_corrupt_overflow(void **state __attribute__((unused)))
+{
+    uint32_t throw_raised_code = 0;
+
+    memset(buffer_jmp_testing, 0, sizeof(jmp_buf));
+    malloc_buffer_size = sizeof(malloc_buffer);
+    mem_ctx_t ctx      = mem_init(malloc_buffer, malloc_buffer_size);
+
+    // assert only one big empty chunk
+    assert_state(ctx, 1, 0);
+
+    char *chunk1 = mem_alloc(ctx, 12);
+    assert_non_null(chunk1);
+    char *chunk2 = mem_alloc(ctx, 120);
+    assert_non_null(chunk2);
+    assert_state(ctx, 3, 2);
+
+    // overflow of first chunk to destroy next chunk and try to free it
+    memset(&chunk1[10], 0x88, 20);
+    if (setjmp(buffer_jmp_testing) == 0) {
+        mem_free(ctx, chunk2);
+    }
+    else {
+        throw_raised_code = get_throw_value();
+    }
+
+    assert_int_equal(throw_raised_code, EXCEPTION_CORRUPT);
+}
+
+static void test_fragmentation(void **state __attribute__((unused)))
+{
+    char *small_chunks[16];
+    char *middle_chunks[16];
+    char *large_chunks[16];
+#ifndef USE_POINTER
+    malloc_buffer_size = 1856 + 52;
+#else   // USE_POINTER
+    malloc_buffer_size = 2048 + 0x90;
+#endif  // USE_POINTER
+    mem_ctx_t ctx = mem_init(malloc_buffer, malloc_buffer_size);
+
+    // assert only one big empty chunk
+    assert_state(ctx, 1, 0);
+
+    // allocate chunks to fill entirely the heap
+    for (int i = 0; i < 8; i++) {
+        mem_stat_t mapping;
+
+        mem_stat(ctx, &mapping);
+#ifndef USE_POINTER
+        assert_int_equal(mapping.free_size,
+                         malloc_buffer_size - 52 - ((16 + 64 + 128) + 3 * 8) * i);
+#else   // USE_POINTER
+        assert_int_equal(mapping.free_size,
+                         malloc_buffer_size - 0x90 - ((16 + 64 + 128) + 6 * 8) * i);
+#endif  // USE_POINTER
+        small_chunks[i] = mem_alloc(ctx, 16);
+        assert_non_null(small_chunks[i]);
+        middle_chunks[i] = mem_alloc(ctx, 64);
+        assert_non_null(middle_chunks[i]);
+        large_chunks[i] = mem_alloc(ctx, 128);
+        assert_non_null(large_chunks[i]);
+    }
+    assert_state(ctx, 24, 24);
+    // release all small chunks and try to allocate a middle chunk
+    for (int i = 0; i < 8; i++) {
+        mem_free(ctx, small_chunks[i]);
+    }
+    assert_state(ctx, 24, 16);
+    middle_chunks[8] = mem_alloc(ctx, 64);
+    assert_null(middle_chunks[8]);
+    // release all middle chunks and try to allocate a large chunk
+    for (int i = 0; i < 8; i++) {
+        mem_free(ctx, middle_chunks[i]);
+    }
+    assert_state(ctx, 16, 8);
+    large_chunks[8] = mem_alloc(ctx, 128);
+    assert_null(large_chunks[8]);
+    middle_chunks[0] = mem_alloc(ctx, 64);
+    assert_non_null(middle_chunks[0]);
+    middle_chunks[1] = mem_alloc(ctx, 64);
+    assert_non_null(middle_chunks[1]);
+    assert_state(ctx, 18, 10);
+
+    // release all large chunks
+    for (int i = 0; i < 8; i++) {
+        mem_free(ctx, large_chunks[i]);
+    }
+    // assert 5 chunks and 2 allocated
+    assert_state(ctx, 5, 2);
+}
+
+int main(int argc, char **argv)
+{
+    const struct CMUnitTest tests[] = {cmocka_unit_test(test_alloc),
+                                       cmocka_unit_test(test_corrupt_invalid),
+                                       cmocka_unit_test(test_corrupt_overflow),
+                                       cmocka_unit_test(test_fragmentation)};
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/unit-tests/lib_alloc/test_mem_alloc.c
+++ b/unit-tests/lib_alloc/test_mem_alloc.c
@@ -140,7 +140,7 @@ static void test_fragmentation(void **state __attribute__((unused)))
     char *middle_chunks[16];
     char *large_chunks[16];
 #ifndef USE_POINTER
-    malloc_buffer_size = 1856 + 52;
+    malloc_buffer_size = 1950 + 52;
 #else   // USE_POINTER
     malloc_buffer_size = 2048 + 0x90;
 #endif  // USE_POINTER


### PR DESCRIPTION
## Description

The goal of this PR is to implement a dynamic memory allocator, usable at least by the applications.
Each application can provide a buffer to be used as dynamic allocation buffer, and then use mem_alloc() and mem_free() to allocate and release memory chunks
A full explanation is available in https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/5371068584/Study+-+Dynamic+Storage+Allocation

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
