### PR TITLE
Improvements in SDK Fuzzing

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest AS LITE_BUILDER
+
+# Base image with clang toolchain
+FROM gcr.io/oss-fuzz-base/base-builder:v1
+
+# Copy the project's source code.
+COPY . $SRC/ledger-secure-sdk
+
+# Working directory for build.sh
+WORKDIR $SRC/ledger-secure-sdk
+
+# Copy build.sh into $SRC dir.
+COPY ./.clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -3,7 +3,8 @@
 # build fuzzers
 
 pushd fuzzing
-cmake -B build
+rm -rf build/*
+cmake -B build -S . -DCMAKE_C_COMPILER=/usr/bin/clang -DSANITIZER=address
 make -C build
-mv ./build/fuzz_bip32 "${OUT}"
+mv ./build/fuzz_alloc "${OUT}"
 popd

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -6,5 +6,5 @@ pushd fuzzing
 rm -rf build/*
 cmake -B build -S . -DCMAKE_C_COMPILER=/usr/bin/clang -DSANITIZER=address
 make -C build
-mv ./build/fuzz_alloc "${OUT}"
+mv ./build/fuzz_* "${OUT}"
 popd

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+# build fuzzers
+
+pushd fuzzing
+cmake -B build
+make -C build
+mv ./build/fuzz_bip32 "${OUT}"
+popd

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -1,0 +1,40 @@
+name: ClusterFuzzLite cron tasks
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main  # Use your actual default branch here.
+  schedule:
+    - cron: '0 13 * * 6'  # At 01:00 PM, only on Saturday
+permissions: read-all
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: batch
+            sanitizer: address
+          - mode: batch
+            sanitizer: memory
+          - mode: prune
+            sanitizer: address
+          - mode: coverage
+            sanitizer: coverage
+    steps:
+      - name: Build Fuzzers (${{ matrix.mode }} - ${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          language: c # Change this to the language you are fuzzing.
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run Fuzzers (${{ matrix.mode }} - ${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300 # 5 minutes
+          mode: ${{ matrix.mode }}
+          sanitizer: ${{ matrix.sanitizer }}

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -12,14 +12,17 @@ set(CMAKE_BUILD_TYPE "Debug")
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS
-    "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -DFUZZ -g -O0 -fsanitize=fuzzer,address,undefined"
+    "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -DFUZZ -g -O0 -fdata-sections -ffunction-sections -funsigned-char -fshort-enums -fsanitize=fuzzer,address,undefined -fprofile-instr-generate -fcoverage-mapping"
 )
 
 include_directories(
-  ../lib_standard_app/
-  ../qrcode/include/
   mock/
+  ../lib_standard_app/
+  ../include/
+  ../qrcode/include/
 )
+
+add_definitions(-DHAVE_NFC -DHAVE_NDEF_SUPPORT)
 
 add_library(base58 SHARED ../../lib_standard_app/base58.c)
 add_library(bip32 SHARED ../../lib_standard_app/bip32.c)

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,16 +1,16 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CPP_COMPILER clang)
 
-if(${CMAKE_VERSION} VERSION_LESS 3.10)
+if(${CMAKE_VERSION} VERSION_LESS 3.14)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
 # project information
-project(FuzzBip32
+project(SDKFuzzer
         VERSION 1.0
-	      DESCRIPTION "Fuzzing of BIP32"
+	        DESCRIPTION "SDK Fuzzer"
         LANGUAGES C)
 
 # guard against bad build-type strings
@@ -23,74 +23,33 @@ if (NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
     message(FATAL_ERROR "Fuzzer needs to be built with Clang")
 endif()
 
+# default fuzz device target
+if (NOT TARGET_DEVICE)
+  set(TARGET_DEVICE "flex")
+endif()
 
 # guard against in-source builds
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
 endif()
 
+
 # compatible with ClusterFuzzLite
 if (NOT DEFINED ENV{LIB_FUZZING_ENGINE})
-	set(COMPILATION_FLAGS_ "-g -Wall -fsanitize=fuzzer,address,undefined")
+	set(COMPILATION_FLAGS -g -O0 -Wall -Wextra -fprofile-instr-generate -fcoverage-mapping)
+  if (SANITIZER MATCHES "address")
+    set(COMPILATION_FLAGS ${COMPILATION_FLAGS} -fsanitize=fuzzer,address,undefined)
+  elseif (SANITIZER MATCHES "memory")
+    set(COMPILATION_FLAGS ${COMPILATION_FLAGS} -fsanitize=fuzzer,memory,undefined -fsanitize-memory-track-origins -fsanitize=fuzzer-no-link)
+  else()
+    message(FATAL_ERROR "Unknown sanitizer type. It must be set to `address` or `memory`.")
+  endif()
 else()
-	set(COMPILATION_FLAGS_ "$ENV{LIB_FUZZING_ENGINE} $ENV{CXXFLAGS}")
+	set(COMPILATION_FLAGS "$ENV{LIB_FUZZING_ENGINE} $ENV{CFLAGS}")
+  separate_arguments(COMPILATION_FLAGS)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-string(REPLACE " " ";" COMPILATION_FLAGS ${COMPILATION_FLAGS_})
-
 include(extra/Bip32.cmake)
-
-add_executable(fuzz_bip32 fuzzer_bip32.c)
-
-target_compile_options(fuzz_bip32 PUBLIC ${COMPILATION_FLAGS})
-target_link_options(fuzz_bip32 PUBLIC ${COMPILATION_FLAGS})
-target_link_libraries(fuzz_bip32 PUBLIC bip32)
-
-
-
-#[===[
-
-cmake_minimum_required(VERSION 3.10)
-
-project(Fuzzer
-        VERSION 1.0
-	      DESCRIPTION "SDK Fuzzer"
-        LANGUAGES C)
-
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CPP_COMPILER clang)
-
-set(CMAKE_BUILD_TYPE "Debug")
-
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS
-    "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -DFUZZ -g -O0 -fdata-sections -ffunction-sections -funsigned-char -fshort-enums -fsanitize=fuzzer,address,undefined -fprofile-instr-generate -fcoverage-mapping"
-)
-
-include_directories(
-  mock/
-  ../lib_standard_app/
-  ../include/
-  ../qrcode/include/
-)
-
-add_definitions(-DHAVE_NFC -DHAVE_NDEF_SUPPORT)
-
-add_library(base58 SHARED ../../lib_standard_app/base58.c)
-add_library(bip32 SHARED ../../lib_standard_app/bip32.c)
-add_library(read SHARED ../../lib_standard_app/read.c)
-add_library(apdu_parser SHARED ../../lib_standard_app/parser.c)
-add_library(qrcodegen SHARED ../../qrcode/src/qrcodegen.c mock/os_task.c)
-
-add_executable(fuzz_apdu_parser fuzzer_apdu_parser.c)
-add_executable(fuzz_base58 fuzzer_base58.c)
-add_executable(fuzz_bip32 fuzzer_bip32.c)
-add_executable(fuzz_qrcodegen fuzzer_qrcodegen.c)
-
-target_link_libraries(fuzz_apdu_parser apdu_parser)
-target_link_libraries(fuzz_base58 base58)
-target_link_libraries(fuzz_bip32 bip32 read)
-target_link_libraries(fuzz_qrcodegen qrcodegen)
-]===]
+include(extra/lib_alloc.cmake)

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,5 +1,59 @@
 cmake_minimum_required(VERSION 3.10)
 
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CPP_COMPILER clang)
+
+if(${CMAKE_VERSION} VERSION_LESS 3.10)
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
+
+# project information
+project(FuzzBip32
+        VERSION 1.0
+	      DESCRIPTION "Fuzzing of BIP32"
+        LANGUAGES C)
+
+# guard against bad build-type strings
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+
+if (NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "Fuzzer needs to be built with Clang")
+endif()
+
+
+# guard against in-source builds
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
+endif()
+
+# compatible with ClusterFuzzLite
+if (NOT DEFINED ENV{LIB_FUZZING_ENGINE})
+	set(COMPILATION_FLAGS_ "-g -Wall -fsanitize=fuzzer,address,undefined")
+else()
+	set(COMPILATION_FLAGS_ "$ENV{LIB_FUZZING_ENGINE} $ENV{CXXFLAGS}")
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+string(REPLACE " " ";" COMPILATION_FLAGS ${COMPILATION_FLAGS_})
+
+include(extra/Bip32.cmake)
+
+add_executable(fuzz_bip32 fuzzer_bip32.c)
+
+target_compile_options(fuzz_bip32 PUBLIC ${COMPILATION_FLAGS})
+target_link_options(fuzz_bip32 PUBLIC ${COMPILATION_FLAGS})
+target_link_libraries(fuzz_bip32 PUBLIC bip32)
+
+
+
+#[===[
+
+cmake_minimum_required(VERSION 3.10)
+
 project(Fuzzer
         VERSION 1.0
 	      DESCRIPTION "SDK Fuzzer"
@@ -39,3 +93,4 @@ target_link_libraries(fuzz_apdu_parser apdu_parser)
 target_link_libraries(fuzz_base58 base58)
 target_link_libraries(fuzz_bip32 bip32 read)
 target_link_libraries(fuzz_qrcodegen qrcodegen)
+]===]

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -51,6 +51,9 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(extra/nfc_ndef.cmake)
-#include(extra/Bip32.cmake)
-#include(extra/lib_alloc.cmake)
+# Include haness cmake files
+file(GLOB cmake_extra_files "extra/*.cmake")
+
+foreach(file IN LISTS cmake_extra_files)
+    include(${file})
+endforeach()

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -51,5 +51,6 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(extra/Bip32.cmake)
-include(extra/lib_alloc.cmake)
+include(extra/nfc_ndef.cmake)
+#include(extra/Bip32.cmake)
+#include(extra/lib_alloc.cmake)

--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -24,7 +24,7 @@ Once in the container, go into the `fuzzing` folder to compile the fuzzer:
 cd fuzzing
 
 # cmake initialization
-cmake -B build -DSANITIZER=address
+cmake -B build -S . -DCMAKE_C_COMPILER=/usr/bin/clang -DSANITIZER=address
 
 # Fuzzer compilation
 make -C build

--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -24,7 +24,7 @@ Once in the container, go into the `fuzzing` folder to compile the fuzzer:
 cd fuzzing
 
 # cmake initialization
-cmake -B build
+cmake -B build -DSANITIZER=address
 
 # Fuzzer compilation
 make -C build

--- a/fuzzing/extra/Bip32.cmake
+++ b/fuzzing/extra/Bip32.cmake
@@ -1,8 +1,8 @@
 include_guard()
 
 add_library(bip32
-    ../lib_standard_app/read.c
-    ../lib_standard_app/bip32.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib_standard_app/read.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib_standard_app/bip32.c
 )
 target_include_directories(bip32 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../lib_standard_app)
 

--- a/fuzzing/extra/Bip32.cmake
+++ b/fuzzing/extra/Bip32.cmake
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(Bip32
+        VERSION 1.0
+	      DESCRIPTION "BIP_32"
+        LANGUAGES C)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CPP_COMPILER clang)
+
+set(CMAKE_BUILD_TYPE "Debug")
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED True)
+set(CMAKE_C_FLAGS
+    "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-function -DFUZZ -pedantic -g -O0"
+)
+
+include_directories(
+  ../lib_standard_app/
+)
+
+add_library(bip32
+    ../lib_standard_app/read.c
+    ../lib_standard_app/bip32.c
+    
+)
+set_target_properties(bip32 PROPERTIES SOVERSION 1)
+
+target_include_directories(bip32 PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib_standard_app
+)

--- a/fuzzing/extra/Bip32.cmake
+++ b/fuzzing/extra/Bip32.cmake
@@ -1,32 +1,16 @@
-cmake_minimum_required(VERSION 3.10)
-
-project(Bip32
-        VERSION 1.0
-	      DESCRIPTION "BIP_32"
-        LANGUAGES C)
-
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CPP_COMPILER clang)
-
-set(CMAKE_BUILD_TYPE "Debug")
-
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED True)
-set(CMAKE_C_FLAGS
-    "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-function -DFUZZ -pedantic -g -O0"
-)
-
-include_directories(
-  ../lib_standard_app/
-)
+include_guard()
 
 add_library(bip32
     ../lib_standard_app/read.c
     ../lib_standard_app/bip32.c
-    
 )
+target_include_directories(bip32 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../lib_standard_app)
+
 set_target_properties(bip32 PROPERTIES SOVERSION 1)
 
-target_include_directories(bip32 PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/../lib_standard_app
-)
+# Define the executable and its properties
+add_executable(fuzz_bip32 ${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_bip32.c)
+target_compile_options(fuzz_bip32 PUBLIC ${COMPILATION_FLAGS})
+target_link_options(fuzz_bip32 PUBLIC ${COMPILATION_FLAGS})
+target_link_libraries(fuzz_bip32 PUBLIC bip32)
+

--- a/fuzzing/extra/lib_alloc.cmake
+++ b/fuzzing/extra/lib_alloc.cmake
@@ -1,0 +1,23 @@
+include_guard()
+
+add_library(lib_mock ${CMAKE_CURRENT_SOURCE_DIR}/mock/os_task.c)
+add_library(lib_alloc ${CMAKE_CURRENT_SOURCE_DIR}/../lib_alloc/mem_alloc.c
+)
+
+set_target_properties(lib_alloc PROPERTIES SOVERSION 1)
+
+target_include_directories(lib_mock PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mock/)
+target_include_directories(lib_alloc PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib_alloc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/../target/${TARGET_DEVICE}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib_standard_app
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+# Define the executable and its properties here
+add_executable(fuzz_alloc ${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_alloc.c)
+target_compile_options(fuzz_alloc PUBLIC ${COMPILATION_FLAGS})
+target_link_options(fuzz_alloc PUBLIC ${COMPILATION_FLAGS})
+target_link_libraries(fuzz_alloc PUBLIC lib_alloc lib_mock)
+

--- a/fuzzing/extra/nfc_ndef.cmake
+++ b/fuzzing/extra/nfc_ndef.cmake
@@ -1,0 +1,20 @@
+include_guard()
+
+add_definitions(-DHAVE_NFC -DHAVE_NDEF_SUPPORT)
+
+add_library(nfc_ndef
+            ${CMAKE_CURRENT_SOURCE_DIR}/../lib_nfc/src/nfc_ndef.c
+)
+target_include_directories(nfc_ndef PUBLIC 
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../lib_nfc/include/
+                                ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+                                )
+
+set_target_properties(nfc_ndef PROPERTIES SOVERSION 1)
+
+# Define the executable and its properties
+add_executable(fuzz_nfc_ndef ${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_nfc_ndef.c)
+target_compile_options(fuzz_nfc_ndef PUBLIC ${COMPILATION_FLAGS})
+target_link_options(fuzz_nfc_ndef PUBLIC ${COMPILATION_FLAGS})
+target_link_libraries(fuzz_nfc_ndef PUBLIC nfc_ndef)
+

--- a/fuzzing/fuzzer_alloc.c
+++ b/fuzzing/fuzzer_alloc.c
@@ -1,0 +1,145 @@
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "mem_alloc.h"
+
+#define HEAP_SIZE 0x7FF0
+#define MAX_ALLOC 0xffff
+
+// #define DEBUG_CRASH
+
+static uint8_t heap[HEAP_SIZE] = {0};
+
+struct alloc {
+    void  *ptr;
+    size_t len;
+};
+static struct alloc allocs[MAX_ALLOC] = {0};
+
+bool insert_alloc(void *ptr, size_t len)
+{
+    for (size_t i = 0; i < MAX_ALLOC; i++) {
+        if (allocs[i].ptr != NULL) {
+            continue;
+        }
+        allocs[i].ptr = ptr;
+        allocs[i].len = len;
+        return true;
+    }
+    return false;
+}
+
+bool remove_alloc(void *ptr)
+{
+    for (size_t i = 0; i < MAX_ALLOC; i++) {
+        if (allocs[i].ptr != ptr) {
+            continue;
+        }
+        allocs[i].ptr = NULL;
+        allocs[i].len = 0;
+        return true;
+    }
+    return false;
+}
+
+bool get_alloc(size_t index, struct alloc **alloc)
+{
+    if (index >= MAX_ALLOC) {
+        return false;
+    }
+    if (allocs[index].ptr == NULL) {
+        return false;
+    }
+    *alloc = &allocs[index];
+    return true;
+}
+
+void exec_alloc(mem_ctx_t *allocator, size_t len)
+{
+    void *ptr = mem_alloc(allocator, len);
+    if (ptr == NULL) {  // not perfect because we would need to ensure that it only happens when the
+                        // buffer is full...
+        return;
+    }
+#ifdef DEBUG_CRASH
+    printf("[ALLOC] ptr = %p | length = %lu\n", ptr, len);
+#endif
+    for (size_t i = 0; i < len; i++) {
+        assert(((uint8_t *) ptr)[i] == 0);
+    }
+    memset(ptr, len & 0xff, len);
+    assert(insert_alloc(ptr, len) == true);
+}
+
+void exec_free(mem_ctx_t *allocator, size_t index)
+{
+    struct alloc *alloc = NULL;
+    if (!get_alloc(index, &alloc)) {
+        return;
+    }
+#ifdef DEBUG_CRASH
+    printf("[FREE] ptr = %p | length = %lu\n", alloc->ptr, alloc->len);
+#endif
+    for (size_t i = 0; i < alloc->len; i++) {
+        assert(((uint8_t *) alloc->ptr)[i] == alloc->len & 0xff);
+    }
+    memset(alloc->ptr, 0, alloc->len);
+    mem_free(allocator, alloc->ptr);
+    assert(remove_alloc(alloc->ptr) == true);
+}
+
+void exec_stat(mem_ctx_t *allocator)
+{
+    mem_stat_t stat = {0};
+    mem_stat(allocator, &stat);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+#ifdef DEBUG_CRASH
+    printf("[INIT] size = %lu\n", HEAP_SIZE);
+#endif
+    memset(heap, 0, HEAP_SIZE);
+    memset(allocs, 0, sizeof(allocs));
+    mem_ctx_t *allocator = mem_init(heap, HEAP_SIZE);  // We need a check on size else the mem_alloc
+                                                       // fails afterwards. For example for 0xffff
+    if (!allocator) {
+        return 0;
+    }
+
+    size_t offset = 0;
+    while (offset < size) {
+        mem_stat_t stat = {0};
+        mem_stat(allocator, &stat);
+#ifdef DEBUG_CRASH
+        printf(
+            "[STATS] total_size = %d | free_size = %d | allocated_size = %d | nb_chunks = %d | "
+            "nb_allocate = %d\n",
+            stat.total_size,
+            stat.free_size,
+            stat.allocated_size,
+            stat.nb_chunks,
+            stat.nb_allocated);
+#endif
+        switch (data[offset++]) {
+            case 'M':
+                if (offset >= size) {
+                    return 0;
+                }
+                size_t len = data[offset++];
+                exec_alloc(allocator, len);
+                break;
+            case 'F':
+                if (offset + 1 >= size) {
+                    return 0;
+                }
+                size_t index = (data[offset++] << 8) + data[offset++];
+                exec_free(allocator, index);
+                break;
+            default:
+                return 0;
+        }
+    }
+    return 0;
+}

--- a/fuzzing/fuzzer_nfc_ndef.c
+++ b/fuzzing/fuzzer_nfc_ndef.c
@@ -1,0 +1,26 @@
+#include "nfc_ndef.h"
+#include <stddef.h>
+#include <string.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char out_string[NFC_NDEF_MAX_SIZE];
+    /*
+    if(size == sizeof(ndef_struct_t)){
+        ndef_struct_t ndef_message;
+        memcpy(&ndef_message, data, sizeof(ndef_struct_t));
+        ndef_message.ndef_type = ndef_message.ndef_type % 2 + 1;
+        ndef_message.uri_id = ndef_message.uri_id % 37;
+        ndef_message.text[NFC_TEXT_MAX_LEN] = '\0';
+        ndef_message.info[NFC_INFO_MAX_LEN] = '\0';
+        os_ndef_to_string(&ndef_message, out_string);
+    }
+    
+    */
+    if(size == sizeof(ndef_struct_t)){
+        ndef_struct_t *ndef_message = (ndef_struct_t*)data;
+        os_ndef_to_string2(ndef_message, out_string);
+    }
+    //os_get_uri_header(uri_id, out_string);
+    return 0;
+}

--- a/fuzzing/fuzzer_nfc_ndef.c
+++ b/fuzzing/fuzzer_nfc_ndef.c
@@ -5,22 +5,21 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     char out_string[NFC_NDEF_MAX_SIZE];
-    /*
-    if(size == sizeof(ndef_struct_t)){
+
+    if (size == sizeof(ndef_struct_t)) {
+        // Fuzz with raw data
+        ndef_struct_t *ndef_message2 = (ndef_struct_t *) data;
+        os_ndef_to_string(ndef_message2, out_string);
+
+        // Fuzz with more specific data
         ndef_struct_t ndef_message;
         memcpy(&ndef_message, data, sizeof(ndef_struct_t));
-        ndef_message.ndef_type = ndef_message.ndef_type % 2 + 1;
-        ndef_message.uri_id = ndef_message.uri_id % 37;
+        ndef_message.ndef_type              = ndef_message.ndef_type % 2 + 1;
+        ndef_message.uri_id                 = ndef_message.uri_id % 37;
         ndef_message.text[NFC_TEXT_MAX_LEN] = '\0';
         ndef_message.info[NFC_INFO_MAX_LEN] = '\0';
         os_ndef_to_string(&ndef_message, out_string);
     }
-    
-    */
-    if(size == sizeof(ndef_struct_t)){
-        ndef_struct_t *ndef_message = (ndef_struct_t*)data;
-        os_ndef_to_string2(ndef_message, out_string);
-    }
-    //os_get_uri_header(uri_id, out_string);
+
     return 0;
 }

--- a/fuzzing/mock/exceptions.h
+++ b/fuzzing/mock/exceptions.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define THROW exit

--- a/fuzzing/mock/os_task.c
+++ b/fuzzing/mock/os_task.c
@@ -4,3 +4,14 @@ void os_sched_exit(__attribute__((unused)) bolos_task_status_t exit_code)
 {
     return;
 }
+
+void os_longjmp(unsigned int exception)
+{
+    
+#ifdef HAVE_DEBUG_THROWS
+
+    DEBUG_THROW(exception);
+    return;
+#endif
+    return;
+}

--- a/fuzzing/mock/os_task.c
+++ b/fuzzing/mock/os_task.c
@@ -7,7 +7,6 @@ void os_sched_exit(__attribute__((unused)) bolos_task_status_t exit_code)
 
 void os_longjmp(unsigned int exception)
 {
-    
 #ifdef HAVE_DEBUG_THROWS
 
     DEBUG_THROW(exception);

--- a/fuzzing/mock/os_task.h
+++ b/fuzzing/mock/os_task.h
@@ -1,3 +1,5 @@
 typedef unsigned char bolos_task_status_t;
 
 void os_sched_exit(bolos_task_status_t exit_code);
+
+void os_longjmp(unsigned int exception);

--- a/lib_nfc/include/nfc_ndef.h
+++ b/lib_nfc/include/nfc_ndef.h
@@ -112,5 +112,5 @@ typedef struct __attribute__((packed)) ndef_struct_s {
 uint16_t os_get_uri_header(uint8_t uri_id, char *uri_header);
 uint8_t  os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed);
 uint16_t os_ndef_to_string(ndef_struct_t *ndef_message, char *out_string);
-
+uint16_t os_ndef_to_string2(ndef_struct_t *ndef_message, char *out_string);
 #endif

--- a/lib_nfc/include/nfc_ndef.h
+++ b/lib_nfc/include/nfc_ndef.h
@@ -112,5 +112,4 @@ typedef struct __attribute__((packed)) ndef_struct_s {
 uint16_t os_get_uri_header(uint8_t uri_id, char *uri_header);
 uint8_t  os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed);
 uint16_t os_ndef_to_string(ndef_struct_t *ndef_message, char *out_string);
-uint16_t os_ndef_to_string2(ndef_struct_t *ndef_message, char *out_string);
 #endif

--- a/lib_nfc/src/nfc_ndef.c
+++ b/lib_nfc/src/nfc_ndef.c
@@ -168,34 +168,35 @@ uint8_t os_parse_ndef(uint8_t *in_buffer, ndef_struct_t *parsed)
  */
 uint16_t os_ndef_to_string(ndef_struct_t *ndef_message, char *out_string)
 {
-    uint16_t tot_length      = 0;
-    uint16_t length_internal = 0;
+    uint16_t size_text = strnlen(ndef_message->text, NFC_TEXT_MAX_LEN);
+    uint16_t size_info = strnlen(ndef_message->info, NFC_INFO_MAX_LEN);
+    uint16_t size_header = 0;
+    if(size_text > NFC_TEXT_MAX_LEN || size_info > NFC_INFO_MAX_LEN)
+        return 0;
+
     if (ndef_message->ndef_type == NFC_NDEF_TYPE_TEXT) {
-        tot_length += strlen(ndef_message->text);
-        if (tot_length > NFC_TEXT_MAX_LEN) {
-            return 0;
-        }
-        strcpy(out_string, ndef_message->text);
+        strncpy(out_string, ndef_message->text, size_text);
+        return size_text;
     }
     else if (ndef_message->ndef_type == NFC_NDEF_TYPE_URI) {
-        tot_length += os_get_uri_header(ndef_message->uri_id, out_string);
-        length_internal = strlen(ndef_message->text);
-        if (tot_length + length_internal > URI_ID_STRING_MAX_LEN + NFC_TEXT_MAX_LEN) {
+        size_header = os_get_uri_header(ndef_message->uri_id, out_string);
+        if (size_header + size_text > URI_ID_STRING_MAX_LEN + NFC_TEXT_MAX_LEN)
             return 0;
-        }
-        strcpy(&out_string[tot_length], ndef_message->text);
-        tot_length += length_internal;
+        
+        strncpy(&out_string[size_header], ndef_message->text, size_text);
+        
         if (ndef_message->info[0] != '\0') {
-            out_string[tot_length++] = '\n';
-            length_internal          = strlen(ndef_message->info);
-            if (tot_length + length_internal > NFC_NDEF_MAX_SIZE) {
+            out_string[size_text + (size_header++)] = '\n';
+            if (size_header + size_text + size_info > NFC_NDEF_MAX_SIZE) {
                 return 0;
             }
-            strcpy(&out_string[tot_length], ndef_message->info);
-            tot_length += length_internal;
+            strncpy(&out_string[size_header + size_text], ndef_message->info, size_info);
         }
+        return size_header + size_text + size_info;
     }
-    return tot_length;
+    return 0;
 }
+
+
 #endif  // HAVE_NDEF_SUPPORT
 #endif  // HAVE_NFC


### PR DESCRIPTION
## Description

Add ClusterFuzzLite to Ledger-Secure-SDK and three fuzzers:
 - `fuzzer_bip32`
 - `fuzzer_lib_alloc`
 - `fuzzer_nfc_ndef`

Update documentation accordingly .

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [X] Tests
- [X] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Changed the function `os_ndef_to_string` in `lib_nfc/src/nfc_ndef.c`
