### PR TITLE
Several fixes for recent SDK changes

### DIFF
--- a/io_legacy/include/os_io_legacy.h
+++ b/io_legacy/include/os_io_legacy.h
@@ -81,9 +81,7 @@ void io_seproxyhal_request_mcu_status(void);
 void io_seproxyhal_display_default(const bagl_element_t *element);
 #endif  // HAVE_BAGL
 
-#ifdef HAVE_PIEZO_SOUND
 void io_seproxyhal_play_tune(tune_index_e tune_index);
-#endif  // HAVE_PIEZO_SOUND
 
 unsigned int io_seph_is_status_sent(void);
 

--- a/lib_nfc/src/nfc_ledger.c
+++ b/lib_nfc/src/nfc_ledger.c
@@ -205,13 +205,12 @@ uint32_t NFC_LEDGER_send(const uint8_t *packet, uint16_t packet_length, uint32_t
         }
 
         while (nfc_ledger_data.protocol_data.tx_apdu_buffer) {
-            ledger_protocol_result_t result
-                = LEDGER_PROTOCOL_tx(&nfc_ledger_data.protocol_data,
-                                     NULL,
-                                     0,
-                                     nfc_ledger_protocol_chunk_buffer,
-                                     sizeof(nfc_ledger_protocol_chunk_buffer),
-                                     sizeof(nfc_ledger_protocol_chunk_buffer));
+            result = LEDGER_PROTOCOL_tx(&nfc_ledger_data.protocol_data,
+                                        NULL,
+                                        0,
+                                        nfc_ledger_protocol_chunk_buffer,
+                                        sizeof(nfc_ledger_protocol_chunk_buffer),
+                                        sizeof(nfc_ledger_protocol_chunk_buffer));
             if (result != LP_SUCCESS) {
                 status = 1;
                 goto error;

--- a/lib_stusb/src/usbd_ledger_hid_u2f.c
+++ b/lib_stusb/src/usbd_ledger_hid_u2f.c
@@ -414,6 +414,9 @@ USBD_StatusTypeDef USBD_LEDGER_HID_U2F_send_message(USBD_HandleTypeDef *pdev,
     uint8_t  cmd       = 0;
     const uint8_t *tx_buffer = message;
     uint16_t tx_length = message_length;
+#ifndef HAVE_BOLOS
+    const uint8_t status[2] = {0x69, 0x85};
+#endif // !HAVE_BOLOS
 
     switch (packet_type) {
         case OS_IO_PACKET_TYPE_USB_U2F_HID_APDU:
@@ -421,7 +424,6 @@ USBD_StatusTypeDef USBD_LEDGER_HID_U2F_send_message(USBD_HandleTypeDef *pdev,
 // Cannot enable user presence handling in the OS, see OS issues/555 for more information
 #ifndef HAVE_BOLOS
             if ((message_length == 2) && (message[0] == 0xFF) && (message[1] == 0xFF)) {
-                const uint8_t status[2] = {0x69, 0x85};
                 tx_buffer = status;
                 handle->user_presence = LEDGER_HID_U2F_USER_PRESENCE_ASKING;
             }


### PR DESCRIPTION
## Description
- [x] a couple of  Clang static analyzer fixes
- [x]  more serious issus when `const uint8_t status[2] = {0x69, 0x85}` was not taken into account when located under the if condition. See the assembly comparison screenshot  - on the left before the fix and on the right after the fix We clearly see the 0x6985 assignment).  This impacts SK and its tests.

<img width="1819" height="761" alt="Screenshot from 2025-08-01 10-15-58" src="https://github.com/user-attachments/assets/d00ab11c-bd08-43cf-a3df-f05d0a31472b" />


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
