### PR TITLE
reFix whole screen issue when building screenshots

### DIFF
--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -353,9 +353,10 @@ static void compute_position(nbgl_obj_t *obj, nbgl_obj_t *prevObj)
 
     obj->area.x0 = parent->obj.area.x0 + obj->rel_x0;
     obj->area.y0 = parent->obj.area.y0 + obj->rel_y0;
-    if ((obj->area.x0 + obj->area.width) > (parent->obj.area.x0 + parent->obj.area.width)) {
+
+    if ((obj->area.x0 + obj->area.width) > SCREEN_WIDTH) {
 #ifdef BUILD_SCREENSHOTS
-        obj->area.width = parent->obj.area.x0 + parent->obj.area.width - obj->area.x0;
+        obj->area.width = SCREEN_WIDTH - obj->area.x0;
         // Be sure the area is not empty
         if (!obj->area.width) {
             obj->area.width = 1;
@@ -370,9 +371,9 @@ static void compute_position(nbgl_obj_t *obj, nbgl_obj_t *prevObj)
 #endif  // BUILD_SCREENSHOTS
     }
 #ifdef HAVE_SE_TOUCH
-    if ((obj->area.y0 + obj->area.height) > (parent->obj.area.y0 + parent->obj.area.height)) {
+    if ((obj->area.y0 + obj->area.height) > SCREEN_HEIGHT) {
 #ifdef BUILD_SCREENSHOTS
-        obj->area.height = parent->obj.area.y0 + parent->obj.area.height - obj->area.y0;
+        obj->area.height = SCREEN_HEIGHT - obj->area.y0;
         // Be sure the area is not empty
         if (!obj->area.height) {
             obj->area.height = 1;


### PR DESCRIPTION
The screen resolution on APEX is much smaller than on Flex/Stax, which causes problems when displaying text across the entire screen.

When such a case occur, LOG_FATAL function is called, causing the build to fail.
When we build screenshots, we don't want the build to fail, we want an error message to be displayed instead, making it possible for translators to make the text shorter.

This PR fix that issue.