### PR TITLE
Fix ble pairing

### DIFF
--- a/lib_blewbxx/src/ble_ledger.c
+++ b/lib_blewbxx/src/ble_ledger.c
@@ -1039,8 +1039,8 @@ void BLE_LEDGER_stop(void)
 
 void BLE_LEDGER_reset_pairings(void)
 {
-    ble_ledger_data.clear_pairing = 1;
     if (ble_ledger_data.state == BLE_STATE_RUNNING) {
+        ble_ledger_data.clear_pairing = 1;
         BLE_LEDGER_stop();
         BLE_LEDGER_start();
     }

--- a/lib_blewbxx/src/ble_ledger.c
+++ b/lib_blewbxx/src/ble_ledger.c
@@ -309,6 +309,7 @@ static void start_mngr(uint8_t *hci_buffer, uint16_t length)
         case BLE_INIT_STEP_END:
             LOG_IO("INIT END\n");
             ble_ledger_data.state = BLE_STATE_RUNNING;
+            ble_ledger_data.clear_pairing = 0;
             break;
 
         default:


### PR DESCRIPTION
## Description
This PR prevents the BLE pairing to be reset at the end of the onboarding or at the end of the update if the device is not onboarded.


## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
