### PR TITLE
RK update & onboarding states

### DIFF
--- a/include/os_seed.h
+++ b/include/os_seed.h
@@ -90,7 +90,8 @@ enum {
     ONBOARDING_STATUS_CHOOSE_NAME,
     ONBOARDING_STATUS_RECOVER_RESTORE_SEED,
     ONBOARDING_STATUS_SETUP_CHOICE_RESTORE_SEED,
-    ONBOARDING_STATUS_CHECKING
+    ONBOARDING_STATUS_CHECKING,
+    ONBOARDING_STATUS_RESTORE_WITH_RK  // 0x10
 };
 SYSCALL void os_perso_set_onboarding_status(unsigned int state,
                                             unsigned int count,

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -201,6 +201,7 @@
 #define SYSCALL_os_dashboard_mbx_ID       0x02000150
 #define SYSCALL_os_ux_set_global_ID       0x03000151
 #define SYSCALL_os_rk_set_backup_state_ID 0x01000152
+#define SYSCALL_os_rk_set_update_state_ID 0x01000155
 
 #ifdef HAVE_CUSTOM_CA_DETAILS_IN_SETTINGS
 #define SYSCALL_CERT_get_ID   0x01000CA0

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1608,6 +1608,13 @@ void RK_set_backup_state(RK_backup_state_t state)
     parameters[0] = (unsigned int) state;
     SVC_Call(SYSCALL_os_rk_set_backup_state_ID, parameters);
 }
+
+void RK_set_update_state(RK_update_state_t state)
+{
+    unsigned int parameters[1];
+    parameters[0] = (unsigned int) state;
+    SVC_Call(SYSCALL_os_rk_set_update_state_ID, parameters);
+}
 #endif  // HAVE_CHARON
 
 void os_lib_call(unsigned int *call_parameters)


### PR DESCRIPTION
## Description

The goal of this PR is to add ways to indicate to Ledger Live the update requirements for Recovery Key, and add a new onboarding state when restoring with RK

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
