### PR TITLE
Add icon constants definitions

### DIFF
--- a/lib_nbgl/include/nbgl_obj.h
+++ b/lib_nbgl/include/nbgl_obj.h
@@ -232,12 +232,14 @@ extern "C" {
 #define IMPORTANT_CIRCLE_ICON C_Important_Circle_64px
 #define LARGE_WARNING_ICON    C_Warning_64px
 #define INFO_CIRCLE_ICON      C_Info_Circle_64px
+#define LARGE_REVIEW_ICON     C_Review_64px
 #elif LARGE_ICON_SIZE == 48
 #define CHECK_CIRCLE_ICON     C_Check_Circle_48px
 #define DENIED_CIRCLE_ICON    C_Denied_Circle_48px
 #define IMPORTANT_CIRCLE_ICON C_Important_Circle_48px
 #define LARGE_WARNING_ICON    C_Warning_48px
 #define INFO_CIRCLE_ICON      C_Info_Circle_48px
+#define LARGE_REVIEW_ICON     C_Review_48px
 #else  // LARGE_ICON_SIZE
 #error Undefined LARGE_ICON_SIZE
 #endif  // LARGE_ICON_SIZE
@@ -256,6 +258,9 @@ extern "C" {
 
 // number of spinner positions
 #define NB_SPINNER_POSITIONS 4
+#else  // SCREEN_SIZE_WALLET
+#define WARNING_ICON C_icon_warning
+#define REVIEW_ICON  C_icon_certificate
 #endif  // SCREEN_SIZE_WALLET
 
 #if NB_COLOR_BITS == 1


### PR DESCRIPTION
Add defines to ease icon usage in Apps without needing `#ifdef` statements

Targeted branched
[ ] TARGET_API_LEVEL: API_LEVEL_24
[X] TARGET_API_LEVEL: API_LEVEL_25

