### PR TITLE
Enable stack protector

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -47,7 +47,7 @@ log = $(if $(strip $(VERBOSE)),$1,@$1) # kept for retrocompat
 L = $(if $(strip $(VERBOSE)),,@)
 
 ifeq ($(CC),)
-CC        = clang
+CC        = clang-19
 endif
 
 SYSROOT = $(shell $(GCCPATH)arm-none-eabi-gcc -print-sysroot)
@@ -77,7 +77,7 @@ CFLAGS   += -std=gnu99
 
 CFLAGS   += -Wall -Wextra
 CFLAGS   += -Wno-main
-CFLAGS   += -Werror=int-to-pointer-cast
+CFLAGS   += -Werror=int-to-pointer-cast -Wno-implicit-function-declaration
 
 # Additional Clang warnings
 CFLAGS   += -Wno-error=int-conversion -Wimplicit-fallthrough
@@ -98,6 +98,10 @@ LDFLAGS  += -fno-common -ffunction-sections -fdata-sections -fwhole-program
 LDFLAGS  += -mno-unaligned-access
 LDFLAGS  += -Wl,--gc-sections -Wl,-Map,$(DBG_DIR)/app.map
 LDFLAGS  += -nostdlib -nodefaultlibs
+
+LDLIBS   += -Wl,--wrap=__stack_chk_fail -Wl,--wrap=__stack_chk_init
+AFLAGS   += -fstack-protector-strong
+CFLAGS   += -fstack-protector-strong
 
 ifeq ($(TARGET_NAME),TARGET_NANOX)
     CPU       = cortex-m3

--- a/Makefile.standard_app
+++ b/Makefile.standard_app
@@ -266,9 +266,9 @@ APP_FLAGS_APP_LOAD_PARAMS = $(shell printf '0x%x' $$(( $(STANDARD_APP_FLAGS) + $
 #####################################################################
 #                         COMPILER SETTINGS                         #
 #####################################################################
-CC       = $(CLANGPATH)clang
-AS       = $(CLANGPATH)clang
-LD       = $(CLANGPATH)clang
+CC       = $(CLANGPATH)clang-19
+AS       = $(CLANGPATH)clang-19
+LD       = $(CLANGPATH)clang-19
 LDLIBS  += -lclang_rt.builtins
 
 AFLAGS  += --target=arm-none-eabi

--- a/src/stack_protector_init.S
+++ b/src/stack_protector_init.S
@@ -16,11 +16,11 @@ __wrap___stack_chk_init:
     // call cx_get_random_bytes(&__stack_chk_guard, sizeof(__stack_chk_guard));
     // we can't use the function cx_get_random_bytes because of PIC
     ldr r0, =SYSCALL_cx_get_random_bytes_ID
-    ldr r2, =__stack_chk_guard
+    mov r2, r9
     movs r3, #4
     push {r2-r3}
     mov r1, sp
-    svc 1
+    bl SVC_Call
     pop {r2-r3}
 
     // restore arguments

--- a/src/stack_protector_init.S
+++ b/src/stack_protector_init.S
@@ -10,6 +10,11 @@
 .global __wrap___stack_chk_init
 .thumb_func
 __wrap___stack_chk_init:
+    // if r0 != 0, skip initialization and jump directly to main
+    // (don't overwrite parent canary during a libcall)
+    cmp r0, #0
+    bne 1f
+
     // save arguments passed to main
     push {r0-r3}
 

--- a/target/apex_m/script.ld
+++ b/target/apex_m/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -106,6 +108,9 @@ SECTIONS
      * Place RAM uninitialized variables
      */
     _bss = .;
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     *(.bss*)
     _ebss = .;
 
@@ -125,6 +130,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/apex_m/script.ld
+++ b/target/apex_m/script.ld
@@ -107,10 +107,10 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 

--- a/target/apex_p/script.ld
+++ b/target/apex_p/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -106,6 +108,9 @@ SECTIONS
      * Place RAM uninitialized variables
      */
     _bss = .;
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     *(.bss*)
     _ebss = .;
 
@@ -125,6 +130,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/apex_p/script.ld
+++ b/target/apex_p/script.ld
@@ -107,10 +107,10 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 

--- a/target/flex/script.ld
+++ b/target/flex/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -109,6 +111,9 @@ SECTIONS
      * Place RAM uninitialized variables
      */
     _bss = .;
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     *(.bss*)
     _ebss = .;
 
@@ -128,6 +133,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/flex/script.ld
+++ b/target/flex/script.ld
@@ -110,10 +110,10 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -108,6 +110,9 @@ SECTIONS
      * Place RAM uninitialized variables
      */
     _bss = .;
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     *(.bss*)
     _ebss = .;
 
@@ -127,6 +132,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -109,10 +109,10 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -104,12 +104,6 @@ SECTIONS
 
   ASSERT( (_edata - _data) <= 0, ".data section must be empty" )
 
-  /* The .init_array is initialized with functions with the constructor
-   * attribute. Discard this section since there's no loader. */
-  /DISCARD/ : {
-    *(.init_array)
-  }
-
   .bss :
   {
     /**
@@ -138,6 +132,12 @@ SECTIONS
   } > SRAM
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -109,10 +109,10 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -109,6 +111,9 @@ SECTIONS
      * Place RAM uninitialized variables
      */
     _bss = .;
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     *(.bss*)
     _ebss = .;
 
@@ -128,6 +133,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -110,10 +110,10 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 


### PR DESCRIPTION
## Description

Support stack protector (stack canaries) to protect against stack buffer overflows.
Close https://github.com/LedgerHQ/ledger-secure-sdk/issues/120

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

This PR enable clang stack protection mechanism. It is a breaking change as it requires clang-19.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_24
[ ] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
