### PR TITLE
Fix FWEO-1394 - Transaction field disclosure should be clickable on the full row, not only the chevron icon

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -2148,16 +2148,18 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
         fullHeight += valueTextArea->obj.area.height + valueTextArea->obj.alignmentMarginY;
         if (valueIcon != NULL) {
             nbgl_image_t *image = (nbgl_image_t *) nbgl_objPoolGet(IMAGE, layoutInt->layer);
-            layoutObj_t  *obj   = layoutAddCallbackObj(
-                layoutInt, (nbgl_obj_t *) image, list->token, TUNE_TAP_CASUAL);
+            // set the container as touchable, not only the image
+            layoutObj_t *obj = layoutAddCallbackObj(
+                layoutInt, (nbgl_obj_t *) container, list->token, TUNE_TAP_CASUAL);
             obj->index                  = i;
             image->foregroundColor      = BLACK;
             image->buffer               = valueIcon;
             image->obj.alignment        = RIGHT_TOP;
             image->obj.alignmentMarginX = 12;
             image->obj.alignTo          = (nbgl_obj_t *) valueTextArea;
-            image->obj.touchMask        = (1 << TOUCHED);
-            image->obj.touchId          = VALUE_BUTTON_1_ID + i;
+            // set the container as touchable, not only the image
+            container->obj.touchMask = (1 << TOUCHED);
+            container->obj.touchId   = VALUE_BUTTON_1_ID + i;
 
             container->children[container->nbChildren] = (nbgl_obj_t *) image;
             container->nbChildren++;

--- a/tests/screenshots/flows/wallet/app-sdk/flow_w3c_dapp.json
+++ b/tests/screenshots/flows/wallet/app-sdk/flow_w3c_dapp.json
@@ -40,7 +40,7 @@
       "name": "w3c-disabled-clear-dapp-03",
       "targets": [
         {
-          "object": "VALUE_BUTTON_2",
+          "object": "CONTROLS,0",
           "page": "w3c-disabled-clear-dapp-04"
         },
         {
@@ -112,7 +112,7 @@
       "name": "w3c-no-threat-clear-dapp-04",
       "targets": [
         {
-          "object": "VALUE_BUTTON_2",
+          "object": "CONTROLS,0",
           "page": "w3c-no-threat-clear-dapp-05"
         },
         {
@@ -206,7 +206,7 @@
       "name": "w3c-threat-clear-dapp-06",
       "targets": [
         {
-          "object": "VALUE_BUTTON_2",
+          "object": "CONTROLS,0",
           "page": "w3c-threat-clear-dapp-07"
         },
         {
@@ -298,7 +298,7 @@
       "name": "w3c-issue-clear-dapp-05",
       "targets": [
         {
-          "object": "VALUE_BUTTON_2",
+          "object": "CONTROLS,0",
           "page": "w3c-issue-clear-dapp-06"
         }
       ]


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledgerhq.atlassian.net/browse/FWEO-1469
Cherry pick from master

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
