### PR TITLE
Replace 'x of y' by 'x / y' on multi pages navigation

### DIFF
--- a/lib_nbgl/src/nbgl_layout_navigation.c
+++ b/lib_nbgl/src/nbgl_layout_navigation.c
@@ -208,7 +208,7 @@ void layoutNavigationPopulate(nbgl_container_t                 *navContainer,
             nbgl_text_area_t *textArea = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layer);
             uint16_t          marginX  = (NAV_BUTTON_WIDTH - CHEVRON_NEXT_ICON.width) / 2;
 
-            SPRINTF(navText, "%d of %d", navConfig->activePage + 1, navConfig->nbPages);
+            SPRINTF(navText, "%d / %d", navConfig->activePage + 1, navConfig->nbPages);
 
             textArea->textColor = LIGHT_TEXT_COLOR;
             // the max width is the width of the whole container, but not overriding the < and >

--- a/lib_nbgl/src/nbgl_obj.c
+++ b/lib_nbgl/src/nbgl_obj.c
@@ -970,7 +970,7 @@ static void draw_pageIndicator(nbgl_page_indicator_t *obj,
     else {
         char navText[11];  // worst case is "ccc of nnn"
 
-        SPRINTF(navText, "%d of %d", obj->activePage + 1, obj->nbPages);
+        SPRINTF(navText, "%d / %d", obj->activePage + 1, obj->nbPages);
         // force height
         obj->obj.area.height = nbgl_getFontHeight(SMALL_REGULAR_FONT);
         // the width must be at least 80


### PR DESCRIPTION
## Description

Replace the text "x of y" by "x / y" when navigating multiple pages.
Doing that will make this string usable on all languages.
The result is what is displayed on next picture

<img width="300" height="400" alt="image" src="https://github.com/user-attachments/assets/3f3442f2-eb86-4877-b19e-2326fa0209fb" />
