### PR TITLE
Adapt the maximum size of an NBGL object in object pool

### DIFF
--- a/lib_nbgl/src/nbgl_obj_pool.c
+++ b/lib_nbgl/src/nbgl_obj_pool.c
@@ -49,10 +49,10 @@ typedef struct {
         nbgl_progress_bar_t progressBarObj;
         nbgl_container_t    containerObj;
         nbgl_image_t        imageObj;
+        nbgl_button_t       buttonObj;
+        nbgl_switch_t       switchObj;
 #ifdef HAVE_SE_TOUCH
         nbgl_radio_t          radioObj;
-        nbgl_switch_t         switchObj;
-        nbgl_button_t         buttonObj;
         nbgl_page_indicator_t navBarObj;
         nbgl_line_t           lineObj;
         nbgl_spinner_t        spinnerObj;


### PR DESCRIPTION
## Description

The goal of this PR is to adapt the maximum size of an NBGL object in object pool.
Currently it's tool smal when using a button in Nano case, and end of objects may be corrupter

## Changes include

- [*] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
