### PR TITLE
app_storage: bring back init

### DIFF
--- a/lib_standard_app/main.c
+++ b/lib_standard_app/main.c
@@ -49,6 +49,11 @@ WEAK void common_app_init(void)
 {
     UX_INIT();
     io_seproxyhal_init();
+
+#ifdef HAVE_APP_STORAGE
+    /* Implicit app storage initialization */
+    app_storage_init();
+#endif  // #ifdef HAVE_APP_STORAGE
 }
 
 WEAK void standalone_app_main(void)


### PR DESCRIPTION
## Description

App storage init has been lost during io-revamp, bring back the init.
Initial PR: https://github.com/LedgerHQ/ledger-secure-sdk/pull/902/

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
