### PR TITLE
Call NFC reader functions directly from os_io_rx_evt()

### DIFF
--- a/io/include/os_io.h
+++ b/io/include/os_io.h
@@ -19,6 +19,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 #include "os_math.h"
 #include "decorators.h"
 #ifdef HAVE_IO_U2F
@@ -163,3 +164,8 @@ SYSCALL int os_io_seph_se_rx_event(unsigned char *buffer PLENGTH(length),
                                    unsigned int          flags);
 
 unsigned int os_io_handle_ux_event_reject_apdu(void);
+
+#ifdef HAVE_NFC_READER
+void os_io_nfc_reader_rx(uint8_t *in_buffer, size_t in_buffer_len);
+void os_io_nfc_evt(uint8_t *buffer_in, size_t buffer_in_length);
+#endif  // HAVE_NFC_READER

--- a/io/src/os_io.c
+++ b/io/src/os_io.c
@@ -297,22 +297,22 @@ int os_io_rx_evt(unsigned char *buffer,
         case SEPROXYHAL_TAG_NFC_APDU_EVENT:
             status
                 = NFC_LEDGER_rx_seph_apdu_evt(G_io_seph_buffer, length, buffer, buffer_max_length);
-#if defined(HAVE_NFC_READER) && !defined(HAVE_BOLOS)
-            io_nfc_process_events();
-#endif  // HAVE_NFC_READER && !HAVE_BOLOS
+
+#ifdef HAVE_NFC_READER
+            if (status > 0 && status < buffer_max_length
+                && buffer[0] == OS_IO_PACKET_TYPE_NFC_APDU_RSP) {
+                os_io_nfc_reader_rx(&buffer[1], status - 1);
+            }
+#endif  // HAVE_NFC_READER
             break;
 
-#if defined(HAVE_NFC_READER) && !defined(HAVE_BOLOS)
+#ifdef HAVE_NFC_READER
         case SEPROXYHAL_TAG_NFC_EVENT:
-            io_nfc_event();
-            io_nfc_process_events();
-            break;
-
         case SEPROXYHAL_TAG_TICKER_EVENT:
-            io_nfc_ticker();
-            io_nfc_process_events();
+            os_io_nfc_evt(&G_io_seph_buffer[1], status - 1);
+            memmove(buffer, G_io_seph_buffer, length);
             break;
-#endif  // HAVE_NFC_READER && !HAVE_BOLOS
+#endif  // HAVE_NFC_READER
 #endif  // HAVE_NFC
 
         case SEPROXYHAL_TAG_CAPDU_EVENT:

--- a/io_legacy/include/os_io_legacy.h
+++ b/io_legacy/include/os_io_legacy.h
@@ -102,10 +102,6 @@ int io_legacy_apdu_rx(uint8_t handle_ux_events);
 int io_legacy_apdu_tx(const unsigned char *buffer, unsigned short length);
 
 #ifdef HAVE_NFC_READER
-void io_nfc_event(void);
-void io_nfc_ticker(void);
-void io_nfc_process_events(void);
-
 bool io_nfc_reader_send(const uint8_t      *cmd_data,
                         size_t              cmd_len,
                         nfc_resp_callback_t callback,
@@ -114,5 +110,4 @@ bool io_nfc_reader_send(const uint8_t      *cmd_data,
 /* Return false if nfc reader can not be started in current conditions */
 bool io_nfc_reader_start(nfc_evt_callback_t callback);
 void io_nfc_reader_stop(void);
-bool io_nfc_is_reader(void);
 #endif  // HAVE_NFC_READER

--- a/lib_standard_app/io.c
+++ b/lib_standard_app/io.c
@@ -77,18 +77,7 @@ WEAK unsigned char io_event(unsigned char channel)
         case SEPROXYHAL_TAG_TICKER_EVENT:
             app_ticker_event_callback();
             UX_TICKER_EVENT(G_io_seproxyhal_spi_buffer, {});
-#ifdef HAVE_NFC_READER
-            io_nfc_ticker();
-            io_nfc_process_events();
-#endif  // HAVE_NFC_READER
             break;
-#ifdef HAVE_NFC_READER
-        case SEPROXYHAL_TAG_NFC_EVENT:
-            io_nfc_event();
-            io_nfc_process_events();
-            break;
-#endif  // HAVE_NFC_READER
-
         default:
             UX_DEFAULT_EVENT();
             break;


### PR DESCRIPTION
This makes sure no NFC event is lost in special edge-cases

## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [ * ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
