### PR TITLE
Cleanup lib_cxng to clearly identify (and use) API header and not internal header

### DIFF
--- a/lib_cxng/include/lcx_blake2.h
+++ b/lib_cxng/include/lcx_blake2.h
@@ -213,6 +213,50 @@ DEPRECATED static inline int cx_blake2b_init2(cx_blake2b_t  *hash,
     CX_THROW(cx_blake2b_init2_no_throw(hash, out_len, salt, salt_len, perso, perso_len));
     return CX_BLAKE2B;
 }
+/**
+ * @brief Update blake2 computation with given buffer
+ *
+ * @param ctx[in/out] context initialized with #cx_blake2b_init2_no_throw
+ * @param data[in] data to add in computation
+ * @param len[in] len of data in bytes
+ * @return WARN_UNUSED_RESULT
+ */
+WARN_UNUSED_RESULT cx_err_t cx_blake2b_update(cx_blake2b_t *ctx, const uint8_t *data, size_t len);
+
+/**
+ * @brief Finalize blake2 computation
+ *
+ * @param ctx[in] context initialized with #cx_blake2b_init2_no_throw
+ * @param digest[out] output digest (size can be retrieved with #cx_blake2b_get_output_size)
+ * @return cx_err_t
+ */
+cx_err_t cx_blake2b_final(cx_blake2b_t *ctx, uint8_t *digest);
+
+/**
+ * @brief Get output size of blake2 digest
+ *
+ * @param ctx [in] context initialized with #cx_blake2b_init2_no_throw
+ * @return size in bytes
+ */
+size_t cx_blake2b_get_output_size(const cx_blake2b_t *ctx);
+
+/**
+ * @brief hash the given input buffer with BLAKE2
+ *
+ * @param hash hash context
+ * @param mode
+ * @param in input buffer to hash
+ * @param in_len length in bytes of input buffer
+ * @param out output buffer to store hash
+ * @param out_len length in bytes of output buffer
+ * @return INVALID_PARAMETER or CX_OK
+ */
+WARN_UNUSED_RESULT cx_err_t cx_blake2b(cx_hash_t     *hash,
+                                       uint32_t       mode,
+                                       const uint8_t *in,
+                                       size_t         in_len,
+                                       uint8_t       *out,
+                                       size_t         out_len);
 
 #endif  // HAVE_BLAKE2
 

--- a/lib_cxng/include/lcx_ecfp.h
+++ b/lib_cxng/include/lcx_ecfp.h
@@ -557,6 +557,44 @@ DEPRECATED static inline void cx_edward_decompress_point(cx_curve_t curve, uint8
 
 #endif  // HAVE_ECC_TWISTED_EDWARDS
 
+/**
+ * @brief Encode the signature of the given
+ *
+ * @param sig[out] output buffer in which to store signature
+ * @param sig_len[in] max len of sig
+ * @param r[in]
+ * @param r_len[in] len of r buffer
+ * @param s[in]
+ * @param s_len[in]  len of s buffer
+ * @return real len of signature
+ */
+size_t cx_ecfp_encode_sig_der(uint8_t       *sig,
+                              size_t         sig_len,
+                              const uint8_t *r,
+                              size_t         r_len,
+                              const uint8_t *s,
+                              size_t         s_len);
+
+/**
+ * @brief Decode the given signature
+ *
+ * @param sig[in] input signature to decode
+ * @param sig_len[in]
+ * @param max_size[in]
+ * @param r[out] buffer in which to store decoded R
+ * @param r_len[out] len of r buffer
+ * @param s[out] buffer in which to store decoded S
+ * @param s_len[out] len of s buffer
+ * @return 0 if error
+ */
+int cx_ecfp_decode_sig_der(const uint8_t  *sig,
+                           size_t          sig_len,
+                           size_t          max_size,
+                           const uint8_t **r,
+                           size_t         *r_len,
+                           const uint8_t **s,
+                           size_t         *s_len);
+
 #endif  // HAVE_ECC
 
 #endif  // LCX_ECFP_H

--- a/lib_cxng/include/lcx_eddsa.h
+++ b/lib_cxng/include/lcx_eddsa.h
@@ -340,6 +340,28 @@ bool cx_eddsa_verify_hash(const cx_ecfp_public_key_t *public_key,
                           const uint8_t              *signature,
                           size_t                      signature_len);
 
+/**
+ * @brief Get the public key from the given private key and hash
+ *
+ * @param[in] pv_key    Private key.
+ * @param[in] hashID       hash identifier to use.
+ * @param[out] pu_key      output public key
+ * @param[out] a     Secret scalar a (can be null)
+ * @param[out] a_len len of a
+ * @param[out] h     Secret scalar h (can be null)
+ * @param[out] h_len eln of h
+ * @param[out] scal full secret scalar
+ * @return error code or CX_OK
+ */
+WARN_UNUSED_RESULT cx_err_t cx_eddsa_get_public_key_internal(const cx_ecfp_private_key_t *pv_key,
+                                                             cx_md_t                      hashID,
+                                                             cx_ecfp_public_key_t        *pu_key,
+                                                             uint8_t                     *a,
+                                                             size_t                       a_len,
+                                                             uint8_t                     *h,
+                                                             size_t                       h_len,
+                                                             uint8_t *scal /*temp uint8[114]*/);
+
 #endif  // HAVE_EDDSA
 
 #endif  // LCX_EDDSA_H

--- a/lib_cxng/include/lcx_hash.h
+++ b/lib_cxng/include/lcx_hash.h
@@ -74,6 +74,10 @@ enum cx_md_e {
     CX_SHA3_256 = 12,  ///< SHA3-256 digest
     CX_SHA3_512 = 13,  ///< SHA3-512 digest
 };
+
+#define SHA256_BLOCK_SIZE 64
+#define SHA512_BLOCK_SIZE 128
+
 /** Convenience type. See #cx_md_e. */
 typedef enum cx_md_e cx_md_t;
 
@@ -234,6 +238,51 @@ WARN_UNUSED_RESULT cx_err_t cx_hash_update(cx_hash_t *hash, const uint8_t *in, s
  *                    - CX_OK on success
  */
 WARN_UNUSED_RESULT cx_err_t cx_hash_final(cx_hash_t *hash, uint8_t *digest);
+
+/**
+ * @brief get information about a hash method
+ *
+ * @param md_type method for hash
+ * @return const cx_hash_info_t*
+ */
+const cx_hash_info_t *cx_hash_get_info(cx_md_t md_type);
+
+/**
+ * @brief HMAC-Based Key Kerivation Function defined at https://tools.ietf.org/html/rfc5869
+ * Used to implement the EIP-2333 for BLS12-381 key generation
+ *
+ * @param hash_id[in] Hash algo to use
+ * @param ikm[in]  Key to derive
+ * @param ikm_len[in] len of ikm
+ * @param salt[in] Salt to use
+ * @param salt_len[in] len of salt
+ * @param prk[out] output key
+ */
+void cx_hkdf_extract(const cx_md_t        hash_id,
+                     const unsigned char *ikm,
+                     unsigned int         ikm_len,
+                     unsigned char       *salt,
+                     unsigned int         salt_len,
+                     unsigned char       *prk);
+
+/**
+ * @brief Expand function (TBC)
+ *
+ * @param hash_id[in] Hash algo to use
+ * @param prk[in] Input key
+ * @param prk_len[in] len of prk
+ * @param info[in]
+ * @param info_len[in]
+ * @param okm[out] Output key
+ * @param okm_len[in] Max output key len
+ */
+void cx_hkdf_expand(const cx_md_t        hash_id,
+                    const unsigned char *prk,
+                    unsigned int         prk_len,
+                    unsigned char       *info,
+                    unsigned int         info_len,
+                    unsigned char       *okm,
+                    unsigned int         okm_len);
 
 #endif  // HAVE_HASH
 

--- a/lib_cxng/include/lcx_pbkdf2.h
+++ b/lib_cxng/include/lcx_pbkdf2.h
@@ -119,6 +119,39 @@ DEPRECATED static inline void cx_pbkdf2(cx_md_t              md_type,
 #define cx_pbkdf2_sha512(password, password_len, salt, salt_len, iterations, out, out_len) \
     cx_pbkdf2_no_throw(CX_SHA512, password, password_len, salt, salt_len, iterations, out, out_len)
 
+/**
+ * @brief Computes a PBKDF2 bytes sequence with the given Message digest algorithm.
+ *
+ * @details It computes the bytes sequence according to
+ *          <a href="https://tools.ietf.org/html/rfc2898">  RFC 2898 </a>
+ *          with SHA512 as the underlying hash function.
+ *
+ * @param[in]  md_type      Message digest algorithm identifier
+ * @param[in]  password     Password used as a base key to compute
+ *                          the HMAC.
+ *
+ * @param[in]  password_len Length of the password i.e. the length
+ *                          of the HMAC key.
+ *
+ * @param[in]  salt         Initial salt.
+ *
+ * @param[in]  salt_len     Length of the salt.
+ * @param[in]  iterations   Per block iteration.
+ * @param[out] key key buffer
+ * @param[in] key_len Length of the key buffer.
+ * @return                  Error code:
+ *                          - CX_OK
+ *                          - CX_INVALID_PARAMETER
+ */
+WARN_UNUSED_RESULT cx_err_t cx_pbkdf2_hmac(cx_md_t        md_type,
+                                           const uint8_t *password,
+                                           size_t         password_len,
+                                           const uint8_t *salt,
+                                           size_t         salt_len,
+                                           uint32_t       iterations,
+                                           uint8_t       *key,
+                                           size_t         key_len);
+
 #endif  // HAVE_PBKDF2
 
 #endif  // LCX_PBKDF2_H

--- a/lib_cxng/include/lcx_poly1305.h
+++ b/lib_cxng/include/lcx_poly1305.h
@@ -50,6 +50,95 @@ typedef struct {
     size_t   block_len;  ///< The number of bytes stored in 'block'
 } cx_poly1305_context_t;
 
+/**
+ * @brief           Initialize the specified Poly1305 context.
+ *
+ * @details         It must be the first API called before using
+ *                  the context.
+ *
+ *                  It is usually followed by a call to
+ *                  #cx_poly1305_set_key, then one or more calls to
+ *                  #cx_poly1305_update, then one call to
+ *                  #cx_poly1305_finish
+ *
+ * @param ctx       The Poly1305 context to initialize. This must
+ *                  not be \c NULL.
+ */
+void cx_poly1305_init(cx_poly1305_context_t *ctx);
+
+/**
+ * @brief           Set the one-time authentication key.
+ *
+ * @warning         The key must be unique and unpredictable for each
+ *                  invocation of Poly1305.
+ *
+ * @param ctx       The Poly1305 context to which the key should be bound.
+ *                  This must be initialized.
+ *
+ * @param key       Pointer to the buffer containing the \c 32 byte (\c 256 bit) key.
+ *
+ */
+void cx_poly1305_set_key(cx_poly1305_context_t *ctx, const uint8_t *key);
+
+/**
+ * @brief           Update the Poly1305 computation given an input buffer.
+ *
+ * @details         It is called between #cx_poly1305_set_key() and
+ *                  #cx_poly1305_finish().
+ *                  It can be called repeatedly to process a stream of data.
+ *
+ * @param ctx       The Poly1305 context to use for the Poly1305 operation.
+ *                  This must be initialized and bound to a key.
+ *
+ * @param input     Pointer to the buffer holding the input data.
+ *                  This pointer can be \c NULL if `in_len == 0`.
+ *
+ * @param in_len    The length of the input data in bytes.
+ *
+ * @return          Error code
+ */
+WARN_UNUSED_RESULT cx_err_t cx_poly1305_update(cx_poly1305_context_t *ctx,
+                                               const uint8_t         *input,
+                                               size_t                 in_len);
+
+/**
+ * @brief           Generate the Poly1305 Message
+ *                  Authentication Code (MAC).
+ *
+ * @param ctx       The Poly1305 context to use for the Poly1305 operation.
+ *                  This must be initialized and bound to a key.
+ *
+ * @param tag       Pointer to the buffer to where the MAC is written. This must
+ *                  be a writable buffer of length \c 16 bytes.
+ *
+ * @return          Error code.
+ */
+WARN_UNUSED_RESULT cx_err_t cx_poly1305_finish(cx_poly1305_context_t *ctx, uint8_t *tag);
+
+/**
+ * @brief           Calculate the Poly1305 MAC of the input
+ *                  buffer with the provided key.
+ *
+ * @warning         The key must be unique and unpredictable for each
+ *                  invocation of Poly1305.
+ *
+ * @param key       Pointer to the buffer containing the \c 32 byte (\c 256 bit) key.
+ *
+ * @param input     Pointer to the buffer holding the input data.
+ *                  This pointer can be \c NULL if `in_len == 0`.
+ *
+ * @param in_len    Length of the input data in bytes.
+ *
+ * @param tag       Pointer to the buffer to where the MAC is written.
+ *                  This must be a writable buffer of length \c 16 bytes.
+ *
+ * @return          Error code
+ */
+WARN_UNUSED_RESULT cx_err_t cx_poly1305_mac(const uint8_t *key,
+                                            const uint8_t *input,
+                                            size_t         in_len,
+                                            uint8_t       *tag);
+
 #endif  // HAVE_POLY1305
 
 #endif  // LCX_POLY1305_H

--- a/lib_cxng/include/lcx_ripemd160.h
+++ b/lib_cxng/include/lcx_ripemd160.h
@@ -130,6 +130,27 @@ static inline cx_err_t cx_ripemd160_hash(const uint8_t *in,
  */
 size_t cx_hash_ripemd160(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_len);
 
+/**
+ * @brief Update RIPEMD160 digest initialized with #cx_ripemd160_init_no_throw
+ *
+ * @param ctx[in] context initialized with #cx_ripemd160_init_no_throw
+ * @param data[in] data to add in RIPEMD160 digest
+ * @param len[in] len of data
+ * @return error or CX_OK
+ */
+WARN_UNUSED_RESULT cx_err_t cx_ripemd160_update(cx_ripemd160_t *ctx,
+                                                const uint8_t  *data,
+                                                size_t          len);
+
+/**
+ * @brief Finalize RIPEMD160 digest initialized with #cx_ripemd160_init_no_throw
+ *
+ * @param ctx[in] context initialized with #cx_ripemd160_init_no_throw
+ * @param digest[out] output digest
+ * @return error or CX_OK
+ */
+WARN_UNUSED_RESULT cx_err_t cx_ripemd160_final(cx_ripemd160_t *ctx, uint8_t *digest);
+
 #endif  // HAVE_RIPEMD160
 
 #endif  // LCX_RIPEMD160_H

--- a/lib_cxng/include/lcx_sha256.h
+++ b/lib_cxng/include/lcx_sha256.h
@@ -147,6 +147,25 @@ static inline int cx_sha256_init(cx_sha256_t *hash)
 }
 
 /**
+ * @brief  Update the current SHA256 operation with the given buffer
+ *
+ * @param ctx context initialized with @ref cx_sha256_init
+ * @param data buffer to add
+ * @param len length in bytes of the data buffer
+ * @return result of the operation
+ */
+WARN_UNUSED_RESULT cx_err_t cx_sha256_update(cx_sha256_t *ctx, const uint8_t *data, size_t len);
+
+/**
+ * @brief Finalizes the current SHA256 and produce the given digest
+ *
+ * @param ctx  context initialized with @ref cx_sha256_init
+ * @param digest (output) output digest (@ref CX_SHA256_SIZE bytes)
+ * @return always CX_OK
+ */
+cx_err_t cx_sha256_final(cx_sha256_t *ctx, uint8_t *digest);
+
+/**
  * @brief   Computes a standalone one shot SHA-256 digest.
  *
  * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.

--- a/lib_cxng/include/lcx_sha3.h
+++ b/lib_cxng/include/lcx_sha3.h
@@ -617,6 +617,33 @@ DEPRECATED static inline int cx_sha3_xof_init(cx_sha3_t   *hash,
     }
 }
 
+/**
+ * @brief Update a sha3 hash initialized with #cx_sha3_init_no_throw
+ *
+ * @param ctx[in] context initialized with #cx_sha3_init_no_throw
+ * @param data[in] data to add to hah
+ * @param len[in] length of data
+ * @return error code or CX_OK
+ */
+WARN_UNUSED_RESULT cx_err_t cx_sha3_update(cx_sha3_t *ctx, const uint8_t *data, size_t len);
+
+/**
+ * @brief Finalize a sha3 hash initialized with #cx_sha3_init_no_throw
+ *
+ * @param ctx[in] context initialized with #cx_sha3_init_no_throw
+ * @param digest[out] hash output
+ * @return error code or CX_OK
+ */
+cx_err_t cx_sha3_final(cx_sha3_t *ctx, uint8_t *digest);
+
+/**
+ * @brief Get size in bytes of the hash output
+ *
+ * @param ctx [in] context initialized with #cx_sha3_init_no_throw
+ * @return size in bytes
+ */
+size_t cx_sha3_get_output_size(const cx_sha3_t *ctx);
+
 #endif  // HAVE_SHA3
 
 #endif  // LCX_SHA3_H

--- a/lib_cxng/include/lcx_sha512.h
+++ b/lib_cxng/include/lcx_sha512.h
@@ -139,6 +139,25 @@ static inline int cx_sha512_init(cx_sha512_t *hash)
 }
 
 /**
+ * @brief  Update the current SHA512 operation with the given buffer
+ *
+ * @param ctx context initialized with @ref cx_sha512_init
+ * @param data buffer to add
+ * @param len length in bytes of the data buffer
+ * @return result of the operation
+ */
+WARN_UNUSED_RESULT cx_err_t cx_sha512_update(cx_sha512_t *ctx, const uint8_t *data, size_t len);
+
+/**
+ * @brief Finalizes the current SHA512 and produce the given digest
+ *
+ * @param ctx  context initialized with @ref cx_sha512_init
+ * @param digest (output) output digest (@ref CX_SHA512_SIZE bytes)
+ * @return always CX_OK
+ */
+cx_err_t cx_sha512_final(cx_sha512_t *ctx, uint8_t *digest);
+
+/**
  * @brief   Computes a standalone one shot SHA-512 digest.
  *
  * @param[in]  iovec     Input data in the form of an array of cx_iovec_t.

--- a/lib_cxng/src/cx_Groestl-ref.h
+++ b/lib_cxng/src/cx_Groestl-ref.h
@@ -273,9 +273,6 @@ typedef enum {
 } HashReturn;
 /* NIST API end */
 
-/* helper functions */
-void PrintHash(BitSequence *, int);
-
 #endif /* __groestl_ref_h */
 
 #endif  // HAVE_GROESTL

--- a/lib_cxng/src/cx_blake2.h
+++ b/lib_cxng/src/cx_blake2.h
@@ -39,55 +39,6 @@ enum blake2s_constant {
     BLAKE2S_PERSONALBYTES = 8
 };
 
-/* move to cx.h */
-/*enum blake2b_constant
- {
-   BLAKE2B_BLOCKBYTES = 128,
-   BLAKE2B_OUTBYTES   = 64,
-   BLAKE2B_KEYBYTES   = 64,
-   BLAKE2B_SALTBYTES  = 16,
-   BLAKE2B_PERSONALBYTES = 16
- };
-*/
-typedef struct blake2s_state__ {
-    uint32_t h[8];
-    uint32_t t[2];
-    uint32_t f[2];
-    uint8_t  buf[BLAKE2S_BLOCKBYTES];
-    size_t   buflen;
-    size_t   outlen;
-    uint8_t  last_node;
-} blake2s_state;
-
-/* move to cx.h */
-/*
-typedef struct blake2b_state__
-{
-  uint64_t h[8];
-  uint64_t t[2];
-  uint64_t f[2];
-  uint8_t  buf[BLAKE2B_BLOCKBYTES];
-  size_t   buflen;
-  size_t   outlen;
-  uint8_t  last_node;
-} blake2b_state;
-*/
-typedef struct blake2sp_state__ {
-    blake2s_state S[8][1];
-    blake2s_state R[1];
-    uint8_t       buf[8 * BLAKE2S_BLOCKBYTES];
-    size_t        buflen;
-    size_t        outlen;
-} blake2sp_state;
-
-typedef struct blake2bp_state__ {
-    blake2b_state S[4][1];
-    blake2b_state R[1];
-    uint8_t       buf[4 * BLAKE2B_BLOCKBYTES];
-    size_t        buflen;
-    size_t        outlen;
-} blake2bp_state;
-
 BLAKE2_PACKED(struct blake2s_param__ {
     uint8_t  digest_length; /* 1 */
     uint8_t  key_length;    /* 2 */
@@ -122,16 +73,6 @@ BLAKE2_PACKED(struct blake2b_param__ {
 
 typedef struct blake2b_param__ blake2b_param;
 
-typedef struct blake2xs_state__ {
-    blake2s_state S[1];
-    blake2s_param P[1];
-} blake2xs_state;
-
-typedef struct blake2xb_state__ {
-    blake2b_state S[1];
-    blake2b_param P[1];
-} blake2xb_state;
-
 /* Padded structs result in a compile-time error */
 enum {
     BLAKE2_DUMMY_1 = 1 / (sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
@@ -139,11 +80,6 @@ enum {
 };
 
 /* Streaming API */
-int blake2s_init(blake2s_state *S, size_t outlen);
-int blake2s_init_key(blake2s_state *S, size_t outlen, const void *key, size_t keylen);
-int blake2s_init_param(blake2s_state *S, const blake2s_param *P);
-int blake2s_update(blake2s_state *S, const void *in, size_t inlen);
-int blake2s_final(blake2s_state *S, void *out, size_t outlen);
 
 int  blake2b_init(blake2b_state *S,
                   size_t         outlen,
@@ -156,56 +92,8 @@ int  blake2b_init_param(blake2b_state *S, const blake2b_param *P);
 void blake2b_update(blake2b_state *S, const void *in, size_t inlen);
 int  blake2b_final(blake2b_state *S, void *out, size_t outlen);
 
-int blake2sp_init(blake2sp_state *S, size_t outlen);
-int blake2sp_init_key(blake2sp_state *S, size_t outlen, const void *key, size_t keylen);
-int blake2sp_update(blake2sp_state *S, const void *in, size_t inlen);
-int blake2sp_final(blake2sp_state *S, void *out, size_t outlen);
-
-int blake2bp_init(blake2bp_state *S, size_t outlen);
-int blake2bp_init_key(blake2bp_state *S, size_t outlen, const void *key, size_t keylen);
-int blake2bp_update(blake2bp_state *S, const void *in, size_t inlen);
-int blake2bp_final(blake2bp_state *S, void *out, size_t outlen);
-
-/* Variable output length API */
-int blake2xs_init(blake2xs_state *S, const size_t outlen);
-int blake2xs_init_key(blake2xs_state *S, const size_t outlen, const void *key, size_t keylen);
-int blake2xs_update(blake2xs_state *S, const void *in, size_t inlen);
-int blake2xs_final(blake2xs_state *S, void *out, size_t outlen);
-
-int blake2xb_init(blake2xb_state *S, const size_t outlen);
-int blake2xb_init_key(blake2xb_state *S, const size_t outlen, const void *key, size_t keylen);
-int blake2xb_update(blake2xb_state *S, const void *in, size_t inlen);
-int blake2xb_final(blake2xb_state *S, void *out, size_t outlen);
-
 /* Simple API */
-int blake2s(void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen);
 int blake2b(void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen);
-
-int blake2sp(void       *out,
-             size_t      outlen,
-             const void *in,
-             size_t      inlen,
-             const void *key,
-             size_t      keylen);
-int blake2bp(void       *out,
-             size_t      outlen,
-             const void *in,
-             size_t      inlen,
-             const void *key,
-             size_t      keylen);
-
-int blake2xs(void       *out,
-             size_t      outlen,
-             const void *in,
-             size_t      inlen,
-             const void *key,
-             size_t      keylen);
-int blake2xb(void       *out,
-             size_t      outlen,
-             const void *in,
-             size_t      inlen,
-             const void *key,
-             size_t      keylen);
 
 /* This is simply an alias for blake2b */
 int blake2(void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen);

--- a/lib_cxng/src/cx_blake2b.c
+++ b/lib_cxng/src/cx_blake2b.c
@@ -139,13 +139,6 @@ cx_err_t cx_blake2b(cx_hash_t     *hash,
    More information about the BLAKE2 hash function can be found at
    https://blake2.net.
 */
-
-// #include <stdint.h>
-// #include <string.h>
-// #include <stdio.h>
-
-// #include "cx_blake2.h" //moved on top
-
 #include <stddef.h>
 #include <string.h>
 

--- a/lib_cxng/src/cx_blake2b.h
+++ b/lib_cxng/src/cx_blake2b.h
@@ -28,19 +28,13 @@
 
 extern const cx_hash_info_t cx_blake2b_info;
 
-WARN_UNUSED_RESULT cx_err_t cx_blake2b_update(cx_blake2b_t *ctx, const uint8_t *data, size_t len);
-// No need to add WARN_UNUSED_RESULT to cx_blake2b_final(), it always returns CX_OK
-cx_err_t cx_blake2b_final(cx_blake2b_t *ctx, uint8_t *digest);
-size_t   cx_blake2b_get_output_size(const cx_blake2b_t *ctx);
-
-struct cx_xblake_s {
+typedef struct cx_xblake_s {
     cx_blake2b_t blake2b;
     uint64_t     m[16];
     uint64_t     v[16];
     uint8_t      buffer[BLAKE2B_OUTBYTES];
     uint8_t      block1[BLAKE2B_BLOCKBYTES];
-};
-typedef struct cx_xblake_s cx_xblake_t;
+} cx_xblake_t;
 
 #endif  // HAVE_BLAKE2
 

--- a/lib_cxng/src/cx_chacha_poly.h
+++ b/lib_cxng/src/cx_chacha_poly.h
@@ -26,7 +26,7 @@
 #endif  // HAVE_AEAD
 #include "lcx_chacha.h"
 #include "lcx_chacha_poly.h"
-#include "cx_poly1305.h"
+#include "lcx_poly1305.h"
 #include "ox.h"
 #include <stddef.h>
 

--- a/lib_cxng/src/cx_cipher.h
+++ b/lib_cxng/src/cx_cipher.h
@@ -20,6 +20,7 @@
 #define CX_CIPHER_H
 
 #include "lcx_cipher.h"
+#include "ox_aes.h"
 
 #ifdef HAVE_AES
 #include "lcx_aes.h"
@@ -28,10 +29,6 @@ extern const cx_cipher_info_t cx_aes_128_info;
 extern const cx_cipher_info_t cx_aes_192_info;
 extern const cx_cipher_info_t cx_aes_256_info;
 
-/** HW support */
-WARN_UNUSED_RESULT cx_err_t cx_aes_set_key_hw(const cx_aes_key_t *keys, uint32_t mode);
-WARN_UNUSED_RESULT cx_err_t cx_aes_block_hw(const uint8_t *inblock, uint8_t *outblock);
-WARN_UNUSED_RESULT cx_err_t cx_aes_reset_hw(void);
 #endif  // HAVE_AES
 
 #endif /* CX_CIPHER_H */

--- a/lib_cxng/src/cx_crc16.c
+++ b/lib_cxng/src/cx_crc16.c
@@ -21,7 +21,7 @@
 #ifdef HAVE_CRC
 
 #include "lcx_crc.h"
-#include "cx_ram.h"
+#include "ox_crc.h"
 
 uint16_t cx_crc16_update(uint16_t crc, const void *buf, size_t len)
 {

--- a/lib_cxng/src/cx_crc32.c
+++ b/lib_cxng/src/cx_crc32.c
@@ -19,7 +19,6 @@
 #ifdef HAVE_CRC
 
 #include "lcx_crc.h"
-#include "cx_ram.h"
 #include "ox_crc.h"
 
 static uint32_t reverse_32_bits(uint32_t value)

--- a/lib_cxng/src/cx_ecdh.c
+++ b/lib_cxng/src/cx_ecdh.c
@@ -18,7 +18,7 @@
 
 #if defined(HAVE_ECDH) || defined(HAVE_X25519) || defined(HAVE_X448)
 
-#include "cx_ecfp.h"
+#include "lcx_ecfp.h"
 #include "cx_utils.h"
 #include "cx_ram.h"
 

--- a/lib_cxng/src/cx_ecdsa.c
+++ b/lib_cxng/src/cx_ecdsa.c
@@ -19,8 +19,8 @@
 #ifdef HAVE_ECDSA
 
 #include "cx_rng.h"
-#include "cx_rng_rfc6979.h"
-#include "cx_ecfp.h"
+#include "lcx_rng.h"
+#include "lcx_ecfp.h"
 #include "cx_ecdsa.h"
 #include "cx_utils.h"
 #include "cx_ram.h"

--- a/lib_cxng/src/cx_ecfp.c
+++ b/lib_cxng/src/cx_ecfp.c
@@ -18,13 +18,17 @@
 
 #ifdef HAVE_ECC
 
-#include "cx_ecfp.h"
+#include "lcx_ecfp.h"
 #include "libcxng.h"
-#include "cx_eddsa.h"
+#include "lcx_eddsa.h"
 #include "cx_utils.h"
 #include "cx_ram.h"
 
 #include <string.h>
+
+#if defined(BOLOS_RELEASE) && defined(HAVE_ECC_WITH_NO_RANDOMIZE)
+#error HAVE_ECC_WITH_NO_RANDOMIZE not allowed for release
+#endif  // HAVE_ECC_WITH_NO_RANDOMIZE
 
 /* ========================================================================= */
 /* ========================================================================= */

--- a/lib_cxng/src/cx_ecfp.h
+++ b/lib_cxng/src/cx_ecfp.h
@@ -19,36 +19,6 @@
 #ifndef CX_ECFP_H
 #define CX_ECFP_H
 
-#ifdef HAVE_ECC
-
-#include <stddef.h>
-#include <stdint.h>
 #include "lcx_ecfp.h"
-
-#define CX_REG_ECC_SIZE 80
-
-#if defined(BOLOS_RELEASE) && defined(HAVE_ECC_WITH_NO_RANDOMIZE)
-#error HAVE_ECC_WITH_NO_RANDOMIZE not allowed for release
-#endif  // HAVE_ECC_WITH_NO_RANDOMIZE
-
-#define CX_BITLEN2BYTELEN(l) (((uint32_t) (l) + 7) >> 3)
-
-/* Encoding/Decoding */
-
-size_t cx_ecfp_encode_sig_der(uint8_t       *sig,
-                              size_t         sig_len,
-                              const uint8_t *r,
-                              size_t         r_len,
-                              const uint8_t *s,
-                              size_t         s_len);
-int    cx_ecfp_decode_sig_der(const uint8_t  *sig,
-                              size_t          sig_len,
-                              size_t          max_size,
-                              const uint8_t **r,
-                              size_t         *r_len,
-                              const uint8_t **s,
-                              size_t         *s_len);
-
-#endif  // HAVE_ECC
 
 #endif  // CX_ECFP_H

--- a/lib_cxng/src/cx_ecschnorr.c
+++ b/lib_cxng/src/cx_ecschnorr.c
@@ -18,9 +18,8 @@
 
 #ifdef HAVE_ECSCHNORR
 
-#include "cx_rng.h"
-#include "cx_ecfp.h"
-#include "cx_eddsa.h"
+#include "lcx_ecfp.h"
+#include "lcx_eddsa.h"
 #include "cx_hash.h"
 #include "cx_utils.h"
 #include "cx_ram.h"

--- a/lib_cxng/src/cx_eddsa.c
+++ b/lib_cxng/src/cx_eddsa.c
@@ -19,8 +19,8 @@
 #ifdef HAVE_ECC_TWISTED_EDWARDS
 
 #include "cx_hash.h"
-#include "cx_ecfp.h"
-#include "cx_eddsa.h"
+#include "lcx_ecfp.h"
+#include "lcx_eddsa.h"
 #include "cx_selftests.h"
 #include "cx_utils.h"
 #include "cx_ram.h"

--- a/lib_cxng/src/cx_eddsa.h
+++ b/lib_cxng/src/cx_eddsa.h
@@ -19,17 +19,6 @@
 #ifndef CX_EDDSA_H
 #define CX_EDDSA_H
 
-#ifdef HAVE_EDDSA
-
-WARN_UNUSED_RESULT cx_err_t cx_eddsa_get_public_key_internal(const cx_ecfp_private_key_t *pv_key,
-                                                             cx_md_t                      hashID,
-                                                             cx_ecfp_public_key_t        *pu_key,
-                                                             uint8_t                     *a,
-                                                             size_t                       a_len,
-                                                             uint8_t                     *h,
-                                                             size_t                       h_len,
-                                                             uint8_t *scal /*temp uint8[114]*/);
-
-#endif  // HAVE_EDDSA
+#include "lcx_eddsa.h"
 
 #endif  // CX_EDDSA_H

--- a/lib_cxng/src/cx_groestl.h
+++ b/lib_cxng/src/cx_groestl.h
@@ -7,12 +7,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-struct cx_xgroestl_s {
+typedef struct cx_xgroestl_s {
     cx_groestl_t  groestl;
     unsigned char temp1[ROWS][COLS1024];
     unsigned char temp2[ROWS][COLS1024];
-};
-typedef struct cx_xgroestl_s cx_xgroestl_t;
+} cx_xgroestl_t;
 
 #endif  // CX_GROESTL_H
 

--- a/lib_cxng/src/cx_hash.h
+++ b/lib_cxng/src/cx_hash.h
@@ -15,7 +15,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
-
+/*
+ * Internal hash function
+ */
 #ifndef CX_HASH_H
 #define CX_HASH_H
 
@@ -24,28 +26,9 @@
 #include "lcx_hash.h"
 #include <stddef.h>
 
-#if defined(HAVE_SHA256) || defined(HAVE_SHA224)
-#define SHA256_BLOCK_SIZE 64
-#endif
-
-#if defined(HAVE_SHA512) || defined(HAVE_SHA384)
-#define SHA512_BLOCK_SIZE 128
-#endif
-
 // #warning reduce MAX_HASH_SIZE and MAX_HASH_BLOCK_SIZE according to HAVE_xxx
 #define MAX_HASH_SIZE       128
 #define MAX_HASH_BLOCK_SIZE 128
-
-#ifdef HAVE_BLAKE2
-WARN_UNUSED_RESULT cx_err_t cx_blake2b(cx_hash_t     *hash,
-                                       uint32_t       mode,
-                                       const uint8_t *in,
-                                       size_t         in_len,
-                                       uint8_t       *out,
-                                       size_t         out_len);
-#endif
-
-const cx_hash_info_t *cx_hash_get_info(cx_md_t md_type);
 
 /**
  * Destroy/clean the hash context.

--- a/lib_cxng/src/cx_hkdf.c
+++ b/lib_cxng/src/cx_hkdf.c
@@ -1,7 +1,7 @@
 #ifdef HAVE_HMAC
-#include "cx_hkdf.h"
+#include "lcx_hash.h"
 #include "cx_hash.h"
-#include "cx_hmac.h"
+#include "lcx_hmac.h"
 #include "cx_ram.h"
 
 #include <string.h>

--- a/lib_cxng/src/cx_hkdf.h
+++ b/lib_cxng/src/cx_hkdf.h
@@ -3,18 +3,4 @@
 
 #include "lcx_hash.h"
 
-void cx_hkdf_extract(const cx_md_t        hash_id,
-                     const unsigned char *ikm,
-                     unsigned int         ikm_len,
-                     unsigned char       *salt,
-                     unsigned int         salt_len,
-                     unsigned char       *prk);
-void cx_hkdf_expand(const cx_md_t        hash_id,
-                    const unsigned char *prk,
-                    unsigned int         prk_len,
-                    unsigned char       *info,
-                    unsigned int         info_len,
-                    unsigned char       *okm,
-                    unsigned int         okm_len);
-
 #endif  // CX_HKDF_H

--- a/lib_cxng/src/cx_hmac.c
+++ b/lib_cxng/src/cx_hmac.c
@@ -18,7 +18,7 @@
 
 #ifdef HAVE_HMAC
 
-#include "cx_hmac.h"
+#include "lcx_hmac.h"
 #include "cx_hash.h"
 #include "cx_ram.h"
 #include "errors.h"

--- a/lib_cxng/src/cx_math.c
+++ b/lib_cxng/src/cx_math.c
@@ -18,7 +18,7 @@
 
 #ifdef HAVE_MATH
 
-#include "cx_math.h"
+#include "lcx_math.h"
 #include "cx_utils.h"
 
 cx_err_t cx_math_cmp_no_throw(const uint8_t *a, const uint8_t *b, size_t length, int *diff)

--- a/lib_cxng/src/cx_pbkdf2.h
+++ b/lib_cxng/src/cx_pbkdf2.h
@@ -22,6 +22,7 @@
 #ifdef HAVE_PBKDF2
 
 #include "lcx_hmac.h"
+#include "lcx_pbkdf2.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -29,7 +30,7 @@
 #define PBKDF2_BUFFER_LENGTH 64
 
 /* ========= PBKDF2 ========= */
-struct cx_pbkdf2_s {
+typedef struct cx_pbkdf2_s {
     // salt buffer used to initialize each pbkdf2 turn.
     uint8_t salt[384];
     uint8_t sha512out[64];  // avoid stack usage in derive_and_set_seed
@@ -51,17 +52,7 @@ struct cx_pbkdf2_s {
         cx_hmac_sha256_t hmac_sha256;
 #endif
     };
-};
-typedef struct cx_pbkdf2_s cx_pbkdf2_t;
-
-WARN_UNUSED_RESULT cx_err_t cx_pbkdf2_hmac(cx_md_t        md_type,
-                                           const uint8_t *password,
-                                           size_t         password_len,
-                                           const uint8_t *salt,
-                                           size_t         salt_len,
-                                           uint32_t       iterations,
-                                           uint8_t       *key,
-                                           size_t         key_len);
+} cx_pbkdf2_t;
 
 #endif  // HAVE_PBKDF2
 

--- a/lib_cxng/src/cx_poly1305.c
+++ b/lib_cxng/src/cx_poly1305.c
@@ -18,7 +18,7 @@
 
 #if defined(HAVE_POLY1305)
 
-#include "cx_poly1305.h"
+#include "lcx_poly1305.h"
 #include "cx_ram.h"
 #include "cx_utils.h"
 #include "os_math.h"

--- a/lib_cxng/src/cx_poly1305.h
+++ b/lib_cxng/src/cx_poly1305.h
@@ -15,105 +15,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ********************************************************************************/
-
+// TODO: empty file, could be removed after some clean-up in apps
 #ifndef CX_POLY1305_H
 #define CX_POLY1305_H
 
-#if defined(HAVE_POLY1305)
-
 #include "lcx_poly1305.h"
-#include "ox.h"
-#include <stddef.h>
-
-/**
- * @brief           Initialize the specified Poly1305 context.
- *
- * @details         It must be the first API called before using
- *                  the context.
- *
- *                  It is usually followed by a call to
- *                  #cx_poly1305_set_key, then one or more calls to
- *                  #cx_poly1305_update, then one call to
- *                  #cx_poly1305_finish
- *
- * @param ctx       The Poly1305 context to initialize. This must
- *                  not be \c NULL.
- */
-void cx_poly1305_init(cx_poly1305_context_t *ctx);
-
-/**
- * @brief           Set the one-time authentication key.
- *
- * @warning         The key must be unique and unpredictable for each
- *                  invocation of Poly1305.
- *
- * @param ctx       The Poly1305 context to which the key should be bound.
- *                  This must be initialized.
- *
- * @param key       Pointer to the buffer containing the \c 32 byte (\c 256 bit) key.
- *
- */
-void cx_poly1305_set_key(cx_poly1305_context_t *ctx, const uint8_t *key);
-
-/**
- * @brief           Update the Poly1305 computation given an input buffer.
- *
- * @details         It is called between #cx_poly1305_set_key() and
- *                  #cx_poly1305_finish().
- *                  It can be called repeatedly to process a stream of data.
- *
- * @param ctx       The Poly1305 context to use for the Poly1305 operation.
- *                  This must be initialized and bound to a key.
- *
- * @param input     Pointer to the buffer holding the input data.
- *                  This pointer can be \c NULL if `in_len == 0`.
- *
- * @param in_len    The length of the input data in bytes.
- *
- * @return          Error code
- */
-WARN_UNUSED_RESULT cx_err_t cx_poly1305_update(cx_poly1305_context_t *ctx,
-                                               const uint8_t         *input,
-                                               size_t                 in_len);
-
-/**
- * @brief           Generate the Poly1305 Message
- *                  Authentication Code (MAC).
- *
- * @param ctx       The Poly1305 context to use for the Poly1305 operation.
- *                  This must be initialized and bound to a key.
- *
- * @param tag       Pointer to the buffer to where the MAC is written. This must
- *                  be a writable buffer of length \c 16 bytes.
- *
- * @return          Error code.
- */
-WARN_UNUSED_RESULT cx_err_t cx_poly1305_finish(cx_poly1305_context_t *ctx, uint8_t *tag);
-
-/**
- * @brief           Calculate the Poly1305 MAC of the input
- *                  buffer with the provided key.
- *
- * @warning         The key must be unique and unpredictable for each
- *                  invocation of Poly1305.
- *
- * @param key       Pointer to the buffer containing the \c 32 byte (\c 256 bit) key.
- *
- * @param input     Pointer to the buffer holding the input data.
- *                  This pointer can be \c NULL if `in_len == 0`.
- *
- * @param in_len    Length of the input data in bytes.
- *
- * @param tag       Pointer to the buffer to where the MAC is written.
- *                  This must be a writable buffer of length \c 16 bytes.
- *
- * @return          Error code
- */
-WARN_UNUSED_RESULT cx_err_t cx_poly1305_mac(const uint8_t *key,
-                                            const uint8_t *input,
-                                            size_t         in_len,
-                                            uint8_t       *tag);
-
-#endif  // HAVE_POLY1305
 
 #endif  // CX_POLY1305_H

--- a/lib_cxng/src/cx_ram.h
+++ b/lib_cxng/src/cx_ram.h
@@ -19,24 +19,22 @@
 #ifndef CX_RAM_H
 #define CX_RAM_H
 
-#include "cx_hash.h"
+#include "lcx_hash.h"
 #include "cx_pbkdf2.h"
-#include "cx_ecfp.h"
-#include "cx_rng.h"
-#include "cx_rng_rfc6979.h"
-#include "cx_hmac.h"
+#include "lcx_ecfp.h"
+#include "lcx_rng.h"
+#include "lcx_hmac.h"
 #include "cx_blake2b.h"
 #include "cx_groestl.h"
 #include "cx_rsa.h"
-#include "cx_sha3.h"
-#include "cx_sha256.h"
-#include "cx_sha512.h"
-#include "cx_ripemd160.h"
-#include "cx_blake3.h"
-#include "cx_poly1305.h"
+#include "lcx_sha3.h"
+#include "lcx_sha256.h"
+#include "lcx_sha512.h"
+#include "lcx_ripemd160.h"
+#include "lcx_blake3.h"
+#include "lcx_poly1305.h"
 #include "lcx_chacha.h"
-#include "cx_cipher.h"
-#include "cx_cmac.h"
+#include "lcx_cipher.h"
 
 /** 1K RAM lib */
 union cx_u {

--- a/lib_cxng/src/cx_ripemd160.h
+++ b/lib_cxng/src/cx_ripemd160.h
@@ -22,15 +22,8 @@
 #ifdef HAVE_RIPEMD160
 
 #include "lcx_ripemd160.h"
-#include <stdbool.h>
-#include <stddef.h>
 
 extern const cx_hash_info_t cx_ripemd160_info;
-
-WARN_UNUSED_RESULT cx_err_t cx_ripemd160_update(cx_ripemd160_t *ctx,
-                                                const uint8_t  *data,
-                                                size_t          len);
-WARN_UNUSED_RESULT cx_err_t cx_ripemd160_final(cx_ripemd160_t *ctx, uint8_t *digest);
 
 #endif  // HAVE_RIPEMD160
 

--- a/lib_cxng/src/cx_rng.c
+++ b/lib_cxng/src/cx_rng.c
@@ -20,17 +20,10 @@
 
 #ifdef HAVE_RNG
 
-#include "cx_ram.h"
-#include "cx_utils.h"
-#include "cx_crc.h"
+#include <stdint.h>
 #include "lcx_rng.h"
-#include "errors.h"
-#include "exceptions.h"
 
-#include "os_halt.h"
-#include "os_math.h"
 #include "os_random.h"
-#include <string.h>
 
 void cx_rng_no_throw(uint8_t *buffer, size_t len)
 {

--- a/lib_cxng/src/cx_rng.h
+++ b/lib_cxng/src/cx_rng.h
@@ -27,14 +27,8 @@
 
 #include <stdint.h>
 
-void cx_rng_init(void);
-
 /// @brief function to be called each time random data is needed
 uint32_t cx_trng_u32(void);
-
-#ifdef CX_EMU_SELFTESTS
-void cx_trng_lengthtest(void);
-#endif
 
 #endif  // HAVE_RNG
 

--- a/lib_cxng/src/cx_rng_rfc6979.c
+++ b/lib_cxng/src/cx_rng_rfc6979.c
@@ -19,8 +19,8 @@
 #ifdef HAVE_RNG_RFC6979
 
 #include <string.h>
-#include "cx_rng_rfc6979.h"
-#include "cx_hmac.h"
+#include "lcx_rng.h"
+#include "lcx_hmac.h"
 #include "cx_hash.h"
 #include "cx_ram.h"
 #include "exceptions.h"

--- a/lib_cxng/src/cx_rng_rfc6979.h
+++ b/lib_cxng/src/cx_rng_rfc6979.h
@@ -19,60 +19,6 @@
 #ifndef CX_RNG_RFC6979_H
 #define CX_RNG_RFC6979_H
 
-#ifdef HAVE_RNG_RFC6979
-
-#include "libcxng.h"
-#include "cx_hash.h"
-#include <stddef.h>
-#include <stdint.h>
-
-#define CX_RFC6979_BUFFER_LENGTH 64
-#define CX_RFC6979_MAX_RLEN      66
-
-typedef struct {
-    uint8_t  v[CX_RFC6979_BUFFER_LENGTH + 1];
-    uint8_t  k[CX_RFC6979_BUFFER_LENGTH];
-    uint8_t  q[CX_RFC6979_MAX_RLEN];
-    uint32_t q_len;
-    uint32_t r_len;
-    uint8_t  tmp[CX_RFC6979_MAX_RLEN];
-    cx_md_t  hash_id;
-    size_t   md_len;
-
-    union {
-#if (!defined(HAVE_SHA512) && !defined(HAVE_SHA384) && !defined(HAVE_SHA256) \
-     && !defined(HAVE_SHA224))                                               \
-    || !defined(HAVE_HMAC)
-#error No hmac defined for rfc6979 support
-#endif
-
-        cx_hmac_t hmac;
-
-#if defined(HAVE_SHA512) || defined(HAVE_SHA384)
-        cx_hmac_sha512_t hmac_sha512;
-#endif
-
-#if defined(HAVE_SHA256) || defined(HAVE_SHA224)
-        cx_hmac_sha256_t hmac_sha256;
-#endif
-    };
-} cx_rnd_rfc6979_ctx_t;
-
-WARN_UNUSED_RESULT cx_err_t cx_rng_rfc6979_init(
-    cx_rnd_rfc6979_ctx_t *rfc_ctx,
-    cx_md_t               hash_id,
-    const uint8_t        *x,
-    size_t                x_len,
-    const uint8_t        *h1,
-    size_t                h1_len,
-    const uint8_t        *q,
-    size_t                q_len
-    /*const uint8_t *additional_input, size_t additional_input_len*/);
-
-WARN_UNUSED_RESULT cx_err_t cx_rng_rfc6979_next(cx_rnd_rfc6979_ctx_t *rfc_ctx,
-                                                uint8_t              *out,
-                                                size_t                out_len);
-
-#endif  // HAVE_RNG_RFC6979
+#include "lcx_rng.h"
 
 #endif  // CX_RNG_RFC6979_H

--- a/lib_cxng/src/cx_rsa.h
+++ b/lib_cxng/src/cx_rsa.h
@@ -188,7 +188,7 @@ cx_pkcs1_eme_oaep_decode(cx_md_t hID, uint8_t *em, size_t em_len, uint8_t *m, si
 // For PKCS1.5
 #define PKCS1_DIGEST_BUFFER_LENGTH 64
 
-struct cx_pkcs1_s {
+typedef struct cx_pkcs1_s {
     union {
         cx_hash_t hash;
 #if defined(HAVE_SHA256)
@@ -201,8 +201,7 @@ struct cx_pkcs1_s {
     } hash_ctx;
     uint8_t digest[PKCS1_DIGEST_BUFFER_LENGTH];
     uint8_t MGF1[512];
-};
-typedef struct cx_pkcs1_s cx_pkcs1_t;
+} cx_pkcs1_t;
 
 #if defined(HAVE_SHA224)
 #define CX_OID_SHA224_LENGTH 19

--- a/lib_cxng/src/cx_selftests.c
+++ b/lib_cxng/src/cx_selftests.c
@@ -20,8 +20,8 @@
 
 #include "os.h"
 #include "cx_selftests.h"
-#include "cx_ecfp.h"
-#include "cx_eddsa.h"
+#include "lcx_ecfp.h"
+#include "lcx_eddsa.h"
 #include "cx_ram.h"
 
 enum test_id {

--- a/lib_cxng/src/cx_sha256.h
+++ b/lib_cxng/src/cx_sha256.h
@@ -22,9 +22,6 @@
 #if defined(HAVE_SHA256) || defined(HAVE_SHA224)
 
 #include "lcx_sha256.h"
-#include <stddef.h>
-#include <stdint.h>
-#include <stdbool.h>
 
 #ifdef HAVE_SHA224
 extern const cx_hash_info_t cx_sha224_info;
@@ -34,10 +31,6 @@ extern const cx_hash_info_t cx_sha224_info;
 extern const cx_hash_info_t cx_sha256_info;
 #endif  // HAVE_SHA256
 
-WARN_UNUSED_RESULT cx_err_t cx_sha256_update(cx_sha256_t *ctx, const uint8_t *data, size_t len);
-// No need to add WARN_UNUSED_RESULT to cx_sha256_final(), it always returns CX_OK
-cx_err_t cx_sha256_final(cx_sha256_t *ctx, uint8_t *digest);
-
-#endif  // HAVE_SHA256
+#endif  // HAVE_SHA256 || HAVE_SHA224
 
 #endif  // CX_SHA256_H

--- a/lib_cxng/src/cx_sha3.h
+++ b/lib_cxng/src/cx_sha3.h
@@ -28,11 +28,6 @@ extern const cx_hash_info_t cx_keccak_info;
 extern const cx_hash_info_t cx_shake128_info;
 extern const cx_hash_info_t cx_shake256_info;
 
-WARN_UNUSED_RESULT cx_err_t cx_sha3_update(cx_sha3_t *ctx, const uint8_t *data, size_t len);
-// No need to add WARN_UNUSED_RESULT to cx_sha3_final(), it always returns CX_OK
-cx_err_t cx_sha3_final(cx_sha3_t *ctx, uint8_t *digest);
-size_t   cx_sha3_get_output_size(const cx_sha3_t *ctx);
-
 #endif  // HAVE_SHA3
 
 #endif  // CX_SHA3_H

--- a/lib_cxng/src/cx_sha512.h
+++ b/lib_cxng/src/cx_sha512.h
@@ -33,10 +33,6 @@ extern const cx_hash_info_t cx_sha384_info;
 extern const cx_hash_info_t cx_sha512_info;
 #endif  // HAVE_SHA512
 
-WARN_UNUSED_RESULT cx_err_t cx_sha512_update(cx_sha512_t *ctx, const uint8_t *data, size_t len);
-// No need to add WARN_UNUSED_RESULT to cx_sha512_final(), it always returns CX_OK
-cx_err_t cx_sha512_final(cx_sha512_t *ctx, uint8_t *digest);
-
 #endif  // defined(HAVE_SHA512) || defined(HAVE_SHA384)
 
 #endif  // CX_SHA512_H

--- a/src/cx_wrappers.c
+++ b/src/cx_wrappers.c
@@ -19,7 +19,7 @@
 #include <stdbool.h>  // bool
 
 #include "cx.h"
-#include "lib_cxng/src/cx_ecfp.h"
+#include "lcx_ecfp.h"
 
 // At some point this could/should be migrated to a cx func included in the cx_lib
 cx_err_t cx_ecdsa_sign_rs_no_throw(const cx_ecfp_private_key_t *key,


### PR DESCRIPTION
## Description

The goal of this PR is to cleanup **lib_cxng** to clearly identify (and use) API header and not internal header

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)
