### PR TITLE
Fix deadcode.DeadStores clang analyzer warning in lib_alloc

### DIFF
--- a/lib_alloc/mem_alloc.c
+++ b/lib_alloc/mem_alloc.c
@@ -90,7 +90,7 @@ typedef struct {
 // For 2^n <= size < 2^(n+1), this function returns n.
 static inline int seglist_index(heap_t *heap, size_t size)
 {
-    size_t  seg = 31 - __builtin_clz(size);
+    size_t  seg;
     uint8_t sub_segment;
 
     seg         = MAX(NB_LINEAR_SEGMENTS, (31 - __builtin_clz(size)));


### PR DESCRIPTION
## Description

Causes :red_circle: CI during static analysis on apps that use the lib_alloc.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)