### PR TITLE
Use os_reset() instead of os_io_seph_cmd_se_reset()/os_io_seph_cmd_se_reset() + for(;;); when possible.

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -94,6 +94,9 @@ void os_boot(void);
  */
 unsigned short io_timeout(unsigned short last_timeout);
 
+// reset the SE and wait forever
+void os_reset(void) __attribute__((noreturn));
+
 /* ----------------------------------------------------------------------- */
 /* -                            EXCEPTIONS                               - */
 /* ----------------------------------------------------------------------- */

--- a/io_legacy/src/os_io_legacy.c
+++ b/io_legacy/src/os_io_legacy.c
@@ -97,9 +97,7 @@ void io_seproxyhal_general_status(void)
 
 void io_seproxyhal_se_reset(void)
 {
-    os_io_seph_cmd_se_reset();
-    for (;;)
-        ;
+    os_reset();
 }
 
 void io_seproxyhal_disable_io(void)

--- a/src/os.c
+++ b/src/os.c
@@ -23,6 +23,7 @@
 #include "os_io.h"
 #include "os_utils.h"
 #include "os.h"
+#include "os_io_seph_cmd.h"
 #include <string.h>
 
 #ifndef BOLOS_OS_UPGRADER_APP
@@ -257,6 +258,13 @@ void u4be_encode(unsigned char *buffer, unsigned int offset, unsigned int value)
 void u4le_encode(unsigned char *buffer, unsigned int offset, unsigned int value)
 {
     U4LE_ENCODE(buffer, offset, value);
+}
+
+void os_reset(void)
+{
+    os_io_seph_cmd_se_reset();
+    for (;;) {
+    }
 }
 
 void *os_memmove(void *dest, const void *src, size_t n)

--- a/tests/screenshots/src/main/stubs.c
+++ b/tests/screenshots/src/main/stubs.c
@@ -158,6 +158,13 @@ void io_seproxyhal_se_reset(void)
     }
 }
 
+void os_reset(void)
+{
+    if (verbose) {
+        printf("os_reset\n");
+    }
+}
+
 void io_seproxyhal_disable_io(void) {}
 
 void io_seproxyhal_general_status(void) {}


### PR DESCRIPTION
## Description

Fix an issue preventing to build the screenshots, by using the mocked version of **os_reset()**, which does nothing and doesn't have an endless loop.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
