### PR TITLE
Fix FWEO-1510 - Apex - Unicodes in some fonts don't have the same baseline as ASCII characters

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1437,7 +1437,7 @@ static void displayFullValuePage(const char                   *backText,
                 info = "ENS names are resolved by Ledger backend.";
             }
             else if (extension->aliasType == ADDRESS_BOOK_ALIAS) {
-                info = "This account label comes from your Address Book in Ledger Live.";
+                info = "This account label comes from your Address Book in Ledger Wallet.";
             }
             else {
                 info = extension->explanation;
@@ -2498,8 +2498,9 @@ static void displaySecurityReport(uint32_t set)
         info.icon                 = &LARGE_WARNING_ICON;
         info.title                = "Transaction Check unavailable";
         info.description
-            = "If you're not using the\nLedger Live app, Transaction Check might not work. If your "
-              "are using Ledger Live, reject the transaction and try again.\n\nGet help at "
+            = "If you're not using the Ledger Wallet app, Transaction Check might not work. If "
+              "your "
+              "are using Ledger Wallet, reject the transaction and try again.\n\nGet help at "
               "ledger.com/e11";
         nbgl_layoutAddContentCenter(reviewWithWarnCtx.modalLayout, &info);
         footerDesc.emptySpace.height = SMALL_CENTERING_HEADER;

--- a/tools/ttf2inc.py
+++ b/tools/ttf2inc.py
@@ -376,11 +376,17 @@ class TTF2INC:
 
         # Build full path of the destination file:
         filename = f"{self.font_prefix}{self.basename}_{unicode_value}"
+        filename_without_unicode = filename.replace('_unicode', '')
         fullpath = os.path.join(self.directory, filename)
+        fullpath_without_unicode = os.path.join(self.directory, filename_without_unicode)
 
         # We'll look for .bmp, .png and .gif extensions to check if file exists
         for ext in [".bmp", ".png", ".gif"]:
             image_name = fullpath + ext
+            if os.path.exists(image_name):
+                break
+            # try without 'unicode' in filename
+            image_name = fullpath_without_unicode + ext
             if os.path.exists(image_name):
                 break
 


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledgerhq.atlassian.net/browse/FWEO-1510?actionerId=5f6374e9cacd83007778f56e&sourceType=assign

This is done by fixing ttf2inc to look at proper .png files for unicode characters, that don't have to same naming as for other fonts

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
