### PR TITLE
Fix missing "Skip" in first page of streaming review

### DIFF
--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1282,7 +1282,8 @@ static void displayGenericContextPage(uint8_t pageIdx, bool forceFullRefresh)
         return;
     }
     // if the operation is skippable
-    if (bundleNavContext.review.operationType & SKIPPABLE_OPERATION) {
+    if ((navType != STREAMING_NAV)
+        && (bundleNavContext.review.operationType & SKIPPABLE_OPERATION)) {
         // only present the "Skip" header on actual tag/value pages
         if ((pageIdx > 0) && (pageIdx < (navInfo.nbPages - 1))) {
             navInfo.progressIndicator = false;


### PR DESCRIPTION
## Description

The goal of this PR is to fix missing "Skip" in first page of streaming review

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_24
[x] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
