### PR TITLE
Memorize streaming op type and manage finish title

### DIFF
--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -44,6 +44,9 @@ extern "C" {
 #define NB_MAX_LINES_IN_DETAILS 12
 #elif defined(TARGET_FLEX)
 #define NB_MAX_LINES_IN_DETAILS 11
+#else
+// Nano
+#define NB_MAX_LINES_IN_DETAILS 3
 #endif  // TARGETS
 
 /**
@@ -53,6 +56,9 @@ extern "C" {
 #define NB_MAX_LINES_IN_REVIEW 10
 #elif defined(TARGET_FLEX)
 #define NB_MAX_LINES_IN_REVIEW 9
+#else
+// Nano
+#define NB_MAX_LINES_IN_REVIEW 3
 #endif  // TARGETS
 
 /**
@@ -98,6 +104,13 @@ extern "C" {
 
 ///< Duration of status screens, automatically closing after this timeout (3s)
 #define STATUS_SCREEN_DURATION 3000
+
+/**
+ * @brief This is the mask to apply on @ref nbgl_operationType_t to get the real type provided by
+ * app
+ *
+ */
+#define REAL_TYPE_MASK 0x7
 
 /**********************
  *      MACROS

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -496,21 +496,38 @@ static void prepareReviewFirstPage(nbgl_contentCenter_t      *contentCenter,
     contentCenter->illustrType = ICON_ILLUSTRATION;
 }
 
-static void prepareReviewLastPage(nbgl_contentInfoLongPress_t *infoLongPress,
+static const char *getFinishTitle(nbgl_operationType_t operationType, const char *finishTitle)
+{
+    if (finishTitle != NULL) {
+        return finishTitle;
+    }
+    switch (operationType & REAL_TYPE_MASK) {
+        case TYPE_TRANSACTION:
+            return "Sign transaction";
+        case TYPE_MESSAGE:
+            return "Sign message";
+        default:
+            return "Sign operation";
+    }
+}
+
+static void prepareReviewLastPage(nbgl_operationType_t         operationType,
+                                  nbgl_contentInfoLongPress_t *infoLongPress,
                                   const nbgl_icon_details_t   *icon,
                                   const char                  *finishTitle)
 {
-    infoLongPress->text           = finishTitle;
+    infoLongPress->text           = getFinishTitle(operationType, finishTitle);
     infoLongPress->icon           = icon;
     infoLongPress->longPressText  = "Hold to sign";
     infoLongPress->longPressToken = CONFIRM_TOKEN;
 }
 
-static void prepareReviewLightLastPage(nbgl_contentInfoButton_t  *infoButton,
+static void prepareReviewLightLastPage(nbgl_operationType_t       operationType,
+                                       nbgl_contentInfoButton_t  *infoButton,
                                        const nbgl_icon_details_t *icon,
                                        const char                *finishTitle)
 {
-    infoButton->text        = finishTitle;
+    infoButton->text        = getFinishTitle(operationType, finishTitle);
     infoButton->icon        = icon;
     infoButton->buttonText  = "Approve";
     infoButton->buttonToken = CONFIRM_TOKEN;
@@ -2332,11 +2349,13 @@ static void useCaseReview(nbgl_operationType_t              operationType,
     // The last page
     if (isLight) {
         localContentsList[2].type = INFO_BUTTON;
-        prepareReviewLightLastPage(&localContentsList[2].content.infoButton, icon, finishTitle);
+        prepareReviewLightLastPage(
+            operationType, &localContentsList[2].content.infoButton, icon, finishTitle);
     }
     else {
         localContentsList[2].type = INFO_LONG_PRESS;
-        prepareReviewLastPage(&localContentsList[2].content.infoLongPress, icon, finishTitle);
+        prepareReviewLastPage(
+            operationType, &localContentsList[2].content.infoLongPress, icon, finishTitle);
     }
 
     // compute number of pages & fill navigation structure
@@ -3902,7 +3921,8 @@ void nbgl_useCaseReviewStreamingFinish(const char           *finishTitle,
 
     // Eventually the long press page
     STARTING_CONTENT.type = INFO_LONG_PRESS;
-    prepareReviewLastPage(&STARTING_CONTENT.content.infoLongPress,
+    prepareReviewLastPage(bundleNavContext.reviewStreaming.operationType,
+                          &STARTING_CONTENT.content.infoLongPress,
                           bundleNavContext.reviewStreaming.icon,
                           finishTitle);
 


### PR DESCRIPTION
## Description

The goal of this PR is to memorize streaming operation type for Nano, and better manage finish title, with default values if NULL

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
