### PR TITLE
Fix memory buffer access

### DIFF
--- a/io_legacy/src/os_io_legacy.c
+++ b/io_legacy/src/os_io_legacy.c
@@ -23,6 +23,7 @@
 #include "os_apdu.h"
 #include "os_io_default_apdu.h"
 #include "os_io_legacy.h"
+#include "os.h"
 
 #ifdef HAVE_IO_USB
 #include "usbd_ledger.h"

--- a/lib_nbgl/src/nbgl_layout_keypad.c
+++ b/lib_nbgl/src/nbgl_layout_keypad.c
@@ -21,6 +21,7 @@
 #include "glyphs.h"
 #include "os_pic.h"
 #include "os_helpers.h"
+#include "os.h"
 
 /*********************
  *      DEFINES

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -918,7 +918,9 @@ static void extensionNavigate(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
 // function used to display the extension pages
 static void displayExtensionStep(nbgl_stepPosition_t pos)
 {
-    nbgl_layoutCenteredInfo_t info = {0};
+    nbgl_layoutCenteredInfo_t info    = {0};
+    char                     *text    = NULL;
+    char                     *subText = NULL;
 
     if (context.review.extensionStepCtx != NULL) {
         nbgl_stepRelease(context.review.extensionStepCtx);
@@ -941,15 +943,12 @@ static void displayExtensionStep(nbgl_stepPosition_t pos)
                                                                 true);
         }
         else if (context.review.extension->aliasType == INFO_LIST_ALIAS) {
+            text = PIC(
+                context.review.extension->infolist->infoTypes[context.review.currentExtensionPage]);
+            subText                         = PIC(context.review.extension->infolist
+                              ->infoContents[context.review.currentExtensionPage]);
             context.review.extensionStepCtx = nbgl_stepDrawText(
-                pos,
-                extensionNavigate,
-                NULL,
-                context.review.extension->infolist->infoTypes[context.review.currentExtensionPage],
-                context.review.extension->infolist
-                    ->infoContents[context.review.currentExtensionPage],
-                BOLD_TEXT1_INFO,
-                true);
+                pos, extensionNavigate, NULL, text, subText, BOLD_TEXT1_INFO, true);
         }
     }
     else if (context.review.currentExtensionPage == (context.review.nbExtensionPages - 1)) {

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -918,9 +918,11 @@ static void extensionNavigate(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
 // function used to display the extension pages
 static void displayExtensionStep(nbgl_stepPosition_t pos)
 {
-    nbgl_layoutCenteredInfo_t info    = {0};
-    char                     *text    = NULL;
-    char                     *subText = NULL;
+    nbgl_layoutCenteredInfo_t         info         = {0};
+    const nbgl_contentTagValueList_t *tagValueList = NULL;
+    const nbgl_contentInfoList_t     *infoList     = NULL;
+    const char                       *text         = NULL;
+    const char                       *subText      = NULL;
 
     if (context.review.extensionStepCtx != NULL) {
         nbgl_stepRelease(context.review.extensionStepCtx);
@@ -933,30 +935,25 @@ static void displayExtensionStep(nbgl_stepPosition_t pos)
             pos |= NEITHER_FIRST_NOR_LAST_STEP;
         }
 
-        if (context.review.extension->aliasType == ENS_ALIAS) {
-            context.review.extensionStepCtx = nbgl_stepDrawText(pos,
-                                                                extensionNavigate,
-                                                                NULL,
-                                                                context.review.extension->title,
-                                                                context.review.extension->fullValue,
-                                                                BOLD_TEXT1_INFO,
-                                                                true);
+        switch (context.review.extension->aliasType) {
+            case ENS_ALIAS:
+                text    = context.review.extension->title;
+                subText = context.review.extension->fullValue;
+                break;
+            case INFO_LIST_ALIAS:
+                infoList = context.review.extension->infolist;
+                text     = PIC(infoList->infoTypes[context.review.currentExtensionPage]);
+                subText  = PIC(infoList->infoContents[context.review.currentExtensionPage]);
+                break;
+            case TAG_VALUE_LIST_ALIAS:
+                tagValueList = context.review.extension->tagValuelist;
+                text         = PIC(tagValueList->pairs[context.review.currentExtensionPage].item);
+                subText      = PIC(tagValueList->pairs[context.review.currentExtensionPage].value);
+                break;
+            default:
+                break;
         }
-        else if (context.review.extension->aliasType == INFO_LIST_ALIAS) {
-            text = PIC(
-                context.review.extension->infolist->infoTypes[context.review.currentExtensionPage]);
-            subText                         = PIC(context.review.extension->infolist
-                              ->infoContents[context.review.currentExtensionPage]);
-            context.review.extensionStepCtx = nbgl_stepDrawText(
-                pos, extensionNavigate, NULL, text, subText, BOLD_TEXT1_INFO, true);
-        }
-        else if (context.review.extension->aliasType == TAG_VALUE_LIST_ALIAS) {
-            text = PIC(
-                context.review.extension->tagValuelist->pairs[context.review.currentExtensionPage]
-                    .item);
-            subText = PIC(
-                context.review.extension->tagValuelist->pairs[context.review.currentExtensionPage]
-                    .value);
+        if (text != NULL) {
             context.review.extensionStepCtx = nbgl_stepDrawText(
                 pos, extensionNavigate, NULL, text, subText, BOLD_TEXT1_INFO, true);
         }
@@ -997,20 +994,21 @@ static void displayAliasFullValue(void)
     context.review.currentExtensionPage = 0;
     context.review.extensionStepCtx     = NULL;
     // create a modal flow to display this extension
-    if (context.review.extension->aliasType == ENS_ALIAS) {
-        context.review.nbExtensionPages = 2;
-    }
-    else if (context.review.extension->aliasType == INFO_LIST_ALIAS) {
-        context.review.nbExtensionPages = context.review.extension->infolist->nbInfos + 1;
-    }
-    else if (context.review.extension->aliasType == TAG_VALUE_LIST_ALIAS) {
-        context.review.nbExtensionPages = context.review.extension->tagValuelist->nbPairs + 1;
-    }
-    else {
-        LOG_WARN(USE_CASE_LOGGER,
-                 "displayAliasFullValue: unsupported alias type %d\n",
-                 context.review.extension->aliasType);
-        return;
+    switch (context.review.extension->aliasType) {
+        case ENS_ALIAS:
+            context.review.nbExtensionPages = 2;
+            break;
+        case INFO_LIST_ALIAS:
+            context.review.nbExtensionPages = context.review.extension->infolist->nbInfos + 1;
+            break;
+        case TAG_VALUE_LIST_ALIAS:
+            context.review.nbExtensionPages = context.review.extension->tagValuelist->nbPairs + 1;
+            break;
+        default:
+            LOG_WARN(USE_CASE_LOGGER,
+                     "displayAliasFullValue: unsupported alias type %d\n",
+                     context.review.extension->aliasType);
+            return;
     }
     displayExtensionStep(FORWARD_DIRECTION);
 }

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -950,6 +950,16 @@ static void displayExtensionStep(nbgl_stepPosition_t pos)
             context.review.extensionStepCtx = nbgl_stepDrawText(
                 pos, extensionNavigate, NULL, text, subText, BOLD_TEXT1_INFO, true);
         }
+        else if (context.review.extension->aliasType == TAG_VALUE_LIST_ALIAS) {
+            text = PIC(
+                context.review.extension->tagValuelist->pairs[context.review.currentExtensionPage]
+                    .item);
+            subText = PIC(
+                context.review.extension->tagValuelist->pairs[context.review.currentExtensionPage]
+                    .value);
+            context.review.extensionStepCtx = nbgl_stepDrawText(
+                pos, extensionNavigate, NULL, text, subText, BOLD_TEXT1_INFO, true);
+        }
     }
     else if (context.review.currentExtensionPage == (context.review.nbExtensionPages - 1)) {
         // draw the back page
@@ -992,6 +1002,9 @@ static void displayAliasFullValue(void)
     }
     else if (context.review.extension->aliasType == INFO_LIST_ALIAS) {
         context.review.nbExtensionPages = context.review.extension->infolist->nbInfos + 1;
+    }
+    else if (context.review.extension->aliasType == TAG_VALUE_LIST_ALIAS) {
+        context.review.nbExtensionPages = context.review.extension->tagValuelist->nbPairs + 1;
     }
     else {
         LOG_WARN(USE_CASE_LOGGER,


### PR DESCRIPTION
## Description

Fix use_case for Nano devices:
- Add a PIC macro to access strings buffer
- Add support for TAG_VALUE_LIST_ALIAS in extensions
- Cleanup code for better readility

In addition:
- Fix few scan-build errors (from app-tester checks: https://github.com/LedgerHQ/ledger-app-tester/actions/runs/16767813227)


## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Targeted branched

[x] TARGET_API_LEVEL: API_LEVEL_24
[X] TARGET_API_LEVEL: API_LEVEL_25
