### PR TITLE
Add lib_alloc fuzzer

### DIFF
--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,38 +1,75 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 
-project(Fuzzer
+# project information
+project(SDKFuzzer
         VERSION 1.0
 	      DESCRIPTION "SDK Fuzzer"
         LANGUAGES C)
 
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CPP_COMPILER clang)
+if (NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+  message(FATAL_ERROR "Fuzzer needs to be built with Clang")
+endif()
 
-set(CMAKE_BUILD_TYPE "Debug")
+# guard against bad build-type strings
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif()
 
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS
-    "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -DFUZZ -g -O0 -fsanitize=fuzzer,address,undefined"
-)
+# default fuzz device target
+if (NOT TARGET_DEVICE)
+  set(TARGET_DEVICE "flex")
+endif()
+
+# compatible with ClusterFuzzLite
+if (NOT DEFINED ENV{LIB_FUZZING_ENGINE})
+	set(COMPILATION_FLAGS -g -O0 -Wall -Wextra -fprofile-instr-generate -fcoverage-mapping)
+  if (SANITIZER MATCHES "address")
+    set(COMPILATION_FLAGS ${COMPILATION_FLAGS} -fsanitize=fuzzer,address,undefined)
+  elseif (SANITIZER MATCHES "memory")
+    set(COMPILATION_FLAGS ${COMPILATION_FLAGS} -fsanitize=fuzzer,memory,undefined -fsanitize-memory-track-origins -fsanitize=fuzzer-no-link)
+  else()
+    message(FATAL_ERROR "Unknown sanitizer type. It must be set to `address` or `memory`.")
+  endif()
+else()
+	set(COMPILATION_FLAGS "$ENV{LIB_FUZZING_ENGINE} $ENV{CFLAGS}")
+  separate_arguments(COMPILATION_FLAGS)
+endif()
+
+add_compile_options(${COMPILATION_FLAGS})
+add_link_options(${COMPILATION_FLAGS})
+
+# guard against in-source builds
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
+endif()
+
 
 include_directories(
+  mock/
+  ../include/
+  ../target/${TARGET_DEVICE}/include
+  ../lib_alloc/
   ../lib_standard_app/
   ../qrcode/include/
-  mock/
 )
 
-add_library(base58 SHARED ../../lib_standard_app/base58.c)
-add_library(bip32 SHARED ../../lib_standard_app/bip32.c)
-add_library(read SHARED ../../lib_standard_app/read.c)
-add_library(apdu_parser SHARED ../../lib_standard_app/parser.c)
-add_library(qrcodegen SHARED ../../qrcode/src/qrcodegen.c mock/os_task.c)
+# Libraries
+add_library(lib_alloc ../../lib_alloc/mem_alloc.c)
+add_library(lib_standard ../../lib_standard_app/base58.c ../../lib_standard_app/bip32.c ../../lib_standard_app/read.c ../../lib_standard_app/parser.c)
+add_library(lib_mock mock/os_task.c)
 
+# Targets
+add_executable(fuzz_alloc fuzzer_alloc.c)
 add_executable(fuzz_apdu_parser fuzzer_apdu_parser.c)
 add_executable(fuzz_base58 fuzzer_base58.c)
 add_executable(fuzz_bip32 fuzzer_bip32.c)
-add_executable(fuzz_qrcodegen fuzzer_qrcodegen.c)
+add_executable(fuzz_qrcodegen fuzzer_qrcodegen.c ../../qrcode/src/qrcodegen.c)
 
-target_link_libraries(fuzz_apdu_parser apdu_parser)
-target_link_libraries(fuzz_base58 base58)
-target_link_libraries(fuzz_bip32 bip32 read)
-target_link_libraries(fuzz_qrcodegen qrcodegen)
+
+target_link_libraries(fuzz_alloc lib_alloc)
+target_link_libraries(fuzz_apdu_parser lib_standard lib_mock)
+target_link_libraries(fuzz_base58 lib_standard lib_mock)
+target_link_libraries(fuzz_bip32 lib_standard lib_mock)
+target_link_libraries(fuzz_qrcodegen lib_mock)
+
+

--- a/fuzzing/fuzzer_alloc.c
+++ b/fuzzing/fuzzer_alloc.c
@@ -1,0 +1,145 @@
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "mem_alloc.h"
+
+#define HEAP_SIZE 0x7FF0
+#define MAX_ALLOC 0xffff
+
+// #define DEBUG_CRASH
+
+static uint8_t heap[HEAP_SIZE] = {0};
+
+struct alloc {
+    void  *ptr;
+    size_t len;
+};
+static struct alloc allocs[MAX_ALLOC] = {0};
+
+bool insert_alloc(void *ptr, size_t len)
+{
+    for (size_t i = 0; i < MAX_ALLOC; i++) {
+        if (allocs[i].ptr != NULL) {
+            continue;
+        }
+        allocs[i].ptr = ptr;
+        allocs[i].len = len;
+        return true;
+    }
+    return false;
+}
+
+bool remove_alloc(void *ptr)
+{
+    for (size_t i = 0; i < MAX_ALLOC; i++) {
+        if (allocs[i].ptr != ptr) {
+            continue;
+        }
+        allocs[i].ptr = NULL;
+        allocs[i].len = 0;
+        return true;
+    }
+    return false;
+}
+
+bool get_alloc(size_t index, struct alloc **alloc)
+{
+    if (index >= MAX_ALLOC) {
+        return false;
+    }
+    if (allocs[index].ptr == NULL) {
+        return false;
+    }
+    *alloc = &allocs[index];
+    return true;
+}
+
+void exec_alloc(mem_ctx_t *allocator, size_t len)
+{
+    void *ptr = mem_alloc(allocator, len);
+    if (ptr == NULL) {  // not perfect because we would need to ensure that it only happens when the
+                        // buffer is full...
+        return;
+    }
+#ifdef DEBUG_CRASH
+    printf("[ALLOC] ptr = %p | length = %lu\n", ptr, len);
+#endif
+    for (size_t i = 0; i < len; i++) {
+        assert(((uint8_t *) ptr)[i] == 0);
+    }
+    memset(ptr, len & 0xff, len);
+    assert(insert_alloc(ptr, len) == true);
+}
+
+void exec_free(mem_ctx_t *allocator, size_t index)
+{
+    struct alloc *alloc = NULL;
+    if (!get_alloc(index, &alloc)) {
+        return;
+    }
+#ifdef DEBUG_CRASH
+    printf("[FREE] ptr = %p | length = %lu\n", alloc->ptr, alloc->len);
+#endif
+    for (size_t i = 0; i < alloc->len; i++) {
+        assert(((uint8_t *) alloc->ptr)[i] == alloc->len & 0xff);
+    }
+    memset(alloc->ptr, 0, alloc->len);
+    mem_free(allocator, alloc->ptr);
+    assert(remove_alloc(alloc->ptr) == true);
+}
+
+void exec_stat(mem_ctx_t *allocator)
+{
+    mem_stat_t stat = {0};
+    mem_stat(allocator, &stat);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+#ifdef DEBUG_CRASH
+    printf("[INIT] size = %lu\n", HEAP_SIZE);
+#endif
+    memset(heap, 0, HEAP_SIZE);
+    memset(allocs, 0, sizeof(allocs));
+    mem_ctx_t *allocator = mem_init(heap, HEAP_SIZE);  // We need a check on size else the mem_alloc
+                                                       // fails afterwards. For example for 0xffff
+    if (!allocator) {
+        return 0;
+    }
+
+    size_t offset = 0;
+    while (offset < size) {
+        mem_stat_t stat = {0};
+        mem_stat(allocator, &stat);
+#ifdef DEBUG_CRASH
+        printf(
+            "[STATS] total_size = %d | free_size = %d | allocated_size = %d | nb_chunks = %d | "
+            "nb_allocate = %d\n",
+            stat.total_size,
+            stat.free_size,
+            stat.allocated_size,
+            stat.nb_chunks,
+            stat.nb_allocated);
+#endif
+        switch (data[offset++]) {
+            case 'M':
+                if (offset >= size) {
+                    return 0;
+                }
+                size_t len = data[offset++];
+                exec_alloc(allocator, len);
+                break;
+            case 'F':
+                if (offset + 1 >= size) {
+                    return 0;
+                }
+                size_t index = (data[offset++] << 8) + data[offset++];
+                exec_free(allocator, index);
+                break;
+            default:
+                return 0;
+        }
+    }
+    return 0;
+}

--- a/fuzzing/mock/exceptions.h
+++ b/fuzzing/mock/exceptions.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define THROW exit


### PR DESCRIPTION
## Description

This PR adds a fuzzing harness for `lib_alloc` and improves the fuzzing CMake as well.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
