### PR TITLE
Use `const` pointers for `ux_process_{finger,button}_event`

### DIFF
--- a/lib_ux_nbgl/ux.c
+++ b/lib_ux_nbgl/ux.c
@@ -62,7 +62,7 @@ static nbgl_touchStatePosition_t pos;
  *
  * @param seph_packet received SEPH packet
  */
-void ux_process_finger_event(uint8_t seph_packet[])
+void ux_process_finger_event(const uint8_t seph_packet[])
 {
     bool displayEnabled = ux_forward_event(true);
     // enable/disable drawing according to UX decision
@@ -88,7 +88,7 @@ void ux_process_finger_event(uint8_t seph_packet[])
  *
  * @param seph_packet received SEPH packet
  */
-void ux_process_button_event(uint8_t seph_packet[])
+void ux_process_button_event(const uint8_t seph_packet[])
 {
     bool displayEnabled = ux_forward_event(true);
     // enable/disable drawing according to UX decision

--- a/lib_ux_nbgl/ux_nbgl.h
+++ b/lib_ux_nbgl/ux_nbgl.h
@@ -50,8 +50,8 @@ struct ux_state_s {
 extern ux_state_t        G_ux;
 extern bolos_ux_params_t G_ux_params;
 
-extern void ux_process_finger_event(uint8_t seph_packet[]);
-extern void ux_process_button_event(uint8_t seph_packet[]);
+extern void ux_process_finger_event(const uint8_t seph_packet[]);
+extern void ux_process_button_event(const uint8_t seph_packet[]);
 extern void ux_process_ticker_event(void);
 extern void ux_process_default_event(void);
 


### PR DESCRIPTION
## Description

The pointer arguments can be `const`, which would make the types better when calling these functions from the Rust SDK.

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
