### PR TITLE
NBGL layout: Fix missing PIC in "addLeftContent"

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1838,12 +1838,12 @@ int nbgl_layoutAddLeftContent(nbgl_layout_t *layout, const nbgl_layoutLeftConten
 
         image                     = (nbgl_image_t *) nbgl_objPoolGet(IMAGE, 0);
         image->foregroundColor    = BLACK;
-        image->buffer             = info->rowIcons[row];
+        image->buffer             = PIC(info->rowIcons[row]);
         rowContainer->children[0] = (nbgl_obj_t *) image;
 
         textArea                = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, 0);
         textArea->textColor     = BLACK;
-        textArea->text          = info->rowTexts[row];
+        textArea->text          = PIC(info->rowTexts[row]);
         textArea->textAlignment = MID_LEFT;
         textArea->fontId        = SMALL_REGULAR_FONT;
         textArea->wrapping      = true;


### PR DESCRIPTION
(cherry picked from commit 10cf12eca28083b2e1af2954996f2a931cb46fc4)

## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_24
[ ] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
