### PR TITLE
OSU: PIC - Disable relocation of addresses in RAM

### DIFF
--- a/src/pic.c
+++ b/src/pic.c
@@ -53,6 +53,7 @@ void *pic(void *link_address)
         link_address = pic_internal(link_address);
     }
 
+#ifndef BOLOS_OS_UPGRADER_APP
     // check if in the LINKED RAM zone
     __asm volatile("ldr %0, =_bss" : "=r"(n));
     __asm volatile("ldr %0, =_estack" : "=r"(en));
@@ -61,6 +62,7 @@ void *pic(void *link_address)
         // deref into the RAM therefore add the RAM offset from R9
         link_address = (char *) link_address - (char *) n + (char *) en;
     }
+#endif  // BOLOS_OS_UPGRADER_APP
 
     return link_address;
 }


### PR DESCRIPTION
## Description

In the context of an OSU, the `pic` function used to link addresses
in RAM. Those addresses are already known at compile time. Applying this
relocation triggered incorrect behaviors.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
