### PR TITLE
Fix BLE issue when device name have 20 characters (FWEO-1477)

### DIFF
--- a/lib_blewbxx/src/ble_cmd.c
+++ b/lib_blewbxx/src/ble_cmd.c
@@ -198,7 +198,7 @@ void ble_aci_gap_forge_cmd_clear_security_db(ble_cmd_data_t *cmd_data)
 void ble_aci_gap_forge_cmd_set_discoverable(ble_cmd_data_t                  *cmd_data,
                                             ble_cmd_set_discoverable_data_t *data)
 {
-    if ((!cmd_data) || (!data) || (data->local_name_length > BLE_GAP_MAX_LOCAL_NAME_LENGTH)) {
+  if ((!cmd_data) || (!data) || (data->local_name_length > (BLE_GAP_MAX_LOCAL_NAME_LENGTH+1))) {
         return;
     }
 
@@ -217,9 +217,9 @@ void ble_aci_gap_forge_cmd_set_discoverable(ble_cmd_data_t                  *cmd
     cmd_data->hci_cmd_buffer[cmd_data->hci_cmd_buffer_length++] = data->own_address_type;
     // Advertising_Filter_Policy
     cmd_data->hci_cmd_buffer[cmd_data->hci_cmd_buffer_length++] = data->advertising_filter_policy;
-    // Local_Name_Length
+    // Local_Name_Length + 1 byte BLE_AD_TYPE_COMPLETE_LOCAL_NAME
     cmd_data->hci_cmd_buffer[cmd_data->hci_cmd_buffer_length++] = data->local_name_length;
-    // Local_Name
+    // Local_Name + 1 byte BLE_AD_TYPE_COMPLETE_LOCAL_NAME
     if (data->local_name_length && data->local_name) {
         memcpy(&cmd_data->hci_cmd_buffer[cmd_data->hci_cmd_buffer_length],
                data->local_name,

--- a/lib_blewbxx/src/ble_ledger.c
+++ b/lib_blewbxx/src/ble_ledger.c
@@ -84,7 +84,7 @@ typedef struct ble_ledger_data_s {
     // General
     bool             enabled;
     ble_state_t         state;
-    char                device_name[BLE_GAP_MAX_LOCAL_NAME_LENGTH + 1];
+    char                device_name[BLE_GAP_MAX_LOCAL_NAME_LENGTH];
     char                device_name_length;
     uint8_t             random_address[BLE_CONFIG_DATA_RANDOM_ADDRESS_LEN];
     uint8_t             nb_of_profile;
@@ -162,7 +162,7 @@ static void get_device_name(void)
     memset(ble_ledger_data.device_name, 0, sizeof(ble_ledger_data.device_name));
     ble_ledger_data.device_name_length = os_setting_get(OS_SETTING_DEVICENAME,
                                                         (uint8_t *) ble_ledger_data.device_name,
-                                                        sizeof(ble_ledger_data.device_name) - 1);
+                                                        sizeof(ble_ledger_data.device_name));
 }
 
 static void start_mngr(uint8_t *hci_buffer, uint16_t length)
@@ -226,7 +226,7 @@ static void start_mngr(uint8_t *hci_buffer, uint16_t length)
             ble_aci_gap_forge_cmd_init(&ble_ledger_data.cmd_data,
                                        BLE_GAP_PERIPHERAL_ROLE,
                                        BLE_GAP_PRIVACY_DISABLED,
-                                       sizeof(ble_ledger_data.device_name) - 1);
+                                       sizeof(ble_ledger_data.device_name));
             send_hci_packet(0);
             break;
 


### PR DESCRIPTION
## Description

This PR fix the issue related in [ticket FWEO-1477](https://ledgerhq.atlassian.net/browse/FWEO-1477)

When we change the device name to use exactly 20 characters, BLE is not working fine anymore!
(device is not discoverable anymore)
Just use a name with less than 20 characters, and BLE is working fine again.
(constated on Flex & Stax devices, with bluetoothctl tool)

## Changes include

- [x ] Bugfix (non-breaking change that solves an issue)
