### PR TITLE
Apex: Partial refresh on radio button selection

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -492,8 +492,8 @@ static void radioTouchCallback(nbgl_obj_t            *obj,
             if (layout->callbackObjPool[foundRadio].tuneId < NBGL_NO_TUNE) {
                 os_io_seph_cmd_piezo_play_tune(layout->callbackObjPool[foundRadio].tuneId);
             }
-            nbgl_refreshSpecial(FULL_COLOR_PARTIAL_REFRESH);
 #endif  // HAVE_PIEZO_SOUND
+            nbgl_refreshSpecial(FULL_COLOR_PARTIAL_REFRESH);
             layout->callback(layout->callbackObjPool[foundRadio].token, foundRadioIndex);
         }
     }


### PR DESCRIPTION
On Apex, partial refresh was not called on radio button selection, due to an inappropriate #ifdef condition.

## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
