### PR TITLE
Allow skippable operation for non-streaming reviews

### DIFF
--- a/lib_nbgl/src/nbgl_draw.c
+++ b/lib_nbgl/src/nbgl_draw.c
@@ -631,14 +631,14 @@ nbgl_font_id_e nbgl_drawText(const nbgl_area_t *area,
                 if (fontId == BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp) {  // switch to bold
                     fontId = BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                    unicode_ctx = nbgl_getUnicodeFont(fontId);
+                    unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                     font = (const nbgl_font_t *) nbgl_getFont(fontId);
                 }
                 else if (fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp) {  // switch to regular
                     fontId = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                    unicode_ctx = nbgl_getUnicodeFont(fontId);
+                    unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                     font = (const nbgl_font_t *) nbgl_getFont(fontId);
                 }

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1228,6 +1228,12 @@ static void displayGenericContextPage(uint8_t pageIdx, bool forceFullRefresh)
             return;
         }
     }
+    else {
+        // if coming from Skip modal, let's say we are at the last page
+        if (pageIdx == LAST_PAGE_FOR_REVIEW) {
+            pageIdx = navInfo.nbPages - 1;
+        }
+    }
 
     if (navInfo.activePage == pageIdx) {
         p_content
@@ -1252,6 +1258,18 @@ static void displayGenericContextPage(uint8_t pageIdx, bool forceFullRefresh)
 
     if (p_content == NULL) {
         return;
+    }
+    // if the operation is skippable
+    if (bundleNavContext.review.operationType & SKIPPABLE_OPERATION) {
+        // only present the "Skip" header on actual tag/value pages
+        if ((pageIdx > 0) && (pageIdx < (navInfo.nbPages - 1))) {
+            navInfo.progressIndicator = false;
+            navInfo.skipText          = "Skip";
+            navInfo.skipToken         = SKIP_TOKEN;
+        }
+        else {
+            navInfo.skipText = NULL;
+        }
     }
 
     // Create next page content

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -142,6 +142,7 @@ typedef struct UseCaseContext_s {
     nbgl_operationType_t operationType;
     uint8_t              nbPages;
     int8_t               currentPage;
+    int8_t               firstPairPage;
     nbgl_stepCallback_t
         stepCallback;  ///< if not NULL, function to be called on "double-key" action
     union {
@@ -727,7 +728,10 @@ static void reviewCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
     if (!buttonGenericCallback(event, &pos)) {
         return;
     }
-
+    else {
+        // memorize last direction
+        context.review.dataDirection = pos;
+    }
     displayReviewPage(pos);
 }
 
@@ -739,7 +743,8 @@ static void buttonSkipCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
 
     if (event == BUTTON_LEFT_PRESSED) {
         // only decrement page if we are going backward but coming from forward (back & forth)
-        if ((context.review.dataDirection == FORWARD_DIRECTION) && (context.currentPage > 0)) {
+        if ((context.review.dataDirection == FORWARD_DIRECTION)
+            && (context.currentPage > context.firstPairPage)) {
             context.currentPage--;
         }
         pos = BACKWARD_DIRECTION;
@@ -747,19 +752,35 @@ static void buttonSkipCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
     else if (event == BUTTON_RIGHT_PRESSED) {
         // only increment page if we are going forward but coming from backward (back & forth)
         if ((context.review.dataDirection == BACKWARD_DIRECTION)
-            && (context.currentPage < (int) (context.nbPages - 1)) && (context.currentPage > 0)) {
+            && (context.currentPage < (int) (context.nbPages - 1))
+            && (context.currentPage > context.firstPairPage)) {
             context.currentPage++;
         }
         pos = FORWARD_DIRECTION;
     }
     else if (event == BUTTON_BOTH_PRESSED) {
-        context.review.skipCallback();
+        // the first tag/value page is at page 0 only in streaming case
+        if (context.firstPairPage == 0) {
+            // in streaming, we have to call the provided callback
+            context.review.skipCallback();
+        }
+        else {
+            // if not in streaming, go directly to the "approve" page
+            context.currentPage = context.nbPages - 2;
+            displayReviewPage(FORWARD_DIRECTION);
+        }
         return;
     }
     else {
         return;
     }
-    displayStreamingReviewPage(pos);
+    // the first tag/value page is at page 0 only in streaming case
+    if (context.firstPairPage == 0) {
+        displayStreamingReviewPage(pos);
+    }
+    else {
+        displayReviewPage(pos);
+    }
 }
 
 // this is the callback used when buttons in "Action" use case are pressed
@@ -1136,8 +1157,28 @@ static void displayReviewPage(nbgl_stepPosition_t pos)
         subText = context.review.address;
     }
     else {
-        bool isCenteredInfo = false;
-        pairIndex           = context.currentPage - reviewPages;
+        // if there is a skip, and we are not already displaying the "skip" page
+        // and we are not at the first tag/value of the first set of data (except if going
+        // backward) then display the "skip" page
+        if ((context.operationType & SKIPPABLE_OPERATION) && (context.review.skipDisplay == false)
+            && ((context.currentPage > reviewPages)
+                || (context.review.dataDirection == BACKWARD_DIRECTION))) {
+            nbgl_stepPosition_t       directions = (pos & BACKWARD_DIRECTION) | FIRST_STEP;
+            nbgl_layoutCenteredInfo_t info       = {0};
+            if ((context.review.nbDataSets == 1) || (context.currentPage > 0)) {
+                directions |= LAST_STEP;
+            }
+            info.icon  = &C_Information_circle_14px;
+            info.text1 = "Press right button to continue message or \bpress both to skip\b";
+            nbgl_stepDrawCenteredInfo(directions, buttonSkipCallback, NULL, &info, false);
+            nbgl_refresh();
+            context.review.skipDisplay = true;
+            context.firstPairPage      = reviewPages;
+            return;
+        }
+        context.review.skipDisplay = false;
+        bool isCenteredInfo        = false;
+        pairIndex                  = context.currentPage - reviewPages;
         if (context.review.address != NULL) {
             pairIndex--;
         }


### PR DESCRIPTION
## Description

The goal of this PR is to allow skippable operations for non-streaming reviews
It also fixes a possible issue in string drawing when using \b in Apps

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

