### PR TITLE
Reset long-press button when overriden by another screen

### DIFF
--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -372,12 +372,14 @@ typedef struct PACKED__ nbgl_switch_s {
  * @note if withBorder, the stroke of the border is fixed (3 pixels)
  */
 typedef struct PACKED__ nbgl_progress_bar_s {
-    nbgl_obj_t obj;            // common part
-    bool       withBorder;     ///< if set to true, a border in black surround the whole object
-    uint8_t    state;          ///< state of the progress, in % (from 0 to 100).
-    bool       partialRedraw;  ///< set to true to redraw only partially the object (update state).
+    nbgl_obj_t obj;  // common part
     uint16_t   previousWidth;
-    color_t    foregroundColor;  ///< color of the inner progress bar and border (if applicable)
+    uint8_t    state;           ///< state of the progress, in % (from 0 to 100).
+    uint8_t partialRedraw : 1;  ///< set to true to redraw only partially the object (update state).
+    uint8_t withBorder : 1;     ///< if set to true, a border in black surround the whole object
+    uint8_t resetIfOverriden : 1;  ///< if set to true, the state is reset to 0 if the screen is
+                                   ///< covered by another screen
+    color_t foregroundColor;       ///< color of the inner progress bar and border (if applicable)
 } nbgl_progress_bar_t;
 
 /**

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -3249,12 +3249,11 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
             layoutInt->upFooterContainer->children[2] = (nbgl_obj_t *) line;
 
             progressBar = (nbgl_progress_bar_t *) nbgl_objPoolGet(PROGRESS_BAR, layoutInt->layer);
-            progressBar->withBorder                   = false;
             progressBar->obj.area.width               = SCREEN_WIDTH;
             progressBar->obj.area.height              = 8;
             progressBar->obj.alignment                = TOP_MIDDLE;
             progressBar->obj.alignmentMarginY         = 4;
-            progressBar->obj.alignTo                  = NULL;
+            progressBar->resetIfOverriden             = true;
             layoutInt->upFooterContainer->children[3] = (nbgl_obj_t *) progressBar;
             break;
         }

--- a/lib_nbgl/src/nbgl_layout_internal.h
+++ b/lib_nbgl/src/nbgl_layout_internal.h
@@ -73,19 +73,7 @@ enum {
  *
  */
 typedef struct nbgl_layoutInternal_s {
-    bool modal;           ///< if true, means the screen is a modal
-    bool withLeftBorder;  ///< if true, draws a light gray left border on the whole height of the
-                          ///< screen
-    uint8_t layer;  ///< if >0, puts the layout on top of screen stack (modal). Otherwise puts on
-                    ///< background (for apps)
-    uint8_t      nbChildren;  ///< number of children in above array
-    nbgl_obj_t **children;    ///< children for main screen
-
-    uint8_t                   nbPages;       ///< number of pages for navigation bar
-    uint8_t                   activePage;    ///< index of active page for navigation bar
-    nbgl_layoutHeaderType_t   headerType;    ///< type of header
-    nbgl_layoutFooterType_t   footerType;    ///< type of footer
-    nbgl_layoutUpFooterType_t upFooterType;  ///< type of up-footer
+    nbgl_obj_t **children;  ///< children for main screen
     nbgl_container_t
         *headerContainer;  ///< container used to store header (progress, back, empty space...)
     nbgl_container_t *footerContainer;    ///< container used to store footer (buttons, nav....)
@@ -95,13 +83,24 @@ typedef struct nbgl_layoutInternal_s {
     nbgl_layoutTouchCallback_t callback;  // user callback for all controls
     // This is the pool of callback objects, potentially used by this layout
     layoutObj_t callbackObjPool[LAYOUT_OBJ_POOL_LEN];
-    // number of callback objects used by the whole layout in callbackObjPool
-    uint8_t nbUsedCallbackObjs;
 
     nbgl_container_t       *container;
-    const nbgl_animation_t *animation;      ///< current animation (if not NULL)
-    uint8_t                 iconIdxInAnim;  ///< current icon index in animation
-    bool incrementAnim;  ///< if true, means that animation index is currently incrementing
+    const nbgl_animation_t *animation;  ///< current animation (if not NULL)
+
+    uint8_t                   nbPages;       ///< number of pages for navigation bar
+    uint8_t                   activePage;    ///< index of active page for navigation bar
+    nbgl_layoutHeaderType_t   headerType;    ///< type of header
+    nbgl_layoutFooterType_t   footerType;    ///< type of footer
+    nbgl_layoutUpFooterType_t upFooterType;  ///< type of up-footer
+    uint8_t                   modal : 1;     ///< if true, means the screen is a modal
+    uint8_t withLeftBorder : 1;  ///< if true, draws a light gray left border on the whole height of
+                                 ///< the screen
+    uint8_t incrementAnim : 1;   ///< if true, means that animation index is currently incrementing
+    uint8_t layer : 5;           ///< layer in screen stack
+    uint8_t nbUsedCallbackObjs;  ///< number of callback objects used by the whole layout in
+                                 ///< callbackObjPool
+    uint8_t            nbChildren;     ///< number of children in above array
+    uint8_t            iconIdxInAnim;  ///< current icon index in animation
     nbgl_swipe_usage_t swipeUsage;
 } nbgl_layoutInternal_t;
 

--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -364,13 +364,13 @@ int nbgl_screenPush(nbgl_obj_t                           ***elements,
                 // update previous topOfStack
                 topOfStack->next                  = &screenStack[screenIndex];
                 screenStack[screenIndex].previous = topOfStack;
-#ifdef HAVE_SE_TOUCH
-                nbgl_touchStatePosition_t touchStatePosition = {.state = RELEASED, .x = 0, .y = 0};
-                // make a fake touch release for the current top-of-stack to avoid issue
-                // (for example in long-touch press)
-                nbgl_touchHandler(topOfStack->isUxScreen, &touchStatePosition, 0);
-#endif  // HAVE_SE_TOUCH
-        // new top of stack
+                // search for a potential progress bar in current topOfStack to reset it if needed
+                nbgl_progress_bar_t *progress
+                    = (nbgl_progress_bar_t *) nbgl_screenContainsObjType(topOfStack, PROGRESS_BAR);
+                if ((progress != NULL) && (progress->resetIfOverriden)) {
+                    progress->state = 0;
+                }
+                // new top of stack
                 topOfStack       = &screenStack[screenIndex];
                 topOfStack->next = NULL;
                 break;


### PR DESCRIPTION
## Description

The goal of this PR is to reset long-press button to 0 when overriden by another screen (a modal, for example lock/battery alert...).
For this we use a boolean in Progress Bar structure to indicate that it's a progress that needs to be reset.
Then, when pushing a new one on top of the screen, its state is reset to 0.

Previously it was done by sending a fake "touch release" to the screen, when pushing a new one on top of it, but it cannot work with App screens overriden by UX screens.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
