### PR TITLE
lib_cxng: further input validation

### DIFF
--- a/lib_cxng/src/cx_aes_gcm.c
+++ b/lib_cxng/src/cx_aes_gcm.c
@@ -306,6 +306,10 @@ cx_err_t cx_aes_gcm_finish(cx_aes_gcm_context_t *ctx, uint8_t *tag, size_t tag_l
 {
     cx_err_t error;
 
+    if (tag_len > AES_GCM_TAG_LEN) {
+        return CX_INVALID_PARAMETER_SIZE;
+    }
+
     STORE64BE(ctx->aad_len * 8, ctx->J0);
     STORE64BE(ctx->len * 8, ctx->J0 + 8);
     cx_gcm_xor_block(ctx->processed, ctx->processed, ctx->J0, AES_BLOCK_BYTES);

--- a/lib_cxng/src/cx_ecdh.c
+++ b/lib_cxng/src/cx_ecdh.c
@@ -84,6 +84,14 @@ cx_err_t cx_ecdh_no_throw(const cx_ecfp_private_key_t *key,
     CX_CHECK(cx_bn_lock(sz, 0));
     CX_CHECK(cx_ecpoint_alloc(&W, curve));
     CX_CHECK(cx_ecpoint_init(&W, public_point + 1, sz, public_point + 1 + sz, sz));
+
+    bool is_on_curve;
+    CX_CHECK(cx_ecpoint_is_on_curve(&W, &is_on_curve));
+    if (!is_on_curve) {
+        error = CX_EC_INVALID_POINT;
+        goto end;
+    }
+
     // Scalar multiplication with random projective coordinates and additive splitting
     if (CX_CURVE_RANGE(curve, WEIERSTRASS)) {
         CX_CHECK(cx_ecpoint_rnd_fixed_scalarmul(&W, key->d, key->d_len));

--- a/lib_cxng/src/cx_ecschnorr.c
+++ b/lib_cxng/src/cx_ecschnorr.c
@@ -120,7 +120,7 @@ cx_err_t cx_ecschnorr_sign_no_throw(const cx_ecfp_private_key_t *pv_key,
         CX_CHECK(cx_hash_no_throw((cx_hash_t *) &H, 0, sig, size, NULL, 0));
         CX_CHECK(cx_ecpoint_export(&Q, P, size, NULL, 0));
         CX_CHECK(cx_hash_no_throw((cx_hash_t *) &H, 0, P, size, NULL, 0));
-        CX_CHECK(cx_hash_no_throw((cx_hash_t *) &H, CX_LAST | CX_NO_REINIT, msg, size, sig, size));
+        CX_CHECK(cx_hash_no_throw((cx_hash_t *) &H, CX_LAST | CX_NO_REINIT, msg, msg_len, sig, size));
     }
 
     // generate random
@@ -445,6 +445,10 @@ bool cx_ecschnorr_verify(const cx_ecfp_public_key_t *pu_key,
     CX_CHECK(cx_bn_alloc(&bn_n, size));
     CX_CHECK(cx_ecdomain_parameter_bn(pu_key->curve, CX_CURVE_PARAM_Order, bn_n));
     if ((mode & CX_MASK_EC) == CX_ECSCHNORR_BIP0340) {
+        if (sig_len < 2 * size) {
+            verified = false;
+            goto end;
+        }
         CX_CHECK(cx_bn_alloc_init(&bn_r, size, sig, size));
         CX_CHECK(cx_bn_alloc_init(&bn_s, size, sig + size, size));
     }

--- a/lib_cxng/src/cx_ecschnorr.c
+++ b/lib_cxng/src/cx_ecschnorr.c
@@ -120,7 +120,8 @@ cx_err_t cx_ecschnorr_sign_no_throw(const cx_ecfp_private_key_t *pv_key,
         CX_CHECK(cx_hash_no_throw((cx_hash_t *) &H, 0, sig, size, NULL, 0));
         CX_CHECK(cx_ecpoint_export(&Q, P, size, NULL, 0));
         CX_CHECK(cx_hash_no_throw((cx_hash_t *) &H, 0, P, size, NULL, 0));
-        CX_CHECK(cx_hash_no_throw((cx_hash_t *) &H, CX_LAST | CX_NO_REINIT, msg, msg_len, sig, size));
+        CX_CHECK(
+            cx_hash_no_throw((cx_hash_t *) &H, CX_LAST | CX_NO_REINIT, msg, msg_len, sig, size));
     }
 
     // generate random

--- a/lib_cxng/src/cx_pkcs1.c
+++ b/lib_cxng/src/cx_pkcs1.c
@@ -378,6 +378,9 @@ cx_err_t cx_pkcs1_emsa_pss_encode_with_salt_len(cx_md_t        hID,
     }
     mDBlen = emLen - (1 + hLen);
 
+    if (mSaltLen > sizeof(salt)) {
+        return CX_INVALID_PARAMETER;
+    }
     if ((hLen + mSaltLen + 2) >= emLen) {
         return CX_INVALID_PARAMETER;
     }

--- a/lib_cxng/src/cx_rsa.c
+++ b/lib_cxng/src/cx_rsa.c
@@ -510,6 +510,10 @@ cx_err_t cx_rsa_decrypt_no_throw(const cx_rsa_private_key_t *key,
     switch (mode & CX_MASK_PAD) {
         case CX_PAD_PKCS1_1o5:
             *dec_len = cx_pkcs1_eme_v1o5_decode(hashID, dec, key->size, dec, *dec_len);
+            if (*dec_len == (size_t) -1) {
+                error = CX_INVALID_PARAMETER;
+                goto end;
+            }
             break;
         case CX_PAD_PKCS1_OAEP:
             CX_CHECK(cx_pkcs1_eme_oaep_decode(hashID, dec, key->size, dec, dec_len));


### PR DESCRIPTION
## Description

- Fix message length parameter in BIP0340 Schnorr nonce derivation to hash the full message
- Add signature length validation in BIP0340 Schnorr verification
- Add on-curve validation for the peer point in ECDH
- Bound the PSS salt length to the stack buffer size
- Propagate PKCS#1 v1.5 padding decode errors in RSA decrypt
- Validate tag_len in cx_aes_gcm_finish to match the existing check in cx_aes_gcm_check_tag

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_25
[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...

