### PR TITLE
OSU: PIC - Disable relocation of addresses in RAM

### DIFF
--- a/src/pic.c
+++ b/src/pic.c
@@ -53,6 +53,7 @@ void *pic(void *link_address)
         link_address = pic_internal(link_address);
     }
 
+#ifndef BOLOS_OS_UPGRADER_APP
     // check if in the LINKED RAM zone
     __asm volatile("ldr %0, =_bss" : "=r"(n));
     __asm volatile("ldr %0, =_estack" : "=r"(en));
@@ -61,6 +62,7 @@ void *pic(void *link_address)
         // deref into the RAM therefore add the RAM offset from R9
         link_address = (char *) link_address - (char *) n + (char *) en;
     }
+#endif  // BOLOS_OS_UPGRADER_APP
 
     return link_address;
 }


### PR DESCRIPTION
In the context of an OSU, the `pic` function used to link addresses in RAM. Those addresses are already known at compile time. Applying this relocation triggered incorrect behaviors.

(cherry picked from commit 8f7135cabc9b55748694bea84c9205cf3004b0ad)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

