### PR TITLE
Fix screensaver on app issue (Level 24)

### DIFF
--- a/lib_nbgl/src/nbgl_screen.c
+++ b/lib_nbgl/src/nbgl_screen.c
@@ -489,6 +489,11 @@ void nbgl_screenHandler(uint32_t intervaleMs)
     if (nbScreensOnStack == 0) {
         return;
     }
+    // ensure the screen is owned by the proper caller
+    if ((os_sched_current_task() == TASK_BOLOS_UX) != topOfStack->isUxScreen) {
+        return;
+    }
+
     // call ticker callback of top of stack if active and not expired yet (for a non periodic)
     if ((topOfStack->ticker.tickerCallback != NULL) && (topOfStack->ticker.tickerValue != 0)) {
         topOfStack->ticker.tickerValue -= MIN(topOfStack->ticker.tickerValue, intervaleMs);


### PR DESCRIPTION
## Description

The goal of this PR is to fix a crash happening when the screensaver starts on top of an App (using NBGL) on Nano (S+, X)

This is done by checking that the nbgl_screenHandler() doesn't call the ticker handler of a screen not belonging to its task (UX for UX, App for App)

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
