### PR TITLE
fuzzing: add generic TLV custom mutator with harnesses

### DIFF
--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -56,13 +56,13 @@ cd fuzzing # You must run it from the fuzzing folder
 ### About local_run.sh
 
 | Parameter              | Type                | Description                                                                   |
-| :--------------------- | :------------------ | :------------------------------------------------------------------- ---------|
+| :--------------------- | :------------------ | :---------------------------------------------------------------------------- |
 | `--BOLOS_SDK`          | `PATH TO BOLOS SDK` | **Required**. Path to the BOLOS SDK                                           |
 | `--build`              | `bool`              | **Optional**. Whether to build the project (default: 0)                       |
 | `--fuzzer`             | `PATH`              | **Required**. Path to the fuzzer binary                                       |
 | `--compute-coverage`   | `bool`              | **Optional**. Whether to compute coverage after fuzzing (default: 0)          |
 | `--run-fuzzer`         | `bool`              | **Optional**. Whether to run or not the fuzzer (default: 0)                   |
-| `--run-crash`          | `FILENAME`          | **Optional**. Run the fuzzer on a specific crash input file (default: 0)      |
+| `--run-crash`          | `FILENAME`          | **Optional**. Run the fuzzer on a specific crash input file                   |
 | `--sanitizer`          | `address or memory` | **Optional**. Compile fuzzer with sanitizer (default: address)                |
 | `--j`                  | `int`               | **Optional**. Number of parallel jobs/CPUs for build and fuzzing (default: 1) |
 | `--help`               |                     | **Optional**. Display help message                                            |
@@ -78,23 +78,59 @@ When writing your harness, keep the following points in mind:
   macros/exclude_macros.txt and rerunning it, or directly change the generated macros/generated/macros.txt.
 - A typical harness looks like this:
 
-  ```console
-
+  ```c
   int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    if (sigsetjmp(fuzz_exit_jump_ctx.jmp_buf, 1)) return 0;
-
-    ### harness code ###
-
-    return 0;
+      /* harness code */
+      return 0;
   }
-
   ```
-
-  This allows a return point when the `os_sched_exit()` function is mocked.
 
 - To provide an SDK interface, we automatically generate syscall mock functions located in
   `SECURE_SDK_PATH/fuzzing/mock/generated/generated_syscalls.c`, if you need a more specific mock,
   you can define it in `APP_PATH/fuzzing/mock` with the same name and without the WEAK attribute.
+
+### Fuzzing TLV use cases
+
+The SDK provides a grammar-aware TLV custom mutator (`tlv_mutator.c`) that generates
+structurally valid TLV messages. Each harness defines its own tag grammar; the mutator
+handles structural mutations (build, append, delete, duplicate, corrupt length, truncate).
+
+SDK reference fuzzers:
+- `fuzz_tlv_trusted_name` — Trusted Name (`fuzzer_tlv_trusted_name.c`)
+- `fuzz_tlv_dynamic_descriptor` — Dynamic Descriptor (`fuzzer_tlv_dynamic_descriptor.c`)
+
+#### Using the TLV mutator from your application
+
+1. Define the tag grammar as a `tlv_tag_info_t` array and set it in `LLVMFuzzerInitialize`:
+
+```c
+#include "tlv_mutator.h"
+
+static const tlv_tag_info_t MY_TAGS[] = {
+    {0x01, 1, 1},    // TAG_TYPE    : uint8
+    {0x02, 1, 32},   // TAG_NAME    : string
+    {0x03, 20, 20},  // TAG_ADDRESS : fixed 20 bytes
+};
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    (void) argc; (void) argv;
+    current_tlv_fuzz_config.tags_info = MY_TAGS;
+    current_tlv_fuzz_config.num_tags  = sizeof(MY_TAGS) / sizeof(MY_TAGS[0]);
+    return 0;
+}
+```
+
+2. Compile `tlv_mutator.c` alongside your harness and link with `secure_sdk`:
+
+```cmake
+add_executable(fuzz_my_tlv my_harness.c ${BOLOS_SDK}/fuzzing/harness/tlv_mutator.c)
+target_link_libraries(fuzz_my_tlv PUBLIC secure_sdk)
+```
+
+3. If your use case calls `check_signature_with_pki`, also compile
+   `fuzz_tlv_common_mocks.c` to bypass PKI verification during fuzzing.
+
+See `fuzzer_tlv_trusted_name.c` and `lib_tlv_trusted_name.cmake` as complete examples.
 
 ### Adding an initial Corpus
 
@@ -143,4 +179,6 @@ cmake -S . -B build -DCMAKE_C_COMPILER=clang -DSANITIZER=address -G Ninja -DTARG
 ./build/fuzz_alloc
 ./build/fuzz_alloc_utils
 ./build/fuzz_nfc_ndef
+./build/fuzz_tlv_trusted_name
+./build/fuzz_tlv_dynamic_descriptor
 ```

--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -62,7 +62,7 @@ cd fuzzing # You must run it from the fuzzing folder
 | `--fuzzer`             | `PATH`              | **Required**. Path to the fuzzer binary                                       |
 | `--compute-coverage`   | `bool`              | **Optional**. Whether to compute coverage after fuzzing (default: 0)          |
 | `--run-fuzzer`         | `bool`              | **Optional**. Whether to run or not the fuzzer (default: 0)                   |
-| `--run-crash`          | `FILENAME`          | **Optional**. Run the fuzzer on a specific crash input file                   |
+| `--run-crash`          | `FILENAME`          | **Optional**. Run the fuzzer on a specific crash input file (default: 0)      |
 | `--sanitizer`          | `address or memory` | **Optional**. Compile fuzzer with sanitizer (default: address)                |
 | `--j`                  | `int`               | **Optional**. Number of parallel jobs/CPUs for build and fuzzing (default: 1) |
 | `--help`               |                     | **Optional**. Display help message                                            |
@@ -128,7 +128,7 @@ target_link_libraries(fuzz_my_tlv PUBLIC secure_sdk)
 ```
 
 3. If your use case calls `check_signature_with_pki`, also compile
-   `fuzz_tlv_common_mocks.c` to bypass PKI verification during fuzzing.
+   `fuzzing/mock/mock_check_signature_with_pki.c` to bypass PKI verification during fuzzing.
 
 See `fuzzer_tlv_trusted_name.c` and `lib_tlv_trusted_name.cmake` as complete examples.
 

--- a/fuzzing/extra/lib_tlv_dynamic_descriptor.cmake
+++ b/fuzzing/extra/lib_tlv_dynamic_descriptor.cmake
@@ -1,0 +1,19 @@
+include_guard()
+
+# Include required libraries
+include(${BOLOS_SDK}/fuzzing/libs/lib_standard_app.cmake)
+include(${BOLOS_SDK}/fuzzing/libs/lib_tlv.cmake)
+include(${BOLOS_SDK}/fuzzing/libs/lib_pki.cmake)
+
+# fuzz_tlv_common_mocks.c overrides check_signature_with_pki to always succeed
+# APPNAME must match the value in seed corpus TAG_APPLICATION_NAME
+add_executable(fuzz_tlv_dynamic_descriptor
+    ${BOLOS_SDK}/fuzzing/harness/fuzzer_tlv_dynamic_descriptor.c
+    ${BOLOS_SDK}/fuzzing/harness/tlv_mutator.c
+    ${BOLOS_SDK}/fuzzing/harness/fuzz_tlv_common_mocks.c)
+target_compile_definitions(fuzz_tlv_dynamic_descriptor PRIVATE APPNAME="Fuzzing")
+target_compile_options(fuzz_tlv_dynamic_descriptor PUBLIC ${COMPILATION_FLAGS})
+target_link_options(fuzz_tlv_dynamic_descriptor PUBLIC ${LINK_FLAGS})
+
+# Link with required libraries
+target_link_libraries(fuzz_tlv_dynamic_descriptor PUBLIC standard_app mock tlv pki cxng nbgl_shared)

--- a/fuzzing/extra/lib_tlv_dynamic_descriptor.cmake
+++ b/fuzzing/extra/lib_tlv_dynamic_descriptor.cmake
@@ -5,12 +5,12 @@ include(${BOLOS_SDK}/fuzzing/libs/lib_standard_app.cmake)
 include(${BOLOS_SDK}/fuzzing/libs/lib_tlv.cmake)
 include(${BOLOS_SDK}/fuzzing/libs/lib_pki.cmake)
 
-# fuzz_tlv_common_mocks.c overrides check_signature_with_pki to always succeed
+# mock_check_signature_with_pki.c overrides check_signature_with_pki to always succeed
 # APPNAME must match the value in seed corpus TAG_APPLICATION_NAME
 add_executable(fuzz_tlv_dynamic_descriptor
     ${BOLOS_SDK}/fuzzing/harness/fuzzer_tlv_dynamic_descriptor.c
     ${BOLOS_SDK}/fuzzing/harness/tlv_mutator.c
-    ${BOLOS_SDK}/fuzzing/harness/fuzz_tlv_common_mocks.c)
+    ${BOLOS_SDK}/fuzzing/mock/mock_check_signature_with_pki.c)
 target_compile_definitions(fuzz_tlv_dynamic_descriptor PRIVATE APPNAME="Fuzzing")
 target_compile_options(fuzz_tlv_dynamic_descriptor PUBLIC ${COMPILATION_FLAGS})
 target_link_options(fuzz_tlv_dynamic_descriptor PUBLIC ${LINK_FLAGS})

--- a/fuzzing/extra/lib_tlv_trusted_name.cmake
+++ b/fuzzing/extra/lib_tlv_trusted_name.cmake
@@ -5,11 +5,11 @@ include(${BOLOS_SDK}/fuzzing/libs/lib_standard_app.cmake)
 include(${BOLOS_SDK}/fuzzing/libs/lib_tlv.cmake)
 include(${BOLOS_SDK}/fuzzing/libs/lib_pki.cmake)
 
-# fuzz_tlv_common_mocks.c overrides the weak check_signature_with_pki to always succeed
+# mock_check_signature_with_pki.c overrides check_signature_with_pki to always succeed
 add_executable(fuzz_tlv_trusted_name
     ${BOLOS_SDK}/fuzzing/harness/fuzzer_tlv_trusted_name.c
     ${BOLOS_SDK}/fuzzing/harness/tlv_mutator.c
-    ${BOLOS_SDK}/fuzzing/harness/fuzz_tlv_common_mocks.c)
+    ${BOLOS_SDK}/fuzzing/mock/mock_check_signature_with_pki.c)
 target_compile_options(fuzz_tlv_trusted_name PUBLIC ${COMPILATION_FLAGS})
 target_link_options(fuzz_tlv_trusted_name PUBLIC ${LINK_FLAGS})
 

--- a/fuzzing/extra/lib_tlv_trusted_name.cmake
+++ b/fuzzing/extra/lib_tlv_trusted_name.cmake
@@ -1,0 +1,17 @@
+include_guard()
+
+# Include required libraries
+include(${BOLOS_SDK}/fuzzing/libs/lib_standard_app.cmake)
+include(${BOLOS_SDK}/fuzzing/libs/lib_tlv.cmake)
+include(${BOLOS_SDK}/fuzzing/libs/lib_pki.cmake)
+
+# fuzz_tlv_common_mocks.c overrides the weak check_signature_with_pki to always succeed
+add_executable(fuzz_tlv_trusted_name
+    ${BOLOS_SDK}/fuzzing/harness/fuzzer_tlv_trusted_name.c
+    ${BOLOS_SDK}/fuzzing/harness/tlv_mutator.c
+    ${BOLOS_SDK}/fuzzing/harness/fuzz_tlv_common_mocks.c)
+target_compile_options(fuzz_tlv_trusted_name PUBLIC ${COMPILATION_FLAGS})
+target_link_options(fuzz_tlv_trusted_name PUBLIC ${LINK_FLAGS})
+
+# Link with required libraries
+target_link_libraries(fuzz_tlv_trusted_name PUBLIC standard_app mock tlv pki cxng nbgl_shared)

--- a/fuzzing/harness/fuzz_tlv_common_mocks.c
+++ b/fuzzing/harness/fuzz_tlv_common_mocks.c
@@ -1,0 +1,23 @@
+/**
+ * Shared mocks for TLV fuzzers.
+ *
+ * Overrides the weak mock of check_signature_with_pki to always return success.
+ * This allows fuzzers to reach all code paths past signature verification,
+ * which is the interesting attack surface for TLV parsing bugs.
+ */
+
+#include "ledger_pki.h"
+#include "buffer.h"
+#include "ox_ec.h"
+
+check_signature_with_pki_status_t check_signature_with_pki(const buffer_t    hash,
+                                                           const uint8_t    *expected_key_usage,
+                                                           const cx_curve_t *expected_curve,
+                                                           const buffer_t    signature)
+{
+    (void) hash;
+    (void) expected_key_usage;
+    (void) expected_curve;
+    (void) signature;
+    return CHECK_SIGNATURE_WITH_PKI_SUCCESS;
+}

--- a/fuzzing/harness/fuzzer_tlv_dynamic_descriptor.c
+++ b/fuzzing/harness/fuzzer_tlv_dynamic_descriptor.c
@@ -1,0 +1,39 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include "buffer.h"
+#include "use_cases/tlv_use_case_dynamic_descriptor.h"
+#include "tlv_mutator.h"
+
+const tlv_tag_info_t DYNAMIC_DESCRIPTOR_TAGS_INFO[] = {
+    {0x01, 1,  1 }, // TAG_STRUCTURE_TYPE : uint8, always 0x90
+    {0x02, 1,  1 }, // TAG_VERSION        : uint8, must be 1
+    {0x03, 4,  4 }, // TAG_COIN_TYPE      : uint32
+    {0x04, 1,  33}, // TAG_APPLICATION_NAME : string, max BOLOS_APPNAME_MAX_SIZE_B+1
+    {0x05, 1,  51}, // TAG_TICKER         : string, max MAX_TICKER_SIZE+1
+    {0x06, 1,  1 }, // TAG_MAGNITUDE      : uint8
+    {0x07, 1,  64}, // TAG_TUID           : bytes, uncapped but reasonable max
+    {0x08, 70, 72}, // TAG_SIGNATURE      : DER sig
+};
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    (void) argc;
+    (void) argv;
+    // Set the grammar for the custom mutator
+    current_tlv_fuzz_config.tags_info = DYNAMIC_DESCRIPTOR_TAGS_INFO;
+    current_tlv_fuzz_config.num_tags
+        = sizeof(DYNAMIC_DESCRIPTOR_TAGS_INFO) / sizeof(DYNAMIC_DESCRIPTOR_TAGS_INFO[0]);
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    buffer_t                     payload = {.ptr = (uint8_t *) data, .size = size, .offset = 0};
+    tlv_dynamic_descriptor_out_t out;
+    memset(&out, 0, sizeof(out));
+
+    tlv_use_case_dynamic_descriptor(&payload, &out);
+
+    return 0;
+}

--- a/fuzzing/harness/fuzzer_tlv_trusted_name.c
+++ b/fuzzing/harness/fuzzer_tlv_trusted_name.c
@@ -1,0 +1,46 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include "buffer.h"
+#include "use_cases/tlv_use_case_trusted_name.h"
+#include "tlv_mutator.h"
+
+// Grammar for the Trusted Name TLV use case: {Tag, Min length, Max length}
+const tlv_tag_info_t TRUSTED_NAME_TAGS_INFO[] = {
+    {0x01, 1,  1 }, // TAG_STRUCTURE_TYPE (uint8_t)
+    {0x02, 1,  1 }, // TAG_VERSION (uint8_t)
+    {0x70, 1,  1 }, // TAG_TRUSTED_NAME_TYPE (uint8_t)
+    {0x71, 1,  1 }, // TAG_TRUSTED_NAME_SOURCE (uint8_t)
+    {0x20, 1,  64}, // TAG_TRUSTED_NAME (String, max TRUSTED_NAME_STRINGS_MAX_SIZE)
+    {0x23, 1,  8 }, // TAG_CHAIN_ID (uint64_t, 1-8 bytes DER)
+    {0x22, 1,  40}, // TAG_ADDRESS (Buffer)
+    {0x72, 32, 32}, // TAG_NFT_ID (32 bytes fixed)
+    {0x73, 1,  40}, // TAG_SOURCE_CONTRACT (Buffer)
+    {0x12, 1,  4 }, // TAG_CHALLENGE (uint32_t, 1-4 bytes DER)
+    {0x10, 4,  4 }, // TAG_NOT_VALID_AFTER (semver: major + minor + patch = 4 bytes)
+    {0x13, 1,  2 }, // TAG_SIGNER_KEY_ID (uint16_t, 1-2 bytes DER)
+    {0x14, 1,  1 }, // TAG_SIGNER_ALGORITHM (uint8_t)
+    {0x15, 64, 72}, // TAG_DER_SIGNATURE (ECDSA DER 64-72 bytes)
+};
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    (void) argc;
+    (void) argv;
+    // Set the grammar for the custom mutator
+    current_tlv_fuzz_config.tags_info = TRUSTED_NAME_TAGS_INFO;
+    current_tlv_fuzz_config.num_tags
+        = sizeof(TRUSTED_NAME_TAGS_INFO) / sizeof(TRUSTED_NAME_TAGS_INFO[0]);
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    buffer_t               payload = {.ptr = (uint8_t *) data, .size = size, .offset = 0};
+    tlv_trusted_name_out_t out;
+    memset(&out, 0, sizeof(out));
+
+    tlv_use_case_trusted_name(&payload, &out);
+
+    return 0;
+}

--- a/fuzzing/harness/tlv_mutator.c
+++ b/fuzzing/harness/tlv_mutator.c
@@ -1,0 +1,174 @@
+#include "tlv_mutator.h"
+#include <string.h>
+#include <stdbool.h>
+
+extern size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);
+
+tlv_fuzz_config_t current_tlv_fuzz_config = {0};
+static bool       is_recursing            = false;
+
+// Pick a random TLV entry in the buffer. Returns false if none found.
+static bool pick_entry(const uint8_t *Data,
+                       size_t         Size,
+                       unsigned int   Seed,
+                       size_t        *off,
+                       size_t        *len)
+{
+    // Count well-formed entries
+    size_t count  = 0;
+    size_t cursor = 0;
+    while (cursor + 2 <= Size) {
+        uint8_t l = Data[cursor + 1];
+        if (cursor + 2 + l > Size) {
+            break;
+        }
+        count++;
+        cursor += 2 + l;
+    }
+    if (count == 0) {
+        return false;
+    }
+
+    size_t target = Seed % count;
+    cursor        = 0;
+    for (size_t i = 0; i < count; i++) {
+        uint8_t l = Data[cursor + 1];
+        if (i == target) {
+            *off = cursor;
+            *len = 2 + l;
+            return true;
+        }
+        cursor += 2 + l;
+    }
+    return false;
+}
+
+// Build a complete TLV message containing all grammar tags with random values.
+static size_t build_complete(uint8_t *Data, size_t MaxSize, unsigned int Seed)
+{
+    size_t pos = 0;
+    for (size_t i = 0; i < current_tlv_fuzz_config.num_tags; i++) {
+        const tlv_tag_info_t *t   = &current_tlv_fuzz_config.tags_info[i];
+        uint8_t               rng = (t->max_len >= t->min_len) ? (t->max_len - t->min_len + 1) : 1;
+        uint8_t               len = t->min_len + (Seed % rng);
+
+        if (pos + 2 + len > MaxSize) {
+            break;
+        }
+        Data[pos]     = t->tag;
+        Data[pos + 1] = len;
+        for (uint8_t j = 0; j < len; j++) {
+            Data[pos + 2 + j] = (uint8_t) (Seed >> ((j + i) % 24));
+        }
+        pos += 2 + len;
+        Seed = Seed * 1103515245u + 12345u;
+    }
+    return pos;
+}
+
+// Append one grammar-valid TLV entry at the end.
+static size_t append_tag(uint8_t *Data, size_t Size, size_t MaxSize, unsigned int Seed)
+{
+    const tlv_tag_info_t *t
+        = &current_tlv_fuzz_config.tags_info[Seed % current_tlv_fuzz_config.num_tags];
+    uint8_t rng = (t->max_len >= t->min_len) ? (t->max_len - t->min_len + 1) : 1;
+    uint8_t len = t->min_len + ((Seed >> 8) % rng);
+
+    if (Size + 2 + len > MaxSize) {
+        return Size;
+    }
+    Data[Size]     = t->tag;
+    Data[Size + 1] = len;
+    for (uint8_t i = 0; i < len; i++) {
+        Data[Size + 2 + i] = (uint8_t) (Seed >> (i % 8));
+    }
+    return Size + 2 + len;
+}
+
+// Remove a random TLV entry from the buffer.
+static size_t delete_entry(uint8_t *Data, size_t Size, unsigned int Seed)
+{
+    size_t off, len;
+    if (!pick_entry(Data, Size, Seed, &off, &len) || len >= Size) {
+        return Size;
+    }
+    memmove(&Data[off], &Data[off + len], Size - off - len);
+    return Size - len;
+}
+
+// Duplicate a random TLV entry at the end.
+static size_t duplicate_entry(uint8_t *Data, size_t Size, size_t MaxSize, unsigned int Seed)
+{
+    size_t off, len;
+    if (!pick_entry(Data, Size, Seed, &off, &len) || Size + len > MaxSize) {
+        return Size;
+    }
+    memcpy(&Data[Size], &Data[off], len);
+    return Size + len;
+}
+
+// Corrupt the length byte of a random entry.
+static size_t corrupt_length(uint8_t *Data, size_t Size, unsigned int Seed)
+{
+    size_t off, len;
+    if (!pick_entry(Data, Size, Seed, &off, &len)) {
+        return Size;
+    }
+    // Pick between: 0, 0xFF, random byte
+    uint8_t choices[] = {0x00, 0xFF, (uint8_t) (Seed >> 12)};
+    Data[off + 1]     = choices[(Seed >> 8) % 3];
+    return Size;
+}
+
+// Truncate the buffer at a random offset.
+static size_t truncate_buf(size_t Size, unsigned int Seed)
+{
+    return (Size > 1) ? 1 + (Seed % (Size - 1)) : Size;
+}
+
+size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size, size_t MaxSize, unsigned int Seed)
+{
+    // Guard against recursion from LLVMFuzzerMutate
+    if (is_recursing) {
+        if (Size > 0) {
+            Data[Seed % Size] ^= (Seed >> 8) & 0xFF;
+        }
+        return Size;
+    }
+
+    // Fallback to default mutator if no grammar is set
+    if (current_tlv_fuzz_config.num_tags == 0) {
+        is_recursing = true;
+        Size         = LLVMFuzzerMutate(Data, Size, MaxSize);
+        is_recursing = false;
+        return Size;
+    }
+
+    unsigned int roll = Seed % 100;
+
+    // 50% structure-preserving
+    if (roll < 10) {
+        return build_complete(Data, MaxSize, Seed);
+    }
+    if (roll < 30) {
+        return append_tag(Data, Size, MaxSize, Seed);
+    }
+    if (roll < 40) {
+        return duplicate_entry(Data, Size, MaxSize, Seed);
+    }
+    if (roll < 50) {
+        return delete_entry(Data, Size, Seed);
+    }
+
+    // 50% error-inducing (let the default mutator hit parser error paths)
+    if (roll < 80) {
+        is_recursing = true;
+        Size         = LLVMFuzzerMutate(Data, Size, MaxSize);
+        is_recursing = false;
+        return Size;
+    }
+    if (roll < 90) {
+        return corrupt_length(Data, Size, Seed);
+    }
+    return truncate_buf(Size, Seed);
+}

--- a/fuzzing/harness/tlv_mutator.c
+++ b/fuzzing/harness/tlv_mutator.c
@@ -1,11 +1,22 @@
 #include "tlv_mutator.h"
-#include <string.h>
 #include <stdbool.h>
+#include <string.h>
 
 extern size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);
 
 tlv_fuzz_config_t current_tlv_fuzz_config = {0};
-static bool       is_recursing            = false;
+
+// Pick a valid value length for one grammar tag.
+static size_t pick_tag_length(const tlv_tag_info_t *t, unsigned int Seed)
+{
+    size_t range = 1;
+
+    if (t->max_len >= t->min_len) {
+        range = (size_t) t->max_len - (size_t) t->min_len + 1u;
+    }
+
+    return (size_t) t->min_len + ((size_t) Seed % range);
+}
 
 // Pick a random TLV entry in the buffer. Returns false if none found.
 static bool pick_entry(const uint8_t *Data,
@@ -49,15 +60,14 @@ static size_t build_complete(uint8_t *Data, size_t MaxSize, unsigned int Seed)
     size_t pos = 0;
     for (size_t i = 0; i < current_tlv_fuzz_config.num_tags; i++) {
         const tlv_tag_info_t *t   = &current_tlv_fuzz_config.tags_info[i];
-        uint8_t               rng = (t->max_len >= t->min_len) ? (t->max_len - t->min_len + 1) : 1;
-        uint8_t               len = t->min_len + (Seed % rng);
+        size_t                len = pick_tag_length(t, Seed);
 
         if (pos + 2 + len > MaxSize) {
             break;
         }
         Data[pos]     = t->tag;
-        Data[pos + 1] = len;
-        for (uint8_t j = 0; j < len; j++) {
+        Data[pos + 1] = (uint8_t) len;
+        for (size_t j = 0; j < len; j++) {
             Data[pos + 2 + j] = (uint8_t) (Seed >> ((j + i) % 24));
         }
         pos += 2 + len;
@@ -71,15 +81,14 @@ static size_t append_tag(uint8_t *Data, size_t Size, size_t MaxSize, unsigned in
 {
     const tlv_tag_info_t *t
         = &current_tlv_fuzz_config.tags_info[Seed % current_tlv_fuzz_config.num_tags];
-    uint8_t rng = (t->max_len >= t->min_len) ? (t->max_len - t->min_len + 1) : 1;
-    uint8_t len = t->min_len + ((Seed >> 8) % rng);
+    size_t len = pick_tag_length(t, Seed >> 8);
 
     if (Size + 2 + len > MaxSize) {
         return Size;
     }
     Data[Size]     = t->tag;
-    Data[Size + 1] = len;
-    for (uint8_t i = 0; i < len; i++) {
+    Data[Size + 1] = (uint8_t) len;
+    for (size_t i = 0; i < len; i++) {
         Data[Size + 2 + i] = (uint8_t) (Seed >> (i % 8));
     }
     return Size + 2 + len;
@@ -103,7 +112,7 @@ static size_t duplicate_entry(uint8_t *Data, size_t Size, size_t MaxSize, unsign
     if (!pick_entry(Data, Size, Seed, &off, &len) || Size + len > MaxSize) {
         return Size;
     }
-    memcpy(&Data[Size], &Data[off], len);
+    memmove(&Data[Size], &Data[off], len);
     return Size + len;
 }
 
@@ -128,20 +137,9 @@ static size_t truncate_buf(size_t Size, unsigned int Seed)
 
 size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size, size_t MaxSize, unsigned int Seed)
 {
-    // Guard against recursion from LLVMFuzzerMutate
-    if (is_recursing) {
-        if (Size > 0) {
-            Data[Seed % Size] ^= (Seed >> 8) & 0xFF;
-        }
-        return Size;
-    }
-
     // Fallback to default mutator if no grammar is set
     if (current_tlv_fuzz_config.num_tags == 0) {
-        is_recursing = true;
-        Size         = LLVMFuzzerMutate(Data, Size, MaxSize);
-        is_recursing = false;
-        return Size;
+        return LLVMFuzzerMutate(Data, Size, MaxSize);
     }
 
     unsigned int roll = Seed % 100;
@@ -162,10 +160,7 @@ size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size, size_t MaxSize, unsig
 
     // 50% error-inducing (let the default mutator hit parser error paths)
     if (roll < 80) {
-        is_recursing = true;
-        Size         = LLVMFuzzerMutate(Data, Size, MaxSize);
-        is_recursing = false;
-        return Size;
+        return LLVMFuzzerMutate(Data, Size, MaxSize);
     }
     if (roll < 90) {
         return corrupt_length(Data, Size, Seed);

--- a/fuzzing/harness/tlv_mutator.h
+++ b/fuzzing/harness/tlv_mutator.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Generic TLV custom mutator for libFuzzer.
+ *
+ * Use-case agnostic: set current_tlv_fuzz_config from your harness
+ * with the tag grammar of your TLV use case.
+ * See fuzzing/README.md for integration details.
+ */
+
+typedef struct {
+    uint8_t tag;
+    uint8_t min_len;
+    uint8_t max_len;
+} tlv_tag_info_t;
+
+typedef struct {
+    const tlv_tag_info_t *tags_info;
+    size_t                num_tags;
+} tlv_fuzz_config_t;
+
+extern tlv_fuzz_config_t current_tlv_fuzz_config;

--- a/fuzzing/libs/lib_tlv.cmake
+++ b/fuzzing/libs/lib_tlv.cmake
@@ -3,12 +3,13 @@ include(${BOLOS_SDK}/fuzzing/macros/macros.cmake)
 include(${BOLOS_SDK}/fuzzing/libs/lib_cxng.cmake)
 include(${BOLOS_SDK}/fuzzing/mock/mock.cmake)
 
-file(GLOB LIB_TLV_SOURCES "${BOLOS_SDK}/lib_tlv/*.c")
+file(GLOB LIB_TLV_SOURCES "${BOLOS_SDK}/lib_tlv/*.c" "${BOLOS_SDK}/lib_tlv/use_cases/*.c")
 
 add_library(tlv ${LIB_TLV_SOURCES})
 target_compile_options(tlv PUBLIC ${COMPILATION_FLAGS})
-target_link_libraries(tlv PUBLIC macros mock cxng)
+target_link_libraries(tlv PUBLIC macros mock cxng pki)
 target_include_directories(
   tlv
   PUBLIC "${BOLOS_SDK}/include/" "${BOLOS_SDK}/target/${TARGET}/include"
-         "${BOLOS_SDK}/lib_tlv/" "${BOLOS_SDK}/lib_cxng/include")
+         "${BOLOS_SDK}/lib_tlv/" "${BOLOS_SDK}/lib_cxng/include"
+         "${BOLOS_SDK}/lib_pki")

--- a/fuzzing/macros/exclude_macros.txt
+++ b/fuzzing/macros/exclude_macros.txt
@@ -2,4 +2,7 @@
 PRINTF(...)=
 # Breaks pic mock function
 USE_OS_IO_STACK
+# Host fuzzing does not build the ARM assembly SHA-512 alternate path.
+HAVE_SHA512_WITH_BLOCK_ALT_METHOD
+HAVE_SHA512_WITH_BLOCK_ALT_METHOD_M0
 NDEBUG

--- a/fuzzing/mock/mock_check_signature_with_pki.c
+++ b/fuzzing/mock/mock_check_signature_with_pki.c
@@ -1,9 +1,10 @@
 /**
- * Shared mocks for TLV fuzzers.
+ * Shared mock for fuzzing: `check_signature_with_pki` always succeeds.
  *
- * Overrides the weak mock of check_signature_with_pki to always return success.
- * This allows fuzzers to reach all code paths past signature verification,
- * which is the interesting attack surface for TLV parsing bugs.
+ * Link this translation unit into a fuzz target (alongside the real PKI library)
+ * to reach code paths past signature verification — the interesting surface for
+ * many TLV and parsing fuzzers. Also useful for any other harness that calls PKI
+ * verification without a real certificate chain.
  */
 
 #include "ledger_pki.h"


### PR DESCRIPTION
## Description

Add a  TLV custom mutator (`tlv_mutator.c`) for libFuzzer that generates
 valid TLV messages with 6 mutation strategies: build, append, delete, duplicate,
corrupt length, and truncate.

Add two  harnesses for  TLV use cases:
- **Trusted Name** (`fuzzer_tlv_trusted_name.c`)
- **Dynamic Descriptor** (`fuzzer_tlv_dynamic_descriptor.c`)

The mutator is use-case agnostic: each harness defines its own tag grammar via a
`tlv_tag_info_t` array, making it reusable for any future TLV-based fuzzing target.


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [x] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_25

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...