### PR TITLE
Adapt for RK backup state

### DIFF
--- a/include/os_settings.h
+++ b/include/os_settings.h
@@ -122,6 +122,9 @@ typedef enum os_setting_e {
 // in side screen is enabled
 #define OS_SETTING_FEATURES_BATT_IN_SIDE_OFFSET   0x2
 #define OS_SETTING_FEATURES_BATT_IN_SIDE          (1 << OS_SETTING_FEATURES_BATT_IN_SIDE_OFFSET)
+// if (os_settings[OS_SETTING_FEATURES] & OS_SETTING_FEATURES_CHARON_BACKUP) then we are in the
+// state "Charon backup at end of onboarding"
+#define OS_SETTING_FEATURES_CHARON_BACKUP         0x80
 
 // Default features value
 #define FEATURES_DEFAULT_NFC_ENABLED    1

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -198,8 +198,9 @@
 #define SYSCALL_os_pki_get_info_ID         0x040000ac
 #endif  // HAVE_LEDGER_PKI
 
-#define SYSCALL_os_dashboard_mbx_ID 0x02000150
-#define SYSCALL_os_ux_set_global_ID 0x03000151
+#define SYSCALL_os_dashboard_mbx_ID       0x02000150
+#define SYSCALL_os_ux_set_global_ID       0x03000151
+#define SYSCALL_os_rk_set_backup_state_ID 0x01000152
 
 #ifdef HAVE_CUSTOM_CA_DETAILS_IN_SETTINGS
 #define SYSCALL_CERT_get_ID   0x01000CA0

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1601,6 +1601,15 @@ void os_ux_set_global(uint8_t param_type, uint8_t *param, size_t param_len)
     SVC_Call(SYSCALL_os_ux_set_global_ID, parameters);
 }
 
+#ifdef HAVE_CHARON
+void RK_set_backup_state(RK_backup_state_t state)
+{
+    unsigned int parameters[1];
+    parameters[0] = (unsigned int) state;
+    SVC_Call(SYSCALL_os_rk_set_backup_state_ID, parameters);
+}
+#endif  // HAVE_CHARON
+
 void os_lib_call(unsigned int *call_parameters)
 {
     unsigned int parameters[2];


### PR DESCRIPTION
## Description

The goal of this PR is to add a new syscall enabling to set in the OS the RK backup state during onboarding

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

New syscall
