### PR TITLE
Fix bottom margin of nbgl_layoutAddText() function

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1070,10 +1070,10 @@ static int addText(nbgl_layout_t *layout,
         else {
             subTextArea->obj.alignmentMarginY = PRE_SUBTEXT_MARGIN;
         }
-        fullHeight += subTextArea->obj.alignmentMarginY;
         container->children[container->nbChildren] = (nbgl_obj_t *) subTextArea;
         container->nbChildren++;
         fullHeight += subTextArea->obj.area.height + subTextArea->obj.alignmentMarginY;
+        fullHeight += POST_SUBTEXT_MARGIN;
     }
     else {
         fullHeight += PRE_TEXT_MARGIN;


### PR DESCRIPTION
## Description

The goal of this PR is to fix bottom margin of nbgl_layoutAddText() function (for example for settings->version in apps)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_22
[x] TARGET_API_LEVEL: API_LEVEL_23
[ ] TARGET_API_LEVEL: API_LEVEL_24

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In such case, there is no other solution than do the operation manually...
