### PR TITLE
Address verif improvements 23

### DIFF
--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -142,7 +142,8 @@ typedef enum {
     ENS_ALIAS,           ///< alias comes from ENS
     ADDRESS_BOOK_ALIAS,  ///< alias comes from Address Book
     QR_CODE_ALIAS,       ///< alias is an address to be displayed as a QR Code
-    INFO_LIST_ALIAS      ///< alias is list of infos
+    INFO_LIST_ALIAS,     ///< alias is list of infos
+    TAG_VALUE_LIST_ALIAS
 } nbgl_contentValueAliasType_t;
 
 /**
@@ -157,8 +158,12 @@ typedef struct {
                         ///< the QR Code
     const char
         *backText;  ///< used as title of the popping page, if not NULL, otherwise "item" is used
-    const struct nbgl_contentInfoList_s *infolist;   ///< if aliasType is INFO_LIST_ALIAS
-    nbgl_contentValueAliasType_t         aliasType;  ///< type of alias
+    union {
+        const struct nbgl_contentInfoList_s *infolist;  ///< if aliasType is INFO_LIST_ALIAS
+        const struct nbgl_contentTagValueList_s
+            *tagValuelist;  ///< if aliasType is TAG_VALUE_LIST_ALIAS
+    };
+    nbgl_contentValueAliasType_t aliasType;  ///< type of alias
 } nbgl_contentValueExt_t;
 
 /**
@@ -203,7 +208,7 @@ typedef void (*nbgl_contentActionCallback_t)(int token, uint8_t index, int page)
 /**
  * @brief This structure contains a list of [tag,value] pairs
  */
-typedef struct {
+typedef struct nbgl_contentTagValueList_s {
     const nbgl_contentTagValue_t
         *pairs;  ///< array of [tag,value] pairs (nbPairs items). If NULL, callback is used instead
     nbgl_contentTagValueCallback_t callback;  ///< function to call to retrieve a given pair

--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -50,6 +50,7 @@ extern "C" {
 #define MEDIUM_CENTERING_HEADER           56
 #define MEDIUM_CENTERING_FOOTER           88
 #define LONG_PRESS_BUTTON_HEIGHT          128
+#define UP_FOOTER_BUTTON_HEIGHT           120
 
 #define PRE_TEXT_MARGIN     32
 #define TEXT_SUBTEXT_MARGIN 16
@@ -75,6 +76,7 @@ extern "C" {
 #define MEDIUM_CENTERING_HEADER           64
 #define MEDIUM_CENTERING_FOOTER           64
 #define LONG_PRESS_BUTTON_HEIGHT          152
+#define UP_FOOTER_BUTTON_HEIGHT           136
 
 #define PRE_TEXT_MARGIN     28
 #define TEXT_SUBTEXT_MARGIN 14

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -44,7 +44,6 @@
 #define FOOTER_HEIGHT                    80
 #define BAR_INTERVALE                    12
 #define FOOTER_BUTTON_HEIGHT             128
-#define UP_FOOTER_BUTTON_HEIGHT          120
 #define ROUNDED_AND_FOOTER_FOOTER_HEIGHT 192
 #define ACTION_AND_FOOTER_FOOTER_HEIGHT  216
 #define FOOTER_TEXT_AND_NAV_WIDTH        160
@@ -67,7 +66,6 @@
 #define FOOTER_HEIGHT                    80
 #define BAR_INTERVALE                    16
 #define FOOTER_BUTTON_HEIGHT             136
-#define UP_FOOTER_BUTTON_HEIGHT          136
 #define ROUNDED_AND_FOOTER_FOOTER_HEIGHT 208
 #define ACTION_AND_FOOTER_FOOTER_HEIGHT  232
 #define FOOTER_TEXT_AND_NAV_WIDTH        192

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -422,6 +422,8 @@ static uint8_t getContentNbElement(const nbgl_content_t *content)
     switch (content->type) {
         case TAG_VALUE_LIST:
             return content->content.tagValueList.nbPairs;
+        case TAG_VALUE_CONFIRM:
+            return content->content.tagValueConfirm.tagValueList.nbPairs;
         case SWITCHES_LIST:
             return content->content.switchesList.nbSwitches;
         case INFOS_LIST:
@@ -1065,9 +1067,26 @@ static bool genericContextPreparePageContent(const nbgl_content_t *p_content,
             break;
         }
         case TAG_VALUE_CONFIRM:
-            memcpy(&pageContent->tagValueConfirm,
-                   &p_content->content.tagValueConfirm,
-                   sizeof(pageContent->tagValueConfirm));
+            // only display a TAG_VALUE_CONFIRM if we are at the last page
+            if ((nextElementIdx + nbElementsInPage)
+                == p_content->content.tagValueConfirm.tagValueList.nbPairs) {
+                memcpy(&pageContent->tagValueConfirm,
+                       &p_content->content.tagValueConfirm,
+                       sizeof(pageContent->tagValueConfirm));
+                nbgl_contentTagValueList_t *p_tagValueList
+                    = &pageContent->tagValueConfirm.tagValueList;
+                p_tagValueList->nbPairs = nbElementsInPage;
+                p_tagValueList->pairs
+                    = PIC(&p_content->content.tagValueConfirm.tagValueList.pairs[nextElementIdx]);
+            }
+            else {
+                // else display it as a TAG_VALUE_LIST
+                pageContent->type                          = TAG_VALUE_LIST;
+                nbgl_contentTagValueList_t *p_tagValueList = &pageContent->tagValueList;
+                p_tagValueList->nbPairs                    = nbElementsInPage;
+                p_tagValueList->pairs
+                    = PIC(&p_content->content.tagValueConfirm.tagValueList.pairs[nextElementIdx]);
+            }
             break;
         case SWITCHES_LIST:
             pageContent->switchesList.nbSwitches = nbElementsInPage;
@@ -1718,10 +1737,119 @@ static void keypadGenericUseCase(const char                *title,
 }
 #endif
 
-static uint8_t nbgl_useCaseGetNbPagesForContent(const nbgl_content_t *content,
-                                                uint8_t               pageIdxStart,
-                                                bool                  isLast,
-                                                bool                  isSkippable)
+/**
+ * @brief computes the number of tag/values pairs displayable in a page, with the given list of
+ * tag/value pairs
+ *
+ * @param nbPairs number of tag/value pairs to use in \b tagValueList
+ * @param tagValueList list of tag/value pairs
+ * @param startIndex first index to consider in \b tagValueList
+ * @param isSkippable if true, a skip header is added
+ * @param hasConfirmationButton if true, a confirmation button is added at last page
+ * @param requireSpecificDisplay (output) set to true if the tag/value needs a specific display:
+ *        - centeredInfo flag is enabled
+ *        - the tag/value doesn't fit in a page
+ * @return the number of tag/value pairs fitting in a page
+ */
+static uint8_t getNbTagValuesInPage(uint8_t                           nbPairs,
+                                    const nbgl_contentTagValueList_t *tagValueList,
+                                    uint8_t                           startIndex,
+                                    bool                              isSkippable,
+                                    bool                              hasConfirmationButton,
+                                    bool                             *requireSpecificDisplay)
+{
+    uint8_t  nbPairsInPage   = 0;
+    uint16_t currentHeight   = PRE_TAG_VALUE_MARGIN;  // upper margin
+    uint16_t maxUsableHeight = TAG_VALUE_AREA_HEIGHT;
+
+    // if the review is skippable, it means that there is less height for tag/value pairs
+    // the small centering header becomes a touchable header
+    if (isSkippable) {
+        maxUsableHeight -= TOUCHABLE_HEADER_BAR_HEIGHT - SMALL_CENTERING_HEADER;
+    }
+
+    *requireSpecificDisplay = false;
+    while (nbPairsInPage < nbPairs) {
+        const nbgl_layoutTagValue_t *pair;
+        nbgl_font_id_e               value_font;
+        uint16_t                     nbLines;
+
+        // margin between pairs
+        // 12 or 24 px between each tag/value pair
+        if (nbPairsInPage > 0) {
+            currentHeight += INTER_TAG_VALUE_MARGIN;
+        }
+        // fetch tag/value pair strings.
+        if (tagValueList->pairs != NULL) {
+            pair = PIC(&tagValueList->pairs[startIndex + nbPairsInPage]);
+        }
+        else {
+            pair = PIC(tagValueList->callback(startIndex + nbPairsInPage));
+        }
+
+        if (pair->forcePageStart && nbPairsInPage > 0) {
+            // This pair must be at the top of a page
+            break;
+        }
+
+        if (pair->centeredInfo) {
+            if (nbPairsInPage > 0) {
+                // This pair must be at the top of a page
+                break;
+            }
+            else {
+                // This pair is the only one of the page and has a specific display behavior
+                nbPairsInPage           = 1;
+                *requireSpecificDisplay = true;
+                break;
+            }
+        }
+
+        // tag height
+        currentHeight += nbgl_getTextHeightInWidth(
+            SMALL_REGULAR_FONT, pair->item, AVAILABLE_WIDTH, tagValueList->wrapping);
+        // space between tag and value
+        currentHeight += 4;
+        // set value font
+        if (tagValueList->smallCaseForValue) {
+            value_font = SMALL_REGULAR_FONT;
+        }
+        else {
+            value_font = LARGE_MEDIUM_FONT;
+        }
+        // value height
+        currentHeight += nbgl_getTextHeightInWidth(
+            value_font, pair->value, AVAILABLE_WIDTH, tagValueList->wrapping);
+        // nb lines for value
+        nbLines = nbgl_getTextNbLinesInWidth(
+            value_font, pair->value, AVAILABLE_WIDTH, tagValueList->wrapping);
+        if ((currentHeight >= maxUsableHeight) || (nbLines > NB_MAX_LINES_IN_REVIEW)) {
+            if (nbPairsInPage == 0) {
+                // Pair too long to fit in a single screen
+                // It will be the only one of the page and has a specific display behavior
+                nbPairsInPage           = 1;
+                *requireSpecificDisplay = true;
+            }
+            break;
+        }
+        nbPairsInPage++;
+    }
+    // if this is a TAG_VALUE_CONFIRM and we have reached the last pairs,
+    // let's check if it still fits with a CONFIRMATION button, and if not,
+    // remove the last pair
+    if (hasConfirmationButton && (nbPairsInPage == nbPairs)) {
+        maxUsableHeight -= UP_FOOTER_BUTTON_HEIGHT;
+        if (currentHeight > maxUsableHeight) {
+            nbPairsInPage--;
+        }
+    }
+    return nbPairsInPage;
+}
+
+static uint8_t getNbPagesForContent(const nbgl_content_t *content,
+                                    uint8_t               pageIdxStart,
+                                    bool                  isLast,
+                                    bool                  isSkippable)
 {
     uint8_t nbElements = 0;
     uint8_t nbPages    = 0;
@@ -1736,8 +1864,16 @@ static uint8_t nbgl_useCaseGetNbPagesForContent(const nbgl_content_t *content,
         // if the current page is not the first one (or last), a navigation bar exists
         bool hasNav = !isLast || (pageIdxStart > 0) || (elemIdx > 0);
         if (content->type == TAG_VALUE_LIST) {
-            nbElementsInPage = nbgl_useCaseGetNbTagValuesInPageExt(
-                nbElements, &content->content.tagValueList, elemIdx, isSkippable, &flag);
+            nbElementsInPage = getNbTagValuesInPage(
+                nbElements, &content->content.tagValueList, elemIdx, isSkippable, false, &flag);
+        }
+        else if (content->type == TAG_VALUE_CONFIRM) {
+            nbElementsInPage = getNbTagValuesInPage(nbElements,
+                                                    &content->content.tagValueConfirm.tagValueList,
+                                                    elemIdx,
+                                                    isSkippable,
+                                                    true,
+                                                    &flag);
         }
         else if (content->type == INFOS_LIST) {
             nbElementsInPage = nbgl_useCaseGetNbInfosInPage(
@@ -1781,10 +1917,10 @@ static uint8_t getNbPagesForGenericContents(const nbgl_genericContents_t *generi
         if (p_content == NULL) {
             return 0;
         }
-        nbPages += nbgl_useCaseGetNbPagesForContent(p_content,
-                                                    pageIdxStart + nbPages,
-                                                    (i == (genericContents->nbContents - 1)),
-                                                    isSkippable);
+        nbPages += getNbPagesForContent(p_content,
+                                        pageIdxStart + nbPages,
+                                        (i == (genericContents->nbContents - 1)),
+                                        isSkippable);
     }
 
     return nbPages;
@@ -2572,8 +2708,8 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                           nbPai
                                          uint8_t                           startIndex,
                                          bool                             *requireSpecificDisplay)
 {
-    return nbgl_useCaseGetNbTagValuesInPageExt(
-        nbPairs, tagValueList, startIndex, false, requireSpecificDisplay);
+    return getNbTagValuesInPage(
+        nbPairs, tagValueList, startIndex, false, false, requireSpecificDisplay);
 }
 
 /**
@@ -2595,83 +2731,8 @@ uint8_t nbgl_useCaseGetNbTagValuesInPageExt(uint8_t                           nb
                                             bool                              isSkippable,
                                             bool *requireSpecificDisplay)
 {
-    uint8_t  nbPairsInPage   = 0;
-    uint16_t currentHeight   = PRE_TAG_VALUE_MARGIN;  // upper margin
-    uint16_t maxUsableHeight = TAG_VALUE_AREA_HEIGHT;
-
-    // if the review is skippable, it means that there is less height for tag/value pairs
-    // the small centering header becomes a touchable header
-    if (isSkippable) {
-        maxUsableHeight -= TOUCHABLE_HEADER_BAR_HEIGHT - SMALL_CENTERING_HEADER;
-    }
-
-    *requireSpecificDisplay = false;
-    while (nbPairsInPage < nbPairs) {
-        const nbgl_layoutTagValue_t *pair;
-        nbgl_font_id_e               value_font;
-        uint16_t                     nbLines;
-
-        // margin between pairs
-        // 12 or 24 px between each tag/value pair
-        if (nbPairsInPage > 0) {
-            currentHeight += INTER_TAG_VALUE_MARGIN;
-        }
-        // fetch tag/value pair strings.
-        if (tagValueList->pairs != NULL) {
-            pair = PIC(&tagValueList->pairs[startIndex + nbPairsInPage]);
-        }
-        else {
-            pair = PIC(tagValueList->callback(startIndex + nbPairsInPage));
-        }
-
-        if (pair->forcePageStart && nbPairsInPage > 0) {
-            // This pair must be at the top of a page
-            break;
-        }
-
-        if (pair->centeredInfo) {
-            if (nbPairsInPage > 0) {
-                // This pair must be at the top of a page
-                break;
-            }
-            else {
-                // This pair is the only one of the page and has a specific display behavior
-                nbPairsInPage           = 1;
-                *requireSpecificDisplay = true;
-                break;
-            }
-        }
-
-        // tag height
-        currentHeight += nbgl_getTextHeightInWidth(
-            SMALL_REGULAR_FONT, pair->item, AVAILABLE_WIDTH, tagValueList->wrapping);
-        // space between tag and value
-        currentHeight += 4;
-        // set value font
-        if (tagValueList->smallCaseForValue) {
-            value_font = SMALL_REGULAR_FONT;
-        }
-        else {
-            value_font = LARGE_MEDIUM_FONT;
-        }
-        // value height
-        currentHeight += nbgl_getTextHeightInWidth(
-            value_font, pair->value, AVAILABLE_WIDTH, tagValueList->wrapping);
-        // nb lines for value
-        nbLines = nbgl_getTextNbLinesInWidth(
-            value_font, pair->value, AVAILABLE_WIDTH, tagValueList->wrapping);
-        if ((currentHeight >= maxUsableHeight) || (nbLines > NB_MAX_LINES_IN_REVIEW)) {
-            if (nbPairsInPage == 0) {
-                // Pair too long to fit in a single screen
-                // It will be the only one of the page and has a specific display behavior
-                nbPairsInPage           = 1;
-                *requireSpecificDisplay = true;
-            }
-            break;
-        }
-        nbPairsInPage++;
-    }
-    return nbPairsInPage;
+    return getNbTagValuesInPage(
+        nbPairs, tagValueList, startIndex, isSkippable, false, requireSpecificDisplay);
 }
 
 /**
@@ -3012,7 +3073,7 @@ void nbgl_useCaseGenericSettings(const char                   *appName,
     // fill navigation structure
     uint8_t nbPages = getNbPagesForGenericContents(&genericContext.genericContents, 0, false);
     if (infosList != NULL) {
-        nbPages += nbgl_useCaseGetNbPagesForContent(&FINISHING_CONTENT, nbPages, true, false);
+        nbPages += getNbPagesForContent(&FINISHING_CONTENT, nbPages, true, false);
     }
 
     prepareNavInfo(false, nbPages, NULL);

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -47,6 +47,9 @@
 /* max number of char for reduced QR Code address */
 #define QRCODE_REDUCED_ADDR_LEN 128
 
+/* maximum number of pairs in a page of address confirm */
+#define ADDR_VERIF_NB_PAIRS 3
+
 // macros to ease access to shared contexts
 #define keypadContext     sharedContext.keypad
 #define reviewWithWarnCtx sharedContext.reviewWithWarning
@@ -115,8 +118,9 @@ typedef struct DetailsContext_s {
 } DetailsContext_t;
 
 typedef struct AddressConfirmationContext_s {
-    nbgl_layoutTagValue_t tagValuePair;
+    nbgl_layoutTagValue_t tagValuePairs[ADDR_VERIF_NB_PAIRS];
     nbgl_layout_t        *modalLayout;
+    uint8_t               nbPairs;
 } AddressConfirmationContext_t;
 
 #ifdef NBGL_KEYPAD
@@ -1419,7 +1423,7 @@ static void displayAddressQRCode(void)
                                                   .tapActionText    = NULL};
     nbgl_layoutHeader_t      headerDesc        = {
                     .type = HEADER_EMPTY, .separationLine = false, .emptySpace.height = SMALL_CENTERING_HEADER};
-    nbgl_layoutQRCode_t qrCode = {.url      = addressConfirmationContext.tagValuePair.value,
+    nbgl_layoutQRCode_t qrCode = {.url      = addressConfirmationContext.tagValuePairs[0].value,
                                   .text1    = NULL,
                                   .centered = true,
                                   .offsetY  = 0};
@@ -1428,16 +1432,18 @@ static void displayAddressQRCode(void)
     // add empty header for better look
     nbgl_layoutAddHeader(addressConfirmationContext.modalLayout, &headerDesc);
     // compute nb lines to check whether it shall be shorten (max is 3 lines)
-    uint16_t nbLines = nbgl_getTextNbLinesInWidth(
-        SMALL_REGULAR_FONT, addressConfirmationContext.tagValuePair.value, AVAILABLE_WIDTH, false);
+    uint16_t nbLines = nbgl_getTextNbLinesInWidth(SMALL_REGULAR_FONT,
+                                                  addressConfirmationContext.tagValuePairs[0].value,
+                                                  AVAILABLE_WIDTH,
+                                                  false);
 
     if (nbLines <= QRCODE_NB_MAX_LINES) {
-        qrCode.text2 = addressConfirmationContext.tagValuePair.value;  // in gray
+        qrCode.text2 = addressConfirmationContext.tagValuePairs[0].value;  // in gray
     }
     else {
         // only keep beginning and end of text, and add ... in the middle
         nbgl_textReduceOnNbLines(SMALL_REGULAR_FONT,
-                                 addressConfirmationContext.tagValuePair.value,
+                                 addressConfirmationContext.tagValuePairs[0].value,
                                  AVAILABLE_WIDTH,
                                  QRCODE_NB_MAX_LINES,
                                  reducedAddress,
@@ -1756,6 +1762,7 @@ static uint8_t getNbTagValuesInPage(uint8_t                           nbPairs,
                                     uint8_t                           startIndex,
                                     bool                              isSkippable,
                                     bool                              hasConfirmationButton,
+                                    bool                              hasDetailsButton,
                                     bool                             *requireSpecificDisplay)
 {
     uint8_t  nbPairsInPage   = 0;
@@ -1843,6 +1850,13 @@ static uint8_t getNbTagValuesInPage(uint8_t                           nbPairs,
             nbPairsInPage--;
         }
     }
+    // do the same with just a details button
+    else if (hasDetailsButton) {
+        maxUsableHeight -= (SMALL_BUTTON_RADIUS * 2);
+        if (currentHeight > maxUsableHeight) {
+            nbPairsInPage--;
+        }
+    }
     return nbPairsInPage;
 }
 
@@ -1864,15 +1878,21 @@ static uint8_t getNbPagesForContent(const nbgl_content_t *content,
         // if the current page is not the first one (or last), a navigation bar exists
         bool hasNav = !isLast || (pageIdxStart > 0) || (elemIdx > 0);
         if (content->type == TAG_VALUE_LIST) {
-            nbElementsInPage = getNbTagValuesInPage(
-                nbElements, &content->content.tagValueList, elemIdx, isSkippable, false, &flag);
+            nbElementsInPage = getNbTagValuesInPage(nbElements,
+                                                    &content->content.tagValueList,
+                                                    elemIdx,
+                                                    isSkippable,
+                                                    false,
+                                                    false,
+                                                    &flag);
         }
         else if (content->type == TAG_VALUE_CONFIRM) {
             nbElementsInPage = getNbTagValuesInPage(nbElements,
                                                     &content->content.tagValueConfirm.tagValueList,
                                                     elemIdx,
                                                     isSkippable,
-                                                    true,
+                                                    isLast,
+                                                    !isLast,
                                                     &flag);
         }
         else if (content->type == INFOS_LIST) {
@@ -1933,8 +1953,9 @@ static void prepareAddressConfirmationPages(const char                       *ad
 {
     nbgl_contentTagValueConfirm_t *tagValueConfirm;
 
-    addressConfirmationContext.tagValuePair.item  = "Address";
-    addressConfirmationContext.tagValuePair.value = address;
+    addressConfirmationContext.tagValuePairs[0].item  = "Address";
+    addressConfirmationContext.tagValuePairs[0].value = address;
+    addressConfirmationContext.nbPairs                = 1;
 
     // First page
     firstPageContent->type = TAG_VALUE_CONFIRM;
@@ -1942,9 +1963,27 @@ static void prepareAddressConfirmationPages(const char                       *ad
 
 #ifdef NBGL_QRCODE
     tagValueConfirm->detailsButtonIcon = &QRCODE_ICON;
-    // only use "Show as QR" when it's not the last page
-    if (tagValueList != NULL) {
-        tagValueConfirm->detailsButtonText = "Show as QR";
+    // only use "Show as QR" when address & pairs are not fitting in a single page
+    if ((tagValueList != NULL) && (tagValueList->nbPairs < ADDR_VERIF_NB_PAIRS)) {
+        nbgl_contentTagValueList_t tmpList;
+        bool                       flag;
+        // copy in intermediate structure
+        for (uint8_t i = 0; i < tagValueList->nbPairs; i++) {
+            memcpy(&addressConfirmationContext.tagValuePairs[1 + i],
+                   &tagValueList->pairs[i],
+                   sizeof(nbgl_contentTagValue_t));
+            addressConfirmationContext.nbPairs++;
+        }
+        // check how many can fit in a page
+        memcpy(&tmpList, tagValueList, sizeof(nbgl_contentTagValueList_t));
+        tmpList.nbPairs                    = addressConfirmationContext.nbPairs;
+        tmpList.pairs                      = addressConfirmationContext.tagValuePairs;
+        addressConfirmationContext.nbPairs = getNbTagValuesInPage(
+            addressConfirmationContext.nbPairs, &tmpList, 0, false, true, true, &flag);
+        // if they don't all fit, keep only the address
+        if (tmpList.nbPairs > addressConfirmationContext.nbPairs) {
+            addressConfirmationContext.nbPairs = 1;
+        }
     }
     else {
         tagValueConfirm->detailsButtonText = NULL;
@@ -1955,24 +1994,17 @@ static void prepareAddressConfirmationPages(const char                       *ad
     tagValueConfirm->detailsButtonIcon = NULL;
 #endif  // NBGL_QRCODE
     tagValueConfirm->tuneId                          = TUNE_TAP_CASUAL;
-    tagValueConfirm->tagValueList.nbPairs            = 1;
-    tagValueConfirm->tagValueList.pairs              = &addressConfirmationContext.tagValuePair;
+    tagValueConfirm->tagValueList.nbPairs            = addressConfirmationContext.nbPairs;
+    tagValueConfirm->tagValueList.pairs              = addressConfirmationContext.tagValuePairs;
     tagValueConfirm->tagValueList.smallCaseForValue  = false;
     tagValueConfirm->tagValueList.nbMaxLinesForValue = 0;
     tagValueConfirm->tagValueList.wrapping           = false;
     // if it's an extended address verif, it takes 2 pages, so display a "Tap to continue", and
     // no confirmation button
-    if (tagValueList != NULL) {
-        tagValueConfirm->confirmationText = NULL;
-    }
-    else {
-        // otherwise no tap to continue but a confirmation button
-        tagValueConfirm->confirmationText  = "Confirm";
-        tagValueConfirm->confirmationToken = CONFIRM_TOKEN;
-    }
-
-    // Second page if any:
-    if (tagValueList != NULL) {
+    if ((tagValueList != NULL)
+        && (tagValueList->nbPairs > (addressConfirmationContext.nbPairs - 1))) {
+        tagValueConfirm->detailsButtonText = "Show as QR";
+        tagValueConfirm->confirmationText  = NULL;
         // the second page is dedicated to the extended tag/value pairs
         secondPageContent->type            = TAG_VALUE_CONFIRM;
         tagValueConfirm                    = &secondPageContent->content.tagValueConfirm;
@@ -1982,6 +2014,15 @@ static void prepareAddressConfirmationPages(const char                       *ad
         tagValueConfirm->detailsButtonIcon = NULL;
         tagValueConfirm->tuneId            = TUNE_TAP_CASUAL;
         memcpy(&tagValueConfirm->tagValueList, tagValueList, sizeof(nbgl_contentTagValueList_t));
+        tagValueConfirm->tagValueList.nbPairs
+            = tagValueList->nbPairs - (addressConfirmationContext.nbPairs - 1);
+        tagValueConfirm->tagValueList.pairs
+            = &tagValueList->pairs[addressConfirmationContext.nbPairs - 1];
+    }
+    else {
+        // otherwise no tap to continue but a confirmation button
+        tagValueConfirm->confirmationText  = "Confirm";
+        tagValueConfirm->confirmationToken = CONFIRM_TOKEN;
     }
 }
 
@@ -2709,7 +2750,7 @@ uint8_t nbgl_useCaseGetNbTagValuesInPage(uint8_t                           nbPai
                                          bool                             *requireSpecificDisplay)
 {
     return getNbTagValuesInPage(
-        nbPairs, tagValueList, startIndex, false, false, requireSpecificDisplay);
+        nbPairs, tagValueList, startIndex, false, false, false, requireSpecificDisplay);
 }
 
 /**
@@ -2732,7 +2773,7 @@ uint8_t nbgl_useCaseGetNbTagValuesInPageExt(uint8_t                           nb
                                             bool *requireSpecificDisplay)
 {
     return getNbTagValuesInPage(
-        nbPairs, tagValueList, startIndex, isSkippable, false, requireSpecificDisplay);
+        nbPairs, tagValueList, startIndex, isSkippable, false, false, requireSpecificDisplay);
 }
 
 /**
@@ -4071,7 +4112,6 @@ void nbgl_useCaseAddressReview(const char                       *address,
     bundleNavContext.review.operationType = TYPE_OPERATION;
 
     genericContext.genericContents.contentsList = localContentsList;
-    genericContext.genericContents.nbContents   = (additionalTagValueList == NULL) ? 2 : 3;
     memset(localContentsList, 0, 3 * sizeof(nbgl_content_t));
 
     // First a centered info
@@ -4085,6 +4125,8 @@ void nbgl_useCaseAddressReview(const char                       *address,
         address, additionalTagValueList, &localContentsList[1], &localContentsList[2]);
 
     // fill navigation structure, common to all pages
+    genericContext.genericContents.nbContents
+        = (localContentsList[2].type == TAG_VALUE_CONFIRM) ? 3 : 2;
     uint8_t nbPages = getNbPagesForGenericContents(&genericContext.genericContents, 0, false);
 
     prepareNavInfo(true, nbPages, "Cancel");

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -36,7 +36,8 @@
     (pagesData[pageIdx / PAGES_PER_UINT8] = pageData \
                                             << ((pageIdx % PAGES_PER_UINT8) * PAGE_DATA_BITS))
 
-#define MAX_PAGE_NB 256
+#define MAX_PAGE_NB       256
+#define MAX_MODAL_PAGE_NB 32
 
 /* Alias to clarify usage of genericContext hasStartingContent and hasFinishingContent feature */
 #define STARTING_CONTENT  localContentsList[0]
@@ -79,6 +80,7 @@ enum {
     NEXT_TOKEN,
     QUIT_TOKEN,
     NAV_TOKEN,
+    MODAL_NAV_TOKEN,
     SKIP_TOKEN,
     CONTINUE_TOKEN,
     ADDRESS_QRCODE_BUTTON_TOKEN,
@@ -111,6 +113,7 @@ typedef enum {
 typedef struct DetailsContext_s {
     uint8_t     nbPages;
     uint8_t     currentPage;
+    uint8_t     currentPairIdx;
     bool        wrapping;
     const char *tag;
     const char *value;
@@ -183,7 +186,8 @@ typedef struct {
                   currentCallback;  // to be used to retrieve the pairs with value alias
     nbgl_layout_t modalLayout;
     nbgl_layout_t backgroundLayout;
-    const nbgl_contentInfoList_t *currentInfos;
+    const nbgl_contentInfoList_t     *currentInfos;
+    const nbgl_contentTagValueList_t *currentTagValues;
 } GenericContext_t;
 
 typedef struct {
@@ -269,6 +273,7 @@ static GenericContext_t genericContext;
 static nbgl_content_t
     localContentsList[3];  // 3 needed for nbgl_useCaseReview (starting page / tags / final page)
 static uint8_t genericContextPagesInfo[MAX_PAGE_NB / PAGES_PER_UINT8];
+static uint8_t modalContextPagesInfo[MAX_MODAL_PAGE_NB / PAGES_PER_UINT8];
 
 // contexts for bundle navigation
 static nbgl_BundleNavContext_t bundleNavContext;
@@ -333,12 +338,14 @@ static char reducedAddress[QRCODE_REDUCED_ADDR_LEN];
  **********************/
 static void displayReviewPage(uint8_t page, bool forceFullRefresh);
 static void displayDetailsPage(uint8_t page, bool forceFullRefresh);
+static void displayTagValueListModalPage(uint8_t pageIdx, bool forceFullRefresh);
 static void displayFullValuePage(const char                   *backText,
                                  const char                   *aliasText,
                                  const nbgl_contentValueExt_t *extension);
 static void displayInfosListModal(const char                   *modalTitle,
                                   const nbgl_contentInfoList_t *infos,
                                   bool                          fromReview);
+static void displayTagValueListModal(const nbgl_contentTagValueList_t *tagValues);
 static void displaySettingsPage(uint8_t page, bool forceFullRefresh);
 static void displayGenericContextPage(uint8_t pageIdx, bool forceFullRefresh);
 static void pageCallback(int token, uint8_t index);
@@ -417,6 +424,27 @@ static void genericContextGetPageInfo(uint8_t pageIdx, uint8_t *nbElements, bool
     }
     if (flag != NULL) {
         *flag = GET_PAGE_FLAG(pageData);
+    }
+}
+
+// Helper to set modalContext page info
+static void modalContextSetPageInfo(uint8_t pageIdx, uint8_t nbElements)
+{
+    uint8_t pageData = SET_PAGE_NB_ELEMENTS(nbElements);
+
+    modalContextPagesInfo[pageIdx / PAGES_PER_UINT8]
+        &= ~(0x0F << ((pageIdx % PAGES_PER_UINT8) * PAGE_DATA_BITS));
+    modalContextPagesInfo[pageIdx / PAGES_PER_UINT8]
+        |= pageData << ((pageIdx % PAGES_PER_UINT8) * PAGE_DATA_BITS);
+}
+
+// Helper to get modalContext page info
+static void modalContextGetPageInfo(uint8_t pageIdx, uint8_t *nbElements)
+{
+    uint8_t pageData = modalContextPagesInfo[pageIdx / PAGES_PER_UINT8]
+                       >> ((pageIdx % PAGES_PER_UINT8) * PAGE_DATA_BITS);
+    if (nbElements != NULL) {
+        *nbElements = GET_PAGE_NB_ELEMENTS(pageData);
     }
 }
 
@@ -575,6 +603,16 @@ static void pageModalCallback(int token, uint8_t index)
         }
         else {
             displayDetailsPage(index, false);
+        }
+    }
+    if (token == MODAL_NAV_TOKEN) {
+        if (index == EXIT_PAGE) {
+            // redraw the background layer
+            nbgl_screenRedraw();
+            nbgl_refresh();
+        }
+        else {
+            displayTagValueListModalPage(index, false);
         }
     }
     else if (token == QUIT_TOKEN) {
@@ -1070,28 +1108,36 @@ static bool genericContextPreparePageContent(const nbgl_content_t *p_content,
 
             break;
         }
-        case TAG_VALUE_CONFIRM:
+        case TAG_VALUE_CONFIRM: {
+            nbgl_contentTagValueList_t *p_tagValueList;
             // only display a TAG_VALUE_CONFIRM if we are at the last page
             if ((nextElementIdx + nbElementsInPage)
                 == p_content->content.tagValueConfirm.tagValueList.nbPairs) {
                 memcpy(&pageContent->tagValueConfirm,
                        &p_content->content.tagValueConfirm,
                        sizeof(pageContent->tagValueConfirm));
-                nbgl_contentTagValueList_t *p_tagValueList
-                    = &pageContent->tagValueConfirm.tagValueList;
-                p_tagValueList->nbPairs = nbElementsInPage;
-                p_tagValueList->pairs
-                    = PIC(&p_content->content.tagValueConfirm.tagValueList.pairs[nextElementIdx]);
+                p_tagValueList = &pageContent->tagValueConfirm.tagValueList;
             }
             else {
                 // else display it as a TAG_VALUE_LIST
-                pageContent->type                          = TAG_VALUE_LIST;
-                nbgl_contentTagValueList_t *p_tagValueList = &pageContent->tagValueList;
-                p_tagValueList->nbPairs                    = nbElementsInPage;
-                p_tagValueList->pairs
-                    = PIC(&p_content->content.tagValueConfirm.tagValueList.pairs[nextElementIdx]);
+                pageContent->type = TAG_VALUE_LIST;
+                p_tagValueList    = &pageContent->tagValueList;
             }
+            p_tagValueList->nbPairs = nbElementsInPage;
+            p_tagValueList->pairs
+                = PIC(&p_content->content.tagValueConfirm.tagValueList.pairs[nextElementIdx]);
+            // parse pairs to check if any contains an alias for value
+            for (uint8_t i = 0; i < nbElementsInPage; i++) {
+                if (p_tagValueList->pairs[i].aliasValue) {
+                    p_tagValueList->token = VALUE_ALIAS_TOKEN;
+                    break;
+                }
+            }
+            // memorize pairs (or callback) for usage when alias is used
+            genericContext.currentPairs    = p_tagValueList->pairs;
+            genericContext.currentCallback = p_tagValueList->callback;
             break;
+        }
         case SWITCHES_LIST:
             pageContent->switchesList.nbSwitches = nbElementsInPage;
             pageContent->switchesList.switches
@@ -1330,6 +1376,10 @@ static void displayFullValuePage(const char                   *backText,
         genericContext.currentInfos = extension->infolist;
         displayInfosListModal(modalTitle, extension->infolist, true);
     }
+    else if (extension->aliasType == TAG_VALUE_LIST_ALIAS) {
+        genericContext.currentTagValues = extension->tagValuelist;
+        displayTagValueListModal(extension->tagValuelist);
+    }
     else {
         nbgl_layoutDescription_t layoutDescription = {.modal            = true,
                                                       .withLeftBorder   = true,
@@ -1411,6 +1461,60 @@ static void displayInfosListModal(const char                   *modalTitle,
     modalPageContext = nbgl_pageDrawGenericContentExt(&pageModalCallback, &info, &content, true);
 
     nbgl_refreshSpecial(FULL_COLOR_CLEAN_REFRESH);
+}
+
+// function used to display the modal containing alias tag-value pairs
+static void displayTagValueListModalPage(uint8_t pageIdx, bool forceFullRefresh)
+{
+    nbgl_pageNavigationInfo_t info    = {.activePage                = pageIdx,
+                                         .nbPages                   = detailsContext.nbPages,
+                                         .navType                   = NAV_WITH_BUTTONS,
+                                         .quitToken                 = QUIT_TOKEN,
+                                         .navWithButtons.navToken   = MODAL_NAV_TOKEN,
+                                         .navWithButtons.quitButton = true,
+                                         .navWithButtons.backButton = true,
+                                         .navWithButtons.quitText   = NULL,
+                                         .progressIndicator         = false,
+                                         .tuneId                    = TUNE_TAP_CASUAL};
+    nbgl_pageContent_t        content = {.type                           = TAG_VALUE_LIST,
+                                         .topRightIcon                   = NULL,
+                                         .tagValueList.smallCaseForValue = true,
+                                         .tagValueList.wrapping          = detailsContext.wrapping};
+    uint8_t                   nbElementsInPage;
+
+    // if first page or forward
+    if (detailsContext.currentPage <= pageIdx) {
+        modalContextGetPageInfo(pageIdx, &nbElementsInPage);
+    }
+    else {
+        // backward direction
+        modalContextGetPageInfo(pageIdx + 1, &nbElementsInPage);
+        detailsContext.currentPairIdx -= nbElementsInPage;
+        modalContextGetPageInfo(pageIdx, &nbElementsInPage);
+        detailsContext.currentPairIdx -= nbElementsInPage;
+    }
+    detailsContext.currentPage = pageIdx;
+
+    content.tagValueList.pairs
+        = &genericContext.currentTagValues->pairs[detailsContext.currentPairIdx];
+    content.tagValueList.nbPairs = nbElementsInPage;
+    detailsContext.currentPairIdx += nbElementsInPage;
+    if (info.nbPages == 1) {
+        // if only one page, no navigation bar, and use a footer instead
+        info.navWithButtons.quitText = "Close";
+    }
+
+    if (modalPageContext != NULL) {
+        nbgl_pageRelease(modalPageContext);
+    }
+    modalPageContext = nbgl_pageDrawGenericContentExt(&pageModalCallback, &info, &content, true);
+
+    if (forceFullRefresh) {
+        nbgl_refreshSpecial(FULL_COLOR_CLEAN_REFRESH);
+    }
+    else {
+        nbgl_refreshSpecial(FULL_COLOR_PARTIAL_REFRESH);
+    }
 }
 
 #ifdef NBGL_QRCODE
@@ -1856,6 +1960,58 @@ static uint8_t getNbTagValuesInPage(uint8_t                           nbPairs,
         if (currentHeight > maxUsableHeight) {
             nbPairsInPage--;
         }
+    }
+    return nbPairsInPage;
+}
+
+/**
+ * @brief computes the number of tag/values pairs displayable in a details page, with the given list
+ * of tag/value pairs
+ *
+ * @param nbPairs number of tag/value pairs to use in \b tagValueList
+ * @param tagValueList list of tag/value pairs
+ * @param startIndex first index to consider in \b tagValueList
+ * @return the number of tag/value pairs fitting in a page
+ */
+static uint8_t getNbTagValuesInDetailsPage(uint8_t                           nbPairs,
+                                           const nbgl_contentTagValueList_t *tagValueList,
+                                           uint8_t                           startIndex)
+{
+    uint8_t  nbPairsInPage   = 0;
+    uint16_t currentHeight   = PRE_TAG_VALUE_MARGIN;  // upper margin
+    uint16_t maxUsableHeight = TAG_VALUE_AREA_HEIGHT;
+
+    while (nbPairsInPage < nbPairs) {
+        const nbgl_layoutTagValue_t *pair;
+
+        // margin between pairs
+        // 12 or 24 px between each tag/value pair
+        if (nbPairsInPage > 0) {
+            currentHeight += INTER_TAG_VALUE_MARGIN;
+        }
+        // fetch tag/value pair strings.
+        if (tagValueList->pairs != NULL) {
+            pair = PIC(&tagValueList->pairs[startIndex + nbPairsInPage]);
+        }
+        else {
+            pair = PIC(tagValueList->callback(startIndex + nbPairsInPage));
+        }
+
+        // tag height
+        currentHeight += nbgl_getTextHeightInWidth(
+            SMALL_REGULAR_FONT, pair->item, AVAILABLE_WIDTH, tagValueList->wrapping);
+        // space between tag and value
+        currentHeight += 4;
+
+        // value height
+        currentHeight += nbgl_getTextHeightInWidth(
+            SMALL_REGULAR_FONT, pair->value, AVAILABLE_WIDTH, tagValueList->wrapping);
+
+        // we have reached the maximum height, it means than there are to many pairs
+        if (currentHeight >= maxUsableHeight) {
+            break;
+        }
+        nbPairsInPage++;
     }
     return nbPairsInPage;
 }
@@ -2726,6 +2882,29 @@ static void displayDetails(const char *tag, const char *value, bool wrapping)
     }
 
     displayDetailsPage(0, true);
+}
+
+// function used to display the modal containing alias tag-value pairs
+static void displayTagValueListModal(const nbgl_contentTagValueList_t *tagValues)
+{
+    uint8_t nbElements = 0;
+    uint8_t nbElementsInPage;
+    uint8_t elemIdx = 0;
+
+    // initialize context
+    memset(&detailsContext, 0, sizeof(detailsContext));
+    nbElements = tagValues->nbPairs;
+
+    while (nbElements > 0) {
+        nbElementsInPage = getNbTagValuesInDetailsPage(nbElements, tagValues, elemIdx);
+
+        elemIdx += nbElementsInPage;
+        modalContextSetPageInfo(detailsContext.nbPages, nbElementsInPage);
+        nbElements -= nbElementsInPage;
+        detailsContext.nbPages++;
+    }
+
+    displayTagValueListModalPage(0, true);
 }
 
 /**********************

--- a/tests/screenshots/flows/wallet/app-sdk/flow_address_verif.json
+++ b/tests/screenshots/flows/wallet/app-sdk/flow_address_verif.json
@@ -117,6 +117,71 @@
     {
       "name": "long_address-03",
       "targets": [
+        {
+          "app_event": "ETH_VERIFY_MULTISIG",
+          "page": "multi-sig-01",
+          "comment": "verify mutli-sig"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-01",
+      "targets": [
+        {
+          "object": "RIGHT_BUTTON",
+          "page": "multi-sig-02"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-02",
+      "targets": [
+        {
+          "object": "EXTRA_BUTTON",
+          "page": "multi-sig-qr_code",
+          "comment": "view QR"
+        },
+        {
+          "object": "RIGHT_BUTTON",
+          "page": "multi-sig-03"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-03",
+      "targets": [
+        {
+          "object": "VALUE_BUTTON_2",
+          "page": "multi-sig-signers-01",
+          "comment": "view signers details (alias)"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-qr_code",
+      "targets": [
+        {
+          "object": "BOTTOM_BUTTON",
+          "page": "multi-sig-02"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-signers-01",
+      "targets": [
+        {
+          "object": "RIGHT_BUTTON",
+          "page": "multi-sig-signers-02"
+        }
+      ]
+    },
+    {
+      "name": "multi-sig-signers-02",
+      "targets": [
+        {
+          "object": "BOTTOM_BUTTON",
+          "page": "multi-sig-03"
+        }
       ]
     }
   ]

--- a/tests/screenshots/src/apps/app_ethereum_verify_addr.c
+++ b/tests/screenshots/src/apps/app_ethereum_verify_addr.c
@@ -24,6 +24,33 @@
  *  STATIC VARIABLES
  **********************/
 
+static nbgl_contentTagValue_t tagValuePairs[] = {
+    {.item = "Signer 1", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 2", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 3", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 4", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 5", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 6", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 7", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+    {.item = "Signer 8", .value = "0x20bfb083C5AdaCc91C46Ac4D37905D0447968166"},
+};
+
+static nbgl_contentTagValueList_t tagValueList
+    = {.nbPairs = 8, .wrapping = false, .pairs = (nbgl_contentTagValue_t *) tagValuePairs};
+
+static nbgl_contentValueExt_t extension
+    = {.tagValuelist = &tagValueList, .aliasType = TAG_VALUE_LIST_ALIAS, .title = ""};
+
+static nbgl_contentTagValue_t pairs[] = {
+    {.item = "Your role", .value = "Signer"},
+    {.item = "Threshold", .value = "3 out of 8", .extension = &extension, .aliasValue = 1},
+};
+
+static nbgl_contentTagValueList_t pairList = {.nbMaxLinesForValue = 0,
+                                              .nbPairs            = 2,
+                                              .wrapping           = true,
+                                              .pairs = (nbgl_contentTagValue_t *) pairs};
+
 /**********************
  *      VARIABLES
  **********************/
@@ -55,6 +82,20 @@ void app_ethereumVerifyAddress(void)
                               NULL,
                               &ETH_MAIN_ICON,
                               "Verify Ethereum\naddress",
+                              NULL,
+                              displayAddressCallback);
+}
+
+/**
+ * @brief Ethereum application verify address page
+ *
+ */
+void app_ethereumVerifyMultiSig(void)
+{
+    nbgl_useCaseAddressReview("0xe87eD43dE2bf1D340e426920F103A10fD5fb8e47",
+                              &pairList,
+                              &ETH_MAIN_ICON,
+                              "Verify Safe address",
                               NULL,
                               displayAddressCallback);
 }

--- a/tests/screenshots/src/apps/apps_api.h
+++ b/tests/screenshots/src/apps/apps_api.h
@@ -66,6 +66,7 @@ void app_ethereumReviewBlindSigningTransaction(void);
 void app_ethereumReviewENSTransaction(void);
 void app_ethereumReviewDappTransaction(void);
 void app_ethereumVerifyAddress(void);
+void app_ethereumVerifyMultiSig(void);
 void app_ethereumSecurityKeyLogin(void);
 void app_fullEthereumShareAddress(void);
 void app_fullAlgorand(void);

--- a/tests/screenshots/src/main/json_scenario.c
+++ b/tests/screenshots/src/main/json_scenario.c
@@ -42,6 +42,7 @@ Event_t appEvents[] = {
     {"ETH_DAPP",            ETH_DAPP           },
     {"ETH_SIGN",            ETH_SIGN           },
     {"ETH_VERIFY_ADDR",     ETH_VERIFY_ADDR    },
+    {"ETH_VERIFY_MULTISIG", ETH_VERIFY_MULTISIG},
     {"RECOV_OPEN",          RECOV_OPEN         },
     {"DOGE_SIGN",           DOGE_SIGN          }
 };
@@ -603,6 +604,9 @@ static int scenario_get_action(void)
                 break;
             case ETH_VERIFY_ADDR:
                 app_ethereumVerifyAddress();
+                break;
+            case ETH_VERIFY_MULTISIG:
+                app_ethereumVerifyMultiSig();
                 break;
             case RECOV_OPEN:
                 app_fullRecoveryCheck();

--- a/tests/screenshots/src/main/json_scenario.h
+++ b/tests/screenshots/src/main/json_scenario.h
@@ -63,6 +63,7 @@ enum {
     ETH_ENS,
     ETH_DAPP,
     ETH_VERIFY_ADDR,
+    ETH_VERIFY_MULTISIG,
     RECOV_OPEN,
     DOGE_SIGN,
 };


### PR DESCRIPTION
## Description

For multi-sig feature, we need to display a list of signers when pressing the alias (>) of a specific pair.
This PR also adds an improvement, to gather tag/value pairs with the address in "address review" if it fits in a signe page.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

