### PR TITLE
Make improvements

### DIFF
--- a/.github/workflows/build_all_c_apps.yml
+++ b/.github/workflows/build_all_c_apps.yml
@@ -61,6 +61,10 @@ jobs:
         with:
           path: sdk
           ref: ${{ inputs.sdk_branch }}
+
+      - name: Install prerequisites
+        run: pip install --break-system-packages ledgered
+
       - name: Build App for Nano X
         if: contains(matrix.apps.devices, 'nanox')
         run: |

--- a/.github/workflows/check_clang_static_analyzer.yml
+++ b/.github/workflows/check_clang_static_analyzer.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           path: sdk
 
+      - name: Install prerequisites
+        run: pip install --break-system-packages ledgered
+
       - name: Build with Clang Static Analyzer
         run: |
           TARGET=${{ matrix.target }} \

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -99,4 +99,17 @@ OBJECTS_DIR += $(sort $(dir $(OBJECT_FILES)))
 DEPEND_FILES = $(subst $(OBJ_DIR), $(DEP_DIR), $(addsuffix .d, $(basename $(OBJECT_FILES))))
 DEPEND_DIR += $(sort $(dir $(DEPEND_FILES)))
 
+# Path to the TOML file
+APP_MANIFEST_FILE := $(APP_DIR)/ledger_app.toml
+# If the TOML file exists, retrieve the use-cases
+ifneq ($(wildcard $(APP_MANIFEST_FILE)),)
+  # Retrieve the use-cases from the TOML file
+  APP_USE_CASES := $(shell ledger-manifest "$(APP_MANIFEST_FILE)" -ouc -j | jq -r 'keys | join(" ")')
+
+  # Function to extract flags for a specific use case
+  define get_flags_for_use_case
+    $(shell ledger-manifest "$(APP_MANIFEST_FILE)" -ouc $1)
+  endef
+endif
+
 include $(BOLOS_SDK)/Makefile.rules_generic

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -75,6 +75,13 @@ prepare:
 
 $(BUILD_DEPENDENCIES): prepare
 
+# Define a generic rule for each use-case
+ifneq ($(APP_USE_CASES),)
+$(APP_USE_CASES):
+	@echo "Building with '$@' configuration..."
+	@$(MAKE) --no-print-directory $(call get_flags_for_use_case,$@)
+endif
+
 BIN_TARGETS := bin/app.elf bin/app.apdu bin/app.sha256 bin/app.hex
 DBG_TARGETS := debug/app.map debug/app.asm
 

--- a/lib_standard_app/main.c
+++ b/lib_standard_app/main.c
@@ -102,9 +102,9 @@ WEAK void standalone_app_main(void)
 #endif
             // Display crash info on screen for debug purpose
             assert_display_exit();
-#else
+#else   // HAVE_DEBUG_THROWS
             PRINTF("Exiting following exception: 0x%04X\n", e);
-#endif
+#endif  // HAVE_DEBUG_THROWS
         }
         FINALLY {}
     }

--- a/lib_standard_app/main_std_app.h
+++ b/lib_standard_app/main_std_app.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "macros.h"
+
+/**
+ * Exit the application and go back to the dashboard.
+ */
+void __attribute__((noreturn)) app_exit(void);
+
+/**
+ * Common init of the App.
+ *  - UX
+ *  - io
+ *  - USB
+ *  - BLE
+ */
+WEAK void common_app_init(void);
+
+/**
+ * Main entry point of the App, in standalone mode.
+ * It calls (inside a try/catch):
+ *  - common_app_init
+ *  - app_main (should be defined in the App)
+ */
+WEAK void standalone_app_main(void);
+
+/**
+ * Main entry point of the App, in library mode.
+ * It calls the swap handlers (inside a try/catch)
+ */
+WEAK void library_app_main(void);


### PR DESCRIPTION
- Add generic standard app main header file (`main_std_app.h`) to be used by the apps
- Add rules allowing to compile Apps based on the pre-defined use-cases. 
  For example, in `app-ethereum`: `make dbg_use_test_keys`, instead of giving the whole set of flags