### PR TITLE
Allow skippable operation for non-streaming reviews

### DIFF
--- a/lib_nbgl/src/nbgl_draw.c
+++ b/lib_nbgl/src/nbgl_draw.c
@@ -677,14 +677,14 @@ nbgl_font_id_e nbgl_drawText(const nbgl_area_t *area,
                 if (fontId == BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp) {  // switch to bold
                     fontId = BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                    unicode_ctx = nbgl_getUnicodeFont(fontId);
+                    unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                     font = (const nbgl_font_t *) nbgl_getFont(fontId);
                 }
                 else if (fontId == BAGL_FONT_OPEN_SANS_EXTRABOLD_11px_1bpp) {  // switch to regular
                     fontId = BAGL_FONT_OPEN_SANS_REGULAR_11px_1bpp;
 #ifdef HAVE_UNICODE_SUPPORT
-                    unicode_ctx = nbgl_getUnicodeFont(fontId);
+                    unicode_ctx = NULL;
 #endif  // HAVE_UNICODE_SUPPORT
                     font = (const nbgl_font_t *) nbgl_getFont(fontId);
                 }

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1250,6 +1250,12 @@ static void displayGenericContextPage(uint8_t pageIdx, bool forceFullRefresh)
             return;
         }
     }
+    else {
+        // if coming from Skip modal, let's say we are at the last page
+        if (pageIdx == LAST_PAGE_FOR_REVIEW) {
+            pageIdx = navInfo.nbPages - 1;
+        }
+    }
 
     if (navInfo.activePage == pageIdx) {
         p_content
@@ -1274,6 +1280,18 @@ static void displayGenericContextPage(uint8_t pageIdx, bool forceFullRefresh)
 
     if (p_content == NULL) {
         return;
+    }
+    // if the operation is skippable
+    if (bundleNavContext.review.operationType & SKIPPABLE_OPERATION) {
+        // only present the "Skip" header on actual tag/value pages
+        if ((pageIdx > 0) && (pageIdx < (navInfo.nbPages - 1))) {
+            navInfo.progressIndicator = false;
+            navInfo.skipText          = "Skip";
+            navInfo.skipToken         = SKIP_TOKEN;
+        }
+        else {
+            navInfo.skipText = NULL;
+        }
     }
 
     // Create next page content


### PR DESCRIPTION
## Description

The goal of this PR is to allow skippable operations for non-streaming reviews
It also fixes a possible issue in string drawing when using \b in Apps

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
