### PR TITLE
Detect when a title is displayed on too many lines

### DIFF
--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -2623,9 +2623,13 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
                                                textArea->obj.area.width,
                                                textArea->wrapping)
                     > nbMaxLines) {
+                    textArea->obj.area.height
+                        = nbMaxLines * nbgl_getFontLineHeight(textArea->fontId);
+#ifndef BUILD_SCREENSHOTS
                     LOG_WARN(LAYOUT_LOGGER,
                              "nbgl_layoutAddHeader: text [%s] is too long for header\n",
                              text);
+#endif  // BUILD_SCREENSHOTS
                 }
                 if (headerDesc->type == HEADER_BACK_ICON_AND_TEXT) {
                     textArea->obj.area.width = nbgl_getTextWidth(textArea->fontId, textArea->text);


### PR DESCRIPTION
## Description

This PR improve the way strings are checked and allow detecting when a title contains too many lines.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
