### PR TITLE
[lib_ble]: fix is_busy, cleanup types

### DIFF
--- a/lib_blewbxx/include/ble_ledger.h
+++ b/lib_blewbxx/include/ble_ledger.h
@@ -64,7 +64,7 @@ uint32_t BLE_LEDGER_send(uint8_t        profile_type,
                          uint32_t       timeout_ms);
 
 // Check data sent
-int32_t BLE_LEDGER_is_busy(void);
+bool BLE_LEDGER_is_busy(void);
 
 // Setting
 void BLE_LEDGER_setting(uint32_t profile_id, uint32_t setting_id, uint8_t *buffer, uint16_t length);

--- a/lib_blewbxx/include/ble_ledger_profile_apdu.h
+++ b/lib_blewbxx/include/ble_ledger_profile_apdu.h
@@ -38,7 +38,7 @@ uint8_t BLE_LEDGER_PROFILE_apdu_mtu_changed(uint16_t mtu, void *cookie);
 
 uint8_t BLE_LEDGER_PROFILE_apdu_write_rsp_ack(void *cookie);
 uint8_t BLE_LEDGER_PROFILE_apdu_update_char_value_ack(void *cookie);
-uint8_t BLE_LEDGER_PROFILE_apdu_is_busy(void *cookie);
+bool BLE_LEDGER_PROFILE_apdu_is_busy(void *cookie);
 
 uint8_t BLE_LEDGER_PROFILE_apdu_send_packet(const uint8_t *packet, uint16_t length, void *cookie);
 

--- a/lib_blewbxx/include/ble_ledger_types.h
+++ b/lib_blewbxx/include/ble_ledger_types.h
@@ -54,7 +54,7 @@ typedef uint8_t (*ble_profile_write_rsp_ack_t)(void *cookie);
 typedef uint8_t (*ble_profile_update_char_value_ack_t)(void *cookie);
 
 typedef uint8_t (*ble_profile_send_packet_t)(const uint8_t *packet, uint16_t length, void *cookie);
-typedef uint8_t (*ble_profile_is_busy_t)(void *cookie);
+typedef bool (*ble_profile_is_busy_t)(void *cookie);
 
 typedef int32_t (*ble_profile_data_ready_t)(uint8_t *buffer, uint16_t max_length, void *cookie);
 

--- a/lib_blewbxx/src/ble_ledger.c
+++ b/lib_blewbxx/src/ble_ledger.c
@@ -1165,23 +1165,23 @@ uint32_t BLE_LEDGER_send(uint8_t        profile_type,
 }
 
 
-int32_t BLE_LEDGER_is_busy(void)
+bool BLE_LEDGER_is_busy(void)
 {
-    int32_t status = -1;
+    bool busy = false;
 
     if (ble_ledger_data.state == BLE_STATE_RUNNING) {
         for (uint8_t index = 0; index < ble_ledger_data.nb_of_profile; index++) {
             ble_profile_info_t *profile_info = ble_ledger_data.profile[index];
             if (profile_info->is_busy) {
-                status = ((ble_profile_is_busy_t) PIC(profile_info->is_busy))(profile_info->cookie);
-                if (status) {
+                busy = ((ble_profile_is_busy_t) PIC(profile_info->is_busy))(profile_info->cookie);
+                if (busy) {
                     break;
                 }
             }
         }
     }
 
-    return status;
+    return busy;
 }
 
 void BLE_LEDGER_setting(uint32_t profile_id, uint32_t setting_id, uint8_t *buffer, uint16_t length)

--- a/lib_blewbxx/src/ble_ledger_profile_apdu.c
+++ b/lib_blewbxx/src/ble_ledger_profile_apdu.c
@@ -562,15 +562,16 @@ uint8_t BLE_LEDGER_PROFILE_apdu_send_packet(const uint8_t *packet, uint16_t leng
     return status;
 }
 
-uint8_t BLE_LEDGER_PROFILE_apdu_is_busy(void *cookie)
+bool BLE_LEDGER_PROFILE_apdu_is_busy(void *cookie)
 {
     ledger_ble_profile_apdu_handle_t *handle = (ledger_ble_profile_apdu_handle_t *) PIC(cookie);
+    bool busy = false;
 
     if (handle->state == LEDGER_BLE_PROFILE_APDU_BUSY) {
-        return 1;
+        busy = true;
     }
 
-    return 0;
+    return busy;
 }
 
 int32_t BLE_LEDGER_PROFILE_apdu_data_ready(uint8_t *buffer, uint16_t max_length, void *cookie)

--- a/lib_stusb/include/usbd_ledger_ccid.h
+++ b/lib_stusb/include/usbd_ledger_ccid.h
@@ -37,7 +37,7 @@ uint8_t USBD_LEDGER_CCID_send_packet(USBD_HandleTypeDef *pdev,
                                      const uint8_t      *packet,
                                      uint16_t            packet_length,
                                      uint32_t            timeout_ms);
-uint8_t USBD_LEDGER_CCID_is_busy(void *cookie);
+bool USBD_LEDGER_CCID_is_busy(void *cookie);
 
 int32_t USBD_LEDGER_CCID_data_ready(USBD_HandleTypeDef *pdev,
                                     void               *cookie,

--- a/lib_stusb/include/usbd_ledger_hid.h
+++ b/lib_stusb/include/usbd_ledger_hid.h
@@ -37,7 +37,7 @@ uint8_t USBD_LEDGER_HID_send_packet(USBD_HandleTypeDef *pdev,
                                     const uint8_t      *packet,
                                     uint16_t            packet_length,
                                     uint32_t            timeout_ms);
-uint8_t USBD_LEDGER_HID_is_busy(void *cookie);
+bool USBD_LEDGER_HID_is_busy(void *cookie);
 
 int32_t USBD_LEDGER_HID_data_ready(USBD_HandleTypeDef *pdev,
                                    void               *cookie,

--- a/lib_stusb/include/usbd_ledger_hid_u2f.h
+++ b/lib_stusb/include/usbd_ledger_hid_u2f.h
@@ -5,6 +5,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include <stdint.h>
+#include <stdbool.h>
 #include "usbd_def.h"
 #include "usbd_ledger_types.h"
 
@@ -44,7 +45,7 @@ uint8_t USBD_LEDGER_HID_U2F_send_message(USBD_HandleTypeDef *pdev,
                                          const uint8_t      *message,
                                          uint16_t            message_length,
                                          uint32_t            timeout_ms);
-uint8_t USBD_LEDGER_HID_U2F_is_busy(void *cookie);
+bool USBD_LEDGER_HID_U2F_is_busy(void *cookie);
 
 int32_t USBD_LEDGER_HID_U2F_data_ready(USBD_HandleTypeDef *pdev,
                                        void               *cookie,

--- a/lib_stusb/include/usbd_ledger_types.h
+++ b/lib_stusb/include/usbd_ledger_types.h
@@ -40,7 +40,7 @@ typedef uint8_t (*usbd_send_packet_t)(USBD_HandleTypeDef *pdev,
                                       const uint8_t      *packet,
                                       uint16_t            packet_length,
                                       uint32_t            timeout_ms);
-typedef uint8_t (*usbd_is_busy_t)(void *cookie);
+typedef bool (*usbd_is_busy_t)(void *cookie);
 
 typedef int32_t (*usbd_data_ready_t)(USBD_HandleTypeDef *pdev,
                                      void               *cookie,

--- a/lib_stusb/include/usbd_ledger_webusb.h
+++ b/lib_stusb/include/usbd_ledger_webusb.h
@@ -37,7 +37,7 @@ uint8_t USBD_LEDGER_WEBUSB_send_packet(USBD_HandleTypeDef *pdev,
                                        const uint8_t      *packet,
                                        uint16_t            packet_length,
                                        uint32_t            timeout_ms);
-uint8_t USBD_LEDGER_WEBUSB_is_busy(void *cookie);
+bool USBD_LEDGER_WEBUSB_is_busy(void *cookie);
 
 int32_t USBD_LEDGER_WEBUSB_data_ready(USBD_HandleTypeDef *pdev,
                                       void               *cookie,

--- a/lib_stusb/src/usbd_ledger_ccid.c
+++ b/lib_stusb/src/usbd_ledger_ccid.c
@@ -381,15 +381,16 @@ uint8_t USBD_LEDGER_CCID_send_packet(USBD_HandleTypeDef *pdev,
     return ret;
 }
 
-uint8_t USBD_LEDGER_CCID_is_busy(void *cookie)
+bool USBD_LEDGER_CCID_is_busy(void *cookie)
 {
     ledger_ccid_handle_t *handle = (ledger_ccid_handle_t *) PIC(cookie);
+    bool busy = false;
 
     if (handle->state == LEDGER_CCID_STATE_BUSY) {
-        return 1;
+        busy = true;
     }
 
-    return 0;
+    return busy;
 }
 
 int32_t USBD_LEDGER_CCID_data_ready(USBD_HandleTypeDef *pdev,

--- a/lib_stusb/src/usbd_ledger_hid.c
+++ b/lib_stusb/src/usbd_ledger_hid.c
@@ -388,15 +388,16 @@ uint8_t USBD_LEDGER_HID_send_packet(USBD_HandleTypeDef *pdev,
     return ret;
 }
 
-uint8_t USBD_LEDGER_HID_is_busy(void *cookie)
+bool USBD_LEDGER_HID_is_busy(void *cookie)
 {
     ledger_hid_handle_t *handle = (ledger_hid_handle_t *) PIC(cookie);
+    bool busy = false;
 
     if (handle->state == LEDGER_HID_STATE_BUSY) {
-        return 1;
+        busy = true;
     }
 
-    return 0;
+    return busy;
 }
 
 int32_t USBD_LEDGER_HID_data_ready(USBD_HandleTypeDef *pdev,

--- a/lib_stusb/src/usbd_ledger_hid_u2f.c
+++ b/lib_stusb/src/usbd_ledger_hid_u2f.c
@@ -457,15 +457,16 @@ uint8_t USBD_LEDGER_HID_U2F_send_message(USBD_HandleTypeDef *pdev,
     return ret;
 }
 
-uint8_t USBD_LEDGER_HID_U2F_is_busy(void *cookie)
+bool USBD_LEDGER_HID_U2F_is_busy(void *cookie)
 {
     ledger_hid_u2f_handle_t *handle = (ledger_hid_u2f_handle_t *) PIC(cookie);
+    bool busy = false;
 
     if (handle->state == LEDGER_HID_U2F_STATE_BUSY) {
-        return 1;
+        busy = true;
     }
 
-    return 0;
+    return busy;
 }
 
 int32_t USBD_LEDGER_HID_U2F_data_ready(USBD_HandleTypeDef *pdev,

--- a/lib_stusb/src/usbd_ledger_webusb.c
+++ b/lib_stusb/src/usbd_ledger_webusb.c
@@ -435,15 +435,16 @@ uint8_t USBD_LEDGER_WEBUSB_send_packet(USBD_HandleTypeDef *pdev,
     return ret;
 }
 
-uint8_t USBD_LEDGER_WEBUSB_is_busy(void *cookie)
+bool USBD_LEDGER_WEBUSB_is_busy(void *cookie)
 {
     ledger_webusb_handle_t *handle = (ledger_webusb_handle_t *) PIC(cookie);
+    bool busy = false;
 
     if (handle->state == LEDGER_WEBUSB_STATE_BUSY) {
-        return 1;
+        busy = true;
     }
 
-    return 0;
+    return busy;
 }
 
 int32_t USBD_LEDGER_WEBUSB_data_ready(USBD_HandleTypeDef *pdev,


### PR DESCRIPTION
## Description

Fix `BLE_LEDGER_is_busy()` and cleanup the signature.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

