### PR TITLE
Fix missing validate key in keypad when 8 digits

### DIFF
--- a/lib_nbgl/src/nbgl_obj_keypad.c
+++ b/lib_nbgl/src/nbgl_obj_keypad.c
@@ -248,7 +248,7 @@ static void keypadDrawDigits(nbgl_keypad_t *keypad)
 #endif  // TARGET_APEX
         nbgl_frontDrawLine(&rectArea, dotStartIdx, LIGHT_GRAY);
     }
-    else if (keypad->validateChanged) {
+    else if (keypad->enableValidate && (keypad->digitsChanged || keypad->validateChanged)) {
         const nbgl_icon_details_t *icon;
 
         if (keypad->softValidation) {


### PR DESCRIPTION
## Description

The goal of this PR is to fix missing validate key in keypad when 8 digits

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
