### PR TITLE
Fix Rendering and Line-breaking EIP-191 message

### DIFF
--- a/lib_nbgl/src/nbgl_fonts.c
+++ b/lib_nbgl/src/nbgl_fonts.c
@@ -606,7 +606,8 @@ bool nbgl_getTextMaxLenInNbLines(nbgl_font_id_e fontId,
             if (maxNbLines == 0) {
                 text--;
             }
-            width = 0;
+            lastDelimiter = NULL;
+            width         = 0;
             continue;
         }
         // if \f, exit

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -1167,18 +1167,23 @@ static void draw_textArea(nbgl_text_area_t *obj, nbgl_obj_t *prevObj, bool compu
         }
         else {
 #ifdef HAVE_SE_TOUCH
-            uint16_t dotsWidth = nbgl_getSingleLineTextWidth(obj->fontId, "...");
             // for last chunk, if nbMaxLines is used, replace the 3 last chars by "..."
-            // draw line except 3 last chars
-            if ((lineWidth + dotsWidth) >= obj->obj.area.width) {
-                lineLen -= 3;
-            }
-            nbgl_drawText(&rectArea, text, lineLen, obj->fontId, obj->textColor);
-            rectArea.x0 += nbgl_getSingleLineTextWidthInLen(obj->fontId, text, lineLen);
+            // only if the line doesn't end with a '\n'
+            if (text[lineLen] != '\n') {
+                uint16_t dotsWidth = nbgl_getSingleLineTextWidth(obj->fontId, "...");
+                if ((lineWidth + dotsWidth) >= obj->obj.area.width) {
+                    lineLen -= 3;
+                }
+                nbgl_drawText(&rectArea, text, lineLen, obj->fontId, obj->textColor);
+                rectArea.x0 += nbgl_getSingleLineTextWidthInLen(obj->fontId, text, lineLen);
 
-            // draw "..." after the other chars
-            rectArea.width = dotsWidth;
-            nbgl_drawText(&rectArea, "...", 3, obj->fontId, obj->textColor);
+                // draw "..." after the other chars
+                rectArea.width = dotsWidth;
+                nbgl_drawText(&rectArea, "...", 3, obj->fontId, obj->textColor);
+            }
+            else {
+                nbgl_drawText(&rectArea, text, lineLen, obj->fontId, obj->textColor);
+            }
 #else   // HAVE_SE_TOUCH
             nbgl_drawText(&rectArea, text, lineLen, fontId, obj->textColor);
 #endif  // HAVE_SE_TOUCH

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1363,11 +1363,16 @@ static void displayDetailsPage(uint8_t detailsPage, bool forceFullRefresh)
                                     NB_MAX_LINES_IN_DETAILS,
                                     &len,
                                     detailsContext.wrapping);
-        len -= 3;
-        // memorize next position to save processing
-        detailsContext.nextPageStart = currentPair.value + len;
+        if (currentPair.value[len] != '\n') {
+            len -= 3;
+            // memorize next position to save processing
+            detailsContext.nextPageStart = currentPair.value + len;
+        }
+        else {
+            detailsContext.nextPageStart = currentPair.value + len + 1;
+        }
         // use special feature to keep only NB_MAX_LINES_IN_DETAILS lines and replace the last 3
-        // chars by "..."
+        // chars by "...", only if the next char to display in next page is not '\n'
         content.tagValueList.nbMaxLinesForValue = NB_MAX_LINES_IN_DETAILS;
     }
     else {


### PR DESCRIPTION
## Description

The goal of this PR is to fix https://ledgerhq.atlassian.net/browse/B2CA-2296

This is done by fixing the computation of nbgl_getTextMaxLenInNbLines() in case of a mix of \n and wrapping
But also by removing the usage of "..." in case the last line ends with a \n

But must of this fix is in the OS part, so a new OS will be necessary

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
