### PR TITLE
switch subText can be NULL

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -3083,9 +3083,9 @@ uint8_t nbgl_useCaseGetNbSwitchesInPage(uint8_t                           nbSwit
 {
     uint8_t               nbSwitchesInPage = 0;
     uint16_t              currentHeight    = 0;
-    uint16_t              previousHeight;
-    uint16_t              navHeight   = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
-    nbgl_contentSwitch_t *switchArray = (nbgl_contentSwitch_t *) PIC(switchesList->switches);
+    uint16_t              previousHeight   = 0;
+    uint16_t              navHeight        = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
+    nbgl_contentSwitch_t *switchArray      = (nbgl_contentSwitch_t *) PIC(switchesList->switches);
 
     while (nbSwitchesInPage < nbSwitches) {
         // The text string must be a 1 liner and its height is LIST_ITEM_MIN_TEXT_HEIGHT

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -3089,15 +3089,19 @@ uint8_t nbgl_useCaseGetNbSwitchesInPage(uint8_t                           nbSwit
 
     while (nbSwitchesInPage < nbSwitches) {
         // The text string must be a 1 liner and its height is LIST_ITEM_MIN_TEXT_HEIGHT
-        currentHeight
-            += LIST_ITEM_MIN_TEXT_HEIGHT + 2 * LIST_ITEM_PRE_HEADING + LIST_ITEM_HEADING_SUB_TEXT;
+        currentHeight += LIST_ITEM_MIN_TEXT_HEIGHT + LIST_ITEM_PRE_HEADING;
 
-        // sub-text height
-        currentHeight
-            += nbgl_getTextHeightInWidth(SMALL_REGULAR_FONT,
-                                         switchArray[startIndex + nbSwitchesInPage].subText,
-                                         AVAILABLE_WIDTH,
-                                         true);
+        if (switchArray[startIndex + nbSwitchesInPage].subText) {
+            currentHeight += LIST_ITEM_HEADING_SUB_TEXT;
+
+            // sub-text height
+            currentHeight
+                += nbgl_getTextHeightInWidth(SMALL_REGULAR_FONT,
+                                             switchArray[startIndex + nbSwitchesInPage].subText,
+                                             AVAILABLE_WIDTH,
+                                             true);
+            currentHeight += LIST_ITEM_PRE_HEADING;  // under the sub-text
+        }
         // if height is over the limit
         if (currentHeight >= (INFOS_AREA_HEIGHT - navHeight)) {
             break;


### PR DESCRIPTION
## Description

When computing the switch height, subText can be NULL

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

[ ] TARGET_API_LEVEL: API_LEVEL_24
[X] TARGET_API_LEVEL: API_LEVEL_25

