### PR TITLE
Address verif improvements

### DIFF
--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -143,7 +143,8 @@ typedef enum {
     ENS_ALIAS,           ///< alias comes from ENS
     ADDRESS_BOOK_ALIAS,  ///< alias comes from Address Book
     QR_CODE_ALIAS,       ///< alias is an address to be displayed as a QR Code
-    INFO_LIST_ALIAS      ///< alias is list of infos
+    INFO_LIST_ALIAS,     ///< alias is list of infos
+    TAG_VALUE_LIST_ALIAS
 } nbgl_contentValueAliasType_t;
 
 /**
@@ -158,8 +159,12 @@ typedef struct {
                         ///< the QR Code
     const char
         *backText;  ///< used as title of the popping page, if not NULL, otherwise "item" is used
-    const struct nbgl_contentInfoList_s *infolist;   ///< if aliasType is INFO_LIST_ALIAS
-    nbgl_contentValueAliasType_t         aliasType;  ///< type of alias
+    union {
+        const struct nbgl_contentInfoList_s *infolist;  ///< if aliasType is INFO_LIST_ALIAS
+        const struct nbgl_contentTagValueList_s
+            *tagValuelist;  ///< if aliasType is TAG_VALUE_LIST_ALIAS
+    };
+    nbgl_contentValueAliasType_t aliasType;  ///< type of alias
 } nbgl_contentValueExt_t;
 
 /**
@@ -204,7 +209,7 @@ typedef void (*nbgl_contentActionCallback_t)(int token, uint8_t index, int page)
 /**
  * @brief This structure contains a list of [tag,value] pairs
  */
-typedef struct {
+typedef struct nbgl_contentTagValueList_s {
     const nbgl_contentTagValue_t
         *pairs;  ///< array of [tag,value] pairs (nbPairs items). If NULL, callback is used instead
     nbgl_contentTagValueCallback_t callback;  ///< function to call to retrieve a given pair

--- a/tests/screenshots/flows/wallet/app-sdk/flow_address_verif.json
+++ b/tests/screenshots/flows/wallet/app-sdk/flow_address_verif.json
@@ -117,6 +117,71 @@
     {
       "name": "long_address-03",
       "targets": [
+        {
+          "app_event": "ETH_VERIFY_MULTISIG",
+          "page": "multi-sig-01",
+          "comment": "verify mutli-sig"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-01",
+      "targets": [
+        {
+          "object": "RIGHT_BUTTON",
+          "page": "multi-sig-02"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-02",
+      "targets": [
+        {
+          "object": "EXTRA_BUTTON",
+          "page": "multi-sig-qr_code",
+          "comment": "view QR"
+        },
+        {
+          "object": "RIGHT_BUTTON",
+          "page": "multi-sig-03"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-03",
+      "targets": [
+        {
+          "object": "VALUE_BUTTON_2",
+          "page": "multi-sig-signers-01",
+          "comment": "view signers details (alias)"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-qr_code",
+      "targets": [
+        {
+          "object": "BOTTOM_BUTTON",
+          "page": "multi-sig-02"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-signers-01",
+      "targets": [
+        {
+          "object": "RIGHT_BUTTON",
+          "page": "multi-sig-signers-02"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-signers-02",
+      "targets": [
+        {
+          "object": "BOTTOM_BUTTON",
+          "page": "multi-sig-03"
+        }
       ]
     }
   ]

--- a/tests/screenshots/src/apps/app_ethereum_verify_addr.c
+++ b/tests/screenshots/src/apps/app_ethereum_verify_addr.c
@@ -24,6 +24,33 @@
  *  STATIC VARIABLES
  **********************/
 
+static nbgl_contentTagValue_t tagValuePairs[] = {
+    {.item = "Signer 1", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 2", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 3", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 4", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 5", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 6", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 7", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 8", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+};
+
+static nbgl_contentTagValueList_t tagValueList
+    = {.nbPairs = 8, .wrapping = false, .pairs = (nbgl_contentTagValue_t *) tagValuePairs};
+
+static nbgl_contentValueExt_t extension
+    = {.tagValuelist = &tagValueList, .aliasType = TAG_VALUE_LIST_ALIAS, .title = ""};
+
+static nbgl_contentTagValue_t pairs[] = {
+    {.item = "Your role", .value = "Signer"},
+    {.item = "Threshold", .value = "3 out of 8", .extension = &extension, .aliasValue = 1},
+};
+
+static nbgl_contentTagValueList_t pairList = {.nbMaxLinesForValue = 0,
+                                              .nbPairs            = 2,
+                                              .wrapping           = true,
+                                              .pairs = (nbgl_contentTagValue_t *) pairs};
+
 /**********************
  *      VARIABLES
  **********************/
@@ -55,6 +82,20 @@ void app_ethereumVerifyAddress(void)
                               NULL,
                               &ETH_MAIN_ICON,
                               "Verify Ethereum\naddress",
+                              NULL,
+                              displayAddressCallback);
+}
+
+/**
+ * @brief Ethereum application verify address page
+ *
+ */
+void app_ethereumVerifyMultiSig(void)
+{
+    nbgl_useCaseAddressReview("0xe87eD43dE2bf1D340e426920F103A10fD5fb8e47",
+                              &pairList,
+                              &ETH_MAIN_ICON,
+                              "Verify Safe address",
                               NULL,
                               displayAddressCallback);
 }

--- a/tests/screenshots/src/apps/apps_api.h
+++ b/tests/screenshots/src/apps/apps_api.h
@@ -66,6 +66,7 @@ void app_ethereumReviewBlindSigningTransaction(void);
 void app_ethereumReviewENSTransaction(void);
 void app_ethereumReviewDappTransaction(void);
 void app_ethereumVerifyAddress(void);
+void app_ethereumVerifyMultiSig(void);
 void app_ethereumSecurityKeyLogin(void);
 void app_fullEthereumShareAddress(void);
 void app_fullAlgorand(void);

--- a/tests/screenshots/src/main/json_scenario.c
+++ b/tests/screenshots/src/main/json_scenario.c
@@ -42,6 +42,7 @@ Event_t appEvents[] = {
     {"ETH_DAPP",            ETH_DAPP           },
     {"ETH_SIGN",            ETH_SIGN           },
     {"ETH_VERIFY_ADDR",     ETH_VERIFY_ADDR    },
+    {"ETH_VERIFY_MULTISIG", ETH_VERIFY_MULTISIG},
     {"RECOV_OPEN",          RECOV_OPEN         },
     {"DOGE_SIGN",           DOGE_SIGN          }
 };
@@ -603,6 +604,9 @@ static int scenario_get_action(void)
                 break;
             case ETH_VERIFY_ADDR:
                 app_ethereumVerifyAddress();
+                break;
+            case ETH_VERIFY_MULTISIG:
+                app_ethereumVerifyMultiSig();
                 break;
             case RECOV_OPEN:
                 app_fullRecoveryCheck();

--- a/tests/screenshots/src/main/json_scenario.h
+++ b/tests/screenshots/src/main/json_scenario.h
@@ -63,6 +63,7 @@ enum {
     ETH_ENS,
     ETH_DAPP,
     ETH_VERIFY_ADDR,
+    ETH_VERIFY_MULTISIG,
     RECOV_OPEN,
     DOGE_SIGN,
 };


### PR DESCRIPTION
## Description

For multi-sig feature, we need to display a list of signers when pressing the alias (>) of a specific pair.
This PR also adds an improvement, to gather tag/value pairs with the address in "address review" if it fits in a signe page.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

