### PR TITLE
lock_delay shall be always available in the union

### DIFF
--- a/include/os_ux.h
+++ b/include/os_ux.h
@@ -24,9 +24,8 @@ typedef struct bolos_ux_params_s {
     bolos_ux_t ux_id;
     // length of parameters in the u union to be copied during the syscall.
     unsigned int len;
-
-#if defined(HAVE_BLE) || defined(HAVE_KEYBOARD_UX)
     union {
+#if defined(HAVE_BLE) || defined(HAVE_KEYBOARD_UX)
         // Structure for the lib ux.
 #if defined(HAVE_KEYBOARD_UX)
         struct {
@@ -65,11 +64,11 @@ typedef struct bolos_ux_params_s {
             } pairing_ok;
         } pairing_status;  // sent in BOLOS_UX_ASYNCHMODAL_PAIRING_STATUS message
 #endif                     // HAVE_BLE
-        struct {           // for BOLOS_UX_DELAY_LOCK command
+#endif  // defined(HAVE_BLE) || defined(HAVE_KEYBOARD_UX)
+        struct {  // for BOLOS_UX_DELAY_LOCK command
             uint32_t delay_ms;
         } lock_delay;
     } u;
-#endif  // defined(HAVE_BLE) || defined(HAVE_KEYBOARD_UX)
 } bolos_ux_params_t;
 
 #endif  // !defined(HAVE_BOLOS)

--- a/include/os_ux.h
+++ b/include/os_ux.h
@@ -64,8 +64,8 @@ typedef struct bolos_ux_params_s {
             } pairing_ok;
         } pairing_status;  // sent in BOLOS_UX_ASYNCHMODAL_PAIRING_STATUS message
 #endif                     // HAVE_BLE
-#endif  // defined(HAVE_BLE) || defined(HAVE_KEYBOARD_UX)
-        struct {  // for BOLOS_UX_DELAY_LOCK command
+#endif                     // defined(HAVE_BLE) || defined(HAVE_KEYBOARD_UX)
+        struct {           // for BOLOS_UX_DELAY_LOCK command
             uint32_t delay_ms;
         } lock_delay;
     } u;


### PR DESCRIPTION
## Description

`lock_delay` struct shall always be available in `bolos_ux_params_t`, whatever the device. 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
