### PR TITLE
remove deprecated keypad functions

### DIFF
--- a/lib_nbgl/doc/nbgl_use_case.dox
+++ b/lib_nbgl/doc/nbgl_use_case.dox
@@ -56,8 +56,7 @@ A few APIs are available to draw typical Use-Cases, such as:
 - for address verification:
  - @ref nbgl_useCaseAddressReview() to draw an address confirmation page, with a possibility to see it as QR Code and some extra tag/value pairs (see @subpage use_case_addr_review)
 - for keypad:
- - @ref nbgl_useCaseKeypadPIN() to draw a default keypad implementation with hidden digits (see @subpage use_case_keypad)
- - @ref nbgl_useCaseKeypadDigits() to draw a default keypad implementation, showing digits (see @subpage use_case_keypad)
+ - @ref nbgl_useCaseKeypad() to draw a default keypad implementation (see @subpage use_case_keypad)
 - for generic navigable content:
  - @ref nbgl_useCaseNavigableContent() to draw a level of generic content navigable pages
 
@@ -697,17 +696,13 @@ As shown on the image above, it consists of:
 - a hidden Digits area (the max nb of supported digits is 12)
 - the keypad at the bottom
 
-The @ref nbgl_useCaseKeypadPIN() function enables to create such page, with the following parameters:
+The @ref nbgl_useCaseKeypad() function enables to create such page, with the following parameters:
 
-- the title
+- a title
 - min and max pin code lengths
-- a token for the navigation callback (if not provided, no navigation bar will appear)
 - a boolean to request a shuffled keypad
-- a tune value
+- a boolean to request \b hidden digits
 - callbacks for navigation and pin validation
-
-The other variant, where digits don't need to be hidden is @ref nbgl_useCaseKeypadDigits();
-it takes the same parameters.
 
 @note The \em backspace and \em validate buttons will be shown or hidden automatically.
 
@@ -718,24 +713,19 @@ static void validate_pin(const uint8_t *pinentry, uint8_t length) {
     // Code to validate the entered pin code
 }
 
-static void pinentry_cb(int token, uint8_t index) {
-    UNUSED(index);
-    // Callback for the key navigation (back key mainly)
-    if (token == TOKEN_PIN_ENTRY_BACK) {
-        ui_init();
-    }
+static void quit_cb() {
+    // Back to the main app menu
 }
 
 void ui_menu_pinentry_display(unsigned int value) {
     // Draw the keypad
-    nbgl_useCaseKeypadPIN("Enter User PIN",
-                          6,
-                          12,
-                          TOKEN_PIN_ENTRY_BACK,
-                          false,
-                          TUNE_TAP_CASUAL,
-                          validate_pin,
-                          pinentry_cb);
+    nbgl_useCaseKeypad("PIN Keypad (5555)",
+                       4,
+                       4,
+                       false,
+                       true,
+                       validate_pin,
+                       quit_cb);
 }
 @endcode
 

--- a/lib_nbgl/doc/nbgl_use_case_nanos.dox
+++ b/lib_nbgl/doc/nbgl_use_case_nanos.dox
@@ -55,8 +55,7 @@ A few APIs are available to draw typical Use-Cases, such as:
 - For address verification:
  - @ref nbgl_useCaseAddressReview() to draw an address confirmation page, with a possibility to see some extra tag/value pairs (see @subpage use_case_addr_review)
 - For keypad:
- - @ref nbgl_useCaseKeypadPIN() to draw a default keypad implementation with hidden digits (see @subpage use_case_keypad)
- - @ref nbgl_useCaseKeypadDigits() to draw a default keypad implementation, showing digits (see @subpage use_case_keypad)
+ - @ref nbgl_useCaseKeypad() to draw a default keypad implementation (see @subpage use_case_keypad)
 - For generic navigable content:
  - @ref nbgl_useCaseNavigableContent() to draw a level of generic content navigable pages
 
@@ -593,15 +592,13 @@ We have here 2 different variants, allowing to \b show or \b hide the entered di
 
 When a pincode is requested, a default keypad can be displayed, with hidden digits.
 
-The @ref nbgl_useCaseKeypadPIN() function enables to create such page, with the following parameters:
+The @ref nbgl_useCaseKeypad() function enables to create such page, with the following parameters:
 
 - A title
 - The min and max lengths
 - A boolean to request a *shuffled* keypad
+- A boolean to request \b hidden digits
 - Callbacks for navigation and pin validation
-
-The other variant, where digits don't need to be hidden is @ref nbgl_useCaseKeypadDigits();
-it takes the same parameters.
 
 @note The \em backspace and \em validate buttons will be shown or hidden automatically.
 @note The \em backspace button is also used as a *cancel* button, when no digits are selected.
@@ -620,12 +617,13 @@ static void quit_cb() {
 
 void ui_menu_pinentry_display(unsigned int value) {
     // Draw the keypad
-    nbgl_useCaseKeypadPIN("PIN Keypad (5555)",
-                          4,
-                          4,
-                          false,
-                          validate_pin,
-                          quit_cb);
+    nbgl_useCaseKeypad("PIN Keypad (5555)",
+                       4,
+                       4,
+                       false,
+                       true,
+                       validate_pin,
+                       quit_cb);
 }
 @endcode
 

--- a/lib_nbgl/include/nbgl_use_case.h
+++ b/lib_nbgl/include/nbgl_use_case.h
@@ -574,40 +574,6 @@ DEPRECATED void nbgl_useCaseAddressConfirmationExt(const char                   
     nbgl_useCaseAddressConfirmationExt(__address, __callback, NULL)
 #endif  // HAVE_SE_TOUCH
 
-#ifdef NBGL_KEYPAD
-#ifdef HAVE_SE_TOUCH
-DEPRECATED void nbgl_useCaseKeypadDigits(const char                *title,
-                                         uint8_t                    minDigits,
-                                         uint8_t                    maxDigits,
-                                         uint8_t                    backToken,
-                                         bool                       shuffled,
-                                         tune_index_e               tuneId,
-                                         nbgl_pinValidCallback_t    validatePinCallback,
-                                         nbgl_layoutTouchCallback_t actionCallback);
-DEPRECATED void nbgl_useCaseKeypadPIN(const char                *title,
-                                      uint8_t                    minDigits,
-                                      uint8_t                    maxDigits,
-                                      uint8_t                    backToken,
-                                      bool                       shuffled,
-                                      tune_index_e               tuneId,
-                                      nbgl_pinValidCallback_t    validatePinCallback,
-                                      nbgl_layoutTouchCallback_t actionCallback);
-#else   // HAVE_SE_TOUCH
-DEPRECATED void nbgl_useCaseKeypadDigits(const char             *title,
-                                         uint8_t                 minDigits,
-                                         uint8_t                 maxDigits,
-                                         bool                    shuffled,
-                                         nbgl_pinValidCallback_t validatePinCallback,
-                                         nbgl_callback_t         backCallback);
-DEPRECATED void nbgl_useCaseKeypadPIN(const char             *title,
-                                      uint8_t                 minDigits,
-                                      uint8_t                 maxDigits,
-                                      bool                    shuffled,
-                                      nbgl_pinValidCallback_t validatePinCallback,
-                                      nbgl_callback_t         backCallback);
-#endif  // HAVE_SE_TOUCH
-#endif  // NBGL_KEYPAD
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1875,10 +1875,6 @@ static void keypadGeneric_cb(int token, uint8_t index)
     }
     onQuit();
 }
-static void old_keypadCallback(void)
-{
-    keypadGeneric_cb(BACK_TOKEN, 0);
-}
 #endif
 
 /**
@@ -4531,39 +4527,6 @@ void nbgl_useCaseKeypad(const char             *title,
     nbgl_layoutDraw(keypadContext.layoutCtx);
     nbgl_refreshSpecialWithPostRefresh(FULL_COLOR_CLEAN_REFRESH, POST_REFRESH_FORCE_POWER_ON);
 }
-
-void nbgl_useCaseKeypadDigits(const char                *title,
-                              uint8_t                    minDigits,
-                              uint8_t                    maxDigits,
-                              uint8_t                    backToken,
-                              bool                       shuffled,
-                              tune_index_e               tuneId,
-                              nbgl_pinValidCallback_t    validatePinCallback,
-                              nbgl_layoutTouchCallback_t actionCallback)
-{
-    UNUSED(backToken);
-    UNUSED(tuneId);
-    UNUSED(actionCallback);
-    nbgl_useCaseKeypad(
-        title, minDigits, maxDigits, shuffled, false, validatePinCallback, old_keypadCallback);
-}
-
-void nbgl_useCaseKeypadPIN(const char                *title,
-                           uint8_t                    minDigits,
-                           uint8_t                    maxDigits,
-                           uint8_t                    backToken,
-                           bool                       shuffled,
-                           tune_index_e               tuneId,
-                           nbgl_pinValidCallback_t    validatePinCallback,
-                           nbgl_layoutTouchCallback_t actionCallback)
-{
-    UNUSED(backToken);
-    UNUSED(tuneId);
-    UNUSED(actionCallback);
-    nbgl_useCaseKeypad(
-        title, minDigits, maxDigits, shuffled, true, validatePinCallback, old_keypadCallback);
-}
-
 #endif  // NBGL_KEYPAD
 
 #endif  // HAVE_SE_TOUCH

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -2972,29 +2972,6 @@ void nbgl_useCaseKeypad(const char             *title,
     }
     nbgl_refresh();
 }
-
-void nbgl_useCaseKeypadDigits(const char             *title,
-                              uint8_t                 minDigits,
-                              uint8_t                 maxDigits,
-                              bool                    shuffled,
-                              nbgl_pinValidCallback_t validatePinCallback,
-                              nbgl_callback_t         backCallback)
-{
-    nbgl_useCaseKeypad(
-        title, minDigits, maxDigits, shuffled, false, validatePinCallback, backCallback);
-}
-
-void nbgl_useCaseKeypadPIN(const char             *title,
-                           uint8_t                 minDigits,
-                           uint8_t                 maxDigits,
-                           bool                    shuffled,
-                           nbgl_pinValidCallback_t validatePinCallback,
-                           nbgl_callback_t         backCallback)
-{
-    nbgl_useCaseKeypad(
-        title, minDigits, maxDigits, shuffled, true, validatePinCallback, backCallback);
-}
-
 #endif  // NBGL_KEYPAD
 
 #endif  // HAVE_SE_TOUCH


### PR DESCRIPTION
## Description

Remove
- `nbgl_useCaseKeypadPIN`
- `nbgl_useCaseKeypadDigits`
Now, a sngloe API is available: `nbgl_useCaseKeypad`

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

