### PR TITLE
Fix switches list height computation in NBGL Use Case

### DIFF
--- a/lib_nbgl/doc/nbgl_use_case.dox
+++ b/lib_nbgl/doc/nbgl_use_case.dox
@@ -577,8 +577,8 @@ static const nbgl_warningDetails_t warningIntroDetails = {
   .type                    = BAR_LIST_WARNING,
   .barList.nbBars          = 2,
   .barList.icons           = barListIcons,
-  .texts                   = barListTexts,
-  .subTexts                = barListSubTexts,
+  .barList.texts           = barListTexts,
+  .barList.subTexts        = barListSubTexts,
   .barList.details         = barListIntroDetails
 };
 
@@ -588,8 +588,8 @@ static const nbgl_warningDetails_t warningReviewDetails = {
   .type                    = BAR_LIST_WARNING,
   .barList.nbBars          = 2,
   .barList.icons           = barListIcons,
-  .texts                   = barListTexts,
-  .subTexts                = barListSubTexts,
+  .barList.texts           = barListTexts,
+  .barList.subTexts        = barListSubTexts,
   .barList.details         = barListReviewDetails
 };
 

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -3088,19 +3088,20 @@ uint8_t nbgl_useCaseGetNbSwitchesInPage(uint8_t                           nbSwit
     nbgl_contentSwitch_t *switchArray      = (nbgl_contentSwitch_t *) PIC(switchesList->switches);
 
     while (nbSwitchesInPage < nbSwitches) {
-        // The text string must be a 1 liner and its height is LIST_ITEM_MIN_TEXT_HEIGHT
-        currentHeight += LIST_ITEM_MIN_TEXT_HEIGHT + LIST_ITEM_PRE_HEADING;
+        nbgl_contentSwitch_t *curSwitch = &switchArray[startIndex + nbSwitchesInPage];
+        // The text string is either a 1 liner and its height is LIST_ITEM_MIN_TEXT_HEIGHT
+        // or we use its height directly
+        uint16_t textHeight = MAX(
+            LIST_ITEM_MIN_TEXT_HEIGHT,
+            nbgl_getTextHeightInWidth(SMALL_BOLD_FONT, curSwitch->text, AVAILABLE_WIDTH, true));
+        currentHeight += textHeight + 2 * LIST_ITEM_PRE_HEADING;
 
-        if (switchArray[startIndex + nbSwitchesInPage].subText) {
+        if (curSwitch->subText) {
             currentHeight += LIST_ITEM_HEADING_SUB_TEXT;
 
             // sub-text height
-            currentHeight
-                += nbgl_getTextHeightInWidth(SMALL_REGULAR_FONT,
-                                             switchArray[startIndex + nbSwitchesInPage].subText,
-                                             AVAILABLE_WIDTH,
-                                             true);
-            currentHeight += LIST_ITEM_PRE_HEADING;  // under the sub-text
+            currentHeight += nbgl_getTextHeightInWidth(
+                SMALL_REGULAR_FONT, curSwitch->subText, AVAILABLE_WIDTH, true);
         }
         // if height is over the limit
         if (currentHeight >= (INFOS_AREA_HEIGHT - navHeight)) {
@@ -4033,9 +4034,10 @@ void nbgl_useCaseAdvancedReview(nbgl_operationType_t              operationType,
     reviewWithWarnCtx.choiceCallback = choiceCallback;
 
     // display the initial warning only of a risk/threat or blind signing
-    if (!(reviewWithWarnCtx.warning->predefinedSet & (1 << W3C_THREAT_DETECTED_WARN))
-        && !(reviewWithWarnCtx.warning->predefinedSet & (1 << W3C_RISK_DETECTED_WARN))
-        && !(reviewWithWarnCtx.warning->predefinedSet & (1 << BLIND_SIGNING_WARN))) {
+    if ((!(reviewWithWarnCtx.warning->predefinedSet & (1 << W3C_THREAT_DETECTED_WARN))
+         && !(reviewWithWarnCtx.warning->predefinedSet & (1 << W3C_RISK_DETECTED_WARN))
+         && !(reviewWithWarnCtx.warning->predefinedSet & (1 << BLIND_SIGNING_WARN)))
+        && (warning->introDetails == NULL)) {
         useCaseReview(operationType,
                       tagValueList,
                       icon,


### PR DESCRIPTION
## Description

The goal of this PR is to fix switches list height computation in NBGL Use Case.
It also fixes a minor issue in custom warning review.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
