### PR TITLE
Fix missing validate key in keypad when 8 digits

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keypad.c
+++ b/lib_nbgl/src/nbgl_obj_keypad.c
@@ -248,7 +248,7 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad)
 #endif  // TARGET_APEX
         nbgl_frontDrawLine(&rectArea, dotStartIdx, LIGHT_GRAY);
     }
-    else if (keypad->validateChanged) {
+    else if (keypad->enableValidate && (keypad->digitsChanged || keypad->validateChanged)) {
         const nbgl_icon_details_t *icon;
 
         if (keypad->softValidation) {


### PR DESCRIPTION
## Description

The goal of this PR is to fix missing validate key in keypad when 8 digits

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
