### PR TITLE
Fix vertical alignement of some Unicode chars on NanoX/S+

### DIFF
--- a/lib_nbgl/fonts/config-open_sans_extrabold_11.ini
+++ b/lib_nbgl/fonts/config-open_sans_extrabold_11.ini
@@ -8,6 +8,7 @@ lineSize=14
 firstChar=0x20
 lastChar=0x7E
 baseline_offset=0
+bottom_offset=1
 crop=true
 bpp=1
 kerning=1

--- a/lib_nbgl/fonts/config-open_sans_regular_11.ini
+++ b/lib_nbgl/fonts/config-open_sans_regular_11.ini
@@ -8,6 +8,7 @@ lineSize=14
 firstChar=0x20
 lastChar=0x7E
 baseline_offset=0
+bottom_offset=1
 crop=true
 bpp=1
 kerning=1


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledger.slack.com/archives/C023GBQCULX/p1754387930803479.
This issue has been seen on some Unicode (non-Ascii) characters, that are 1 pixel lower than the other chars.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
