### PR TITLE
Implement a real screen stack in NBGL layout layer

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -181,6 +181,9 @@ typedef struct {
  */
 static nbgl_layoutInternal_t gLayout[NB_MAX_LAYOUTS] = {0};
 
+// current top of stack
+static nbgl_layoutInternal_t *topLayout;
+
 // numbers of touchable controls for the whole page
 static uint8_t nbTouchableControls = 0;
 
@@ -216,28 +219,23 @@ static bool getLayoutAndLayoutObj(nbgl_obj_t             *obj,
                                   nbgl_layoutInternal_t **layout,
                                   layoutObj_t           **layoutObj)
 {
-    uint8_t i = NB_MAX_LAYOUTS;
-
-    // parse all layouts (starting with modals) to find the object
+    // only try to find the object on top layout on the stack (the other cannot receive touch
+    // events)
     *layout = NULL;
-    while (i > 0) {
-        i--;
-        if (gLayout[i].nbChildren > 0) {
-            uint8_t j;
+    if ((topLayout) && (topLayout->isUsed)) {
+        uint8_t j;
 
-            // search index of obj in this layout
-            for (j = 0; j < gLayout[i].nbUsedCallbackObjs; j++) {
-                if (obj == gLayout[i].callbackObjPool[j].obj) {
-                    LOG_DEBUG(LAYOUT_LOGGER,
-                              "getLayoutAndLayoutObj(): obj found in layout[%d], index = %d, "
-                              "nbUsedCallbackObjs = %d\n",
-                              i,
-                              j,
-                              gLayout[i].nbUsedCallbackObjs);
-                    *layout    = &gLayout[i];
-                    *layoutObj = &(gLayout[i].callbackObjPool[j]);
-                    return true;
-                }
+        // search index of obj in this layout
+        for (j = 0; j < topLayout->nbUsedCallbackObjs; j++) {
+            if (obj == topLayout->callbackObjPool[j].obj) {
+                LOG_DEBUG(LAYOUT_LOGGER,
+                          "getLayoutAndLayoutObj(): obj found in layout %p "
+                          "nbUsedCallbackObjs = %d\n",
+                          topLayout,
+                          topLayout->nbUsedCallbackObjs);
+                *layout    = topLayout;
+                *layoutObj = &(topLayout->callbackObjPool[j]);
+                return true;
             }
         }
     }
@@ -376,11 +374,7 @@ static void longTouchCallback(nbgl_obj_t            *obj,
     // 4th child of container is the progress bar
     nbgl_progress_bar_t *progressBar = (nbgl_progress_bar_t *) container->children[3];
 
-    LOG_DEBUG(LAYOUT_LOGGER,
-              "longTouchCallback(): eventType = %d, obj = %p, gLayout[1].nbChildren = %d\n",
-              eventType,
-              obj,
-              gLayout[1].nbChildren);
+    LOG_DEBUG(LAYOUT_LOGGER, "longTouchCallback(): eventType = %d, obj = %p\n", eventType, obj);
 
     // case of pressing a long press button
     if (eventType == TOUCHING) {
@@ -505,22 +499,17 @@ static void radioTouchCallback(nbgl_obj_t            *obj,
 // callback for spinner ticker
 static void spinnerTickerCallback(void)
 {
-    nbgl_spinner_t        *spinner;
-    uint8_t                i = 0;
-    nbgl_layoutInternal_t *layout;
+    nbgl_spinner_t *spinner;
+    uint8_t         i = 0;
 
-    // gLayout[1] is on top of gLayout[0] so if gLayout[1] is active, it must catch the event
-    if (gLayout[1].nbChildren > 0) {
-        layout = &gLayout[1];
-    }
-    else {
-        layout = &gLayout[0];
+    if (!topLayout || !topLayout->isUsed) {
+        return;
     }
 
     // get index of obj
-    while (i < layout->container->nbChildren) {
-        if (layout->container->children[i]->type == CONTAINER) {
-            nbgl_container_t *container = (nbgl_container_t *) layout->container->children[i];
+    while (i < topLayout->container->nbChildren) {
+        if (topLayout->container->children[i]->type == CONTAINER) {
+            nbgl_container_t *container = (nbgl_container_t *) topLayout->container->children[i];
             if (container->nbChildren && (container->children[0]->type == SPINNER)) {
                 spinner = (nbgl_spinner_t *) container->children[0];
                 spinner->position++;
@@ -541,18 +530,10 @@ static void spinnerTickerCallback(void)
 static void animTickerCallback(void)
 {
     nbgl_image_t          *image;
-    uint8_t                i = 0;
-    nbgl_layoutInternal_t *layout;
+    uint8_t                i      = 0;
+    nbgl_layoutInternal_t *layout = topLayout;
 
-    // gLayout[1] is on top of gLayout[0] so if gLayout[1] is active, it must catch the event
-    if (gLayout[1].nbChildren > 0) {
-        layout = &gLayout[1];
-    }
-    else {
-        layout = &gLayout[0];
-    }
-
-    if (layout->animation == NULL) {
+    if (!layout || !layout->isUsed || (layout->animation == NULL)) {
         return;
     }
 
@@ -1081,19 +1062,21 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description)
 {
     nbgl_layoutInternal_t *layout = NULL;
 
-    // find an empty layout in the proper "layer"
     if (description->modal) {
-        if (gLayout[1].nbChildren == 0) {
-            layout = &gLayout[1];
-        }
-        else if (gLayout[2].nbChildren == 0) {
-            layout = &gLayout[2];
+        int i;
+        // find an empty layout in the array of layouts (0 is reserved for background)
+        for (i = 1; i < NB_MAX_LAYOUTS; i++) {
+            if (!gLayout[i].isUsed) {
+                layout = &gLayout[i];
+            }
         }
     }
     else {
-        // automatically "release" a potentially opened non-modal layout
-        gLayout[0].nbChildren = 0;
-        layout                = &gLayout[0];
+        // always use layout 0 for background
+        layout = &gLayout[0];
+        if (topLayout == NULL) {
+            topLayout = layout;
+        }
     }
     if (layout == NULL) {
         LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutGet(): impossible to get a layout!\n");
@@ -1101,7 +1084,26 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description)
     }
 
     // reset globals
+    nbgl_layoutInternal_t *backgroundTop = gLayout[0].top;
     memset(layout, 0, sizeof(nbgl_layoutInternal_t));
+    // link layout to other ones
+    if (description->modal) {
+        if (topLayout != NULL) {
+            // if topLayout already existing, push this new one on top of it
+            topLayout->top = layout;
+            layout->bottom = topLayout;
+        }
+        else {
+            // otherwise put it on top of background layout
+            layout->bottom = &gLayout[0];
+            gLayout[0].top = layout;
+        }
+        topLayout = layout;
+    }
+    else {
+        // restore potentially valid background top layer
+        gLayout[0].top = backgroundTop;
+    }
 
     nbTouchableControls = 0;
 
@@ -1130,7 +1132,7 @@ nbgl_layout_t *nbgl_layoutGet(const nbgl_layoutDescription_t *description)
     layout->container->obj.alignment = TOP_LEFT;
     // main container is always the second object, leaving space for header
     layout->children[MAIN_CONTAINER_INDEX] = (nbgl_obj_t *) layout->container;
-    layout->nbChildren                     = NB_MAX_SCREEN_CHILDREN;
+    layout->isUsed                         = true;
 
     // if a tap text is defined, make the container tapable and display this text in gray
     if (description->tapActionText != NULL) {
@@ -3759,10 +3761,7 @@ int nbgl_layoutDraw(nbgl_layout_t *layoutParam)
     if (layout == NULL) {
         return -1;
     }
-    LOG_DEBUG(LAYOUT_LOGGER,
-              "nbgl_layoutDraw(): container.nbChildren =%d, layout->nbChildren = %d\n",
-              layout->container->nbChildren,
-              layout->nbChildren);
+    LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutDraw(): layout->isUsed = %d\n", layout->isUsed);
     if (layout->tapText) {
         // set this new container as child of main container
         layoutAddObject(layout, (nbgl_obj_t *) layout->tapText);
@@ -3789,14 +3788,24 @@ int nbgl_layoutRelease(nbgl_layout_t *layoutParam)
 {
     nbgl_layoutInternal_t *layout = (nbgl_layoutInternal_t *) layoutParam;
     LOG_DEBUG(PAGE_LOGGER, "nbgl_layoutRelease(): \n");
-    if (layout == NULL) {
+    if ((layout == NULL) || (!layout->isUsed)) {
         return -1;
     }
     // if modal
     if (layout->modal) {
         nbgl_screenPop(layout->layer);
+        // if this layout was on top, use its bottom layout as top
+        if (layout == topLayout) {
+            topLayout      = layout->bottom;
+            topLayout->top = NULL;
+        }
+        else {
+            // otherwise connect top to bottom
+            layout->bottom->top = layout->top;
+            layout->top->bottom = layout->bottom;
+        }
     }
-    layout->nbChildren = 0;
+    layout->isUsed = false;
     return 0;
 }
 

--- a/lib_nbgl/src/nbgl_layout_internal.h
+++ b/lib_nbgl/src/nbgl_layout_internal.h
@@ -76,14 +76,16 @@ enum {
  *
  */
 typedef struct nbgl_layoutInternal_s {
-    nbgl_obj_t **children;  ///< children for main screen
+    struct nbgl_layoutInternal_s *top;       ///< layout above this one, in stack
+    struct nbgl_layoutInternal_s *bottom;    ///< layout under this one, in stack
+    nbgl_obj_t                  **children;  ///< children for main screen
     nbgl_container_t
         *headerContainer;  ///< container used to store header (progress, back, empty space...)
     nbgl_container_t *footerContainer;    ///< container used to store footer (buttons, nav....)
     nbgl_container_t *upFooterContainer;  ///< container used on top on footer to store special
                                           ///< contents like tip-box or long-press button
     nbgl_text_area_t          *tapText;
-    nbgl_layoutTouchCallback_t callback;  // user callback for all controls
+    nbgl_layoutTouchCallback_t callback;  ///< user callback for all controls
     // This is the pool of callback objects, potentially used by this layout
     layoutObj_t callbackObjPool[LAYOUT_OBJ_POOL_LEN];
 
@@ -100,11 +102,11 @@ typedef struct nbgl_layoutInternal_s {
                                  ///< the screen
     uint8_t incrementAnim : 1;   ///< if true, means that animation index is currently incrementing
     uint8_t layer : 5;           ///< layer in screen stack
-    uint8_t nbUsedCallbackObjs;  ///< number of callback objects used by the whole layout in
-                                 ///< callbackObjPool
-    uint8_t            nbChildren;      ///< number of children in above array
-    uint8_t            iconIdxInAnim;   ///< current icon index in animation
-    bool               invertedColors;  ///< if true, means that background is black
+    uint8_t nbUsedCallbackObjs : 6;  ///< number of callback objects used by the whole layout in
+                                     ///< callbackObjPool
+    uint8_t            isUsed : 1;   ///< if true, means this layout is in use
+    uint8_t            invertedColors : 1;  ///< if true, means that background is black
+    uint8_t            iconIdxInAnim;       ///< current icon index in animation
     nbgl_swipe_usage_t swipeUsage;
 } nbgl_layoutInternal_t;
 


### PR DESCRIPTION
## Description

The goal of this PR is to create a real screen stack in NBGL layout layer.
Currenty, the mechanism is incomplete at this level of NBGL, and it assumes that the layers are always released at the reverse order of their creation.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
