### PR TITLE
Fix missing nbgl_getTextMaxLenAndWidth in OS

### DIFF
--- a/lib_nbgl/nbgl.export
+++ b/lib_nbgl/nbgl.export
@@ -38,7 +38,6 @@ nbgl_getSingleLineTextWidth
 nbgl_getSingleLineTextWidthInLen
 nbgl_getTextHeight
 nbgl_getTextHeightInWidth
-nbgl_getTextMaxLenAndWidth
 nbgl_getTextNbLinesInWidth
 nbgl_getTextNbPagesInWidth
 nbgl_getTextWidth

--- a/src/nbgl_stubs.S
+++ b/src/nbgl_stubs.S
@@ -50,7 +50,6 @@ NBGL_TRAMPOLINE _NR_nbgl_getSingleLineTextWidth              nbgl_getSingleLineT
 NBGL_TRAMPOLINE _NR_nbgl_getSingleLineTextWidthInLen         nbgl_getSingleLineTextWidthInLen
 NBGL_TRAMPOLINE _NR_nbgl_getTextHeight                       nbgl_getTextHeight
 NBGL_TRAMPOLINE _NR_nbgl_getTextHeightInWidth                nbgl_getTextHeightInWidth
-NBGL_TRAMPOLINE _NR_nbgl_getTextMaxLenAndWidth               nbgl_getTextMaxLenAndWidth
 NBGL_TRAMPOLINE _NR_nbgl_getTextNbLinesInWidth               nbgl_getTextNbLinesInWidth
 NBGL_TRAMPOLINE _NR_nbgl_getTextNbPagesInWidth               nbgl_getTextNbPagesInWidth
 NBGL_TRAMPOLINE _NR_nbgl_getTextWidth                        nbgl_getTextWidth


### PR DESCRIPTION
## Description

The goal of this PR is to fix missing nbgl_getTextMaxLenAndWidth() in OS trampoline. It is so forbidden to use in Apps. So it's better to remove it from nbgl_stubs.S
It solves https://ledgerhq.atlassian.net/browse/B2CA-2257

NO cherry-pick in API Level >=25

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
