### PR TITLE
Configure Git user identity for the cherry-pick

### DIFF
--- a/.github/workflows/scripts/pr_check.py
+++ b/.github/workflows/scripts/pr_check.py
@@ -155,6 +155,10 @@ def cherry_pick_commits(repo_path: str, commits: List[str], auto_branch: str, dr
     repo = Repo(repo_path)
     origin = repo.remotes.origin
 
+    # Configure Git user identity for the cherry-pick
+    repo.config_writer().set_value("user", "name", "github-actions[bot]").release()
+    repo.config_writer().set_value("user", "email", "github-actions[bot]@users.noreply.github.com").release()
+
     # Fetch latest changes
     origin.fetch()
 


### PR DESCRIPTION
## Description

Add git user config (name, email) in auto-cherr-pick

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
