### PR TITLE
Sanitize head_ref in branch delete job

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -28,10 +28,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Delete branch
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
         # Check if branch exists before deleting
-        if git ls-remote --heads origin ${{ github.head_ref }} | grep -q .; then
-          git push origin --delete ${{ github.head_ref }}
+        if git ls-remote --heads origin "$HEAD_REF" | grep -q .; then
+          git push origin --delete "$HEAD_REF"
         fi
 
   PR_Check:


### PR DESCRIPTION
## Description

Sanitize `head_ref` in branch delete job

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_25
[ ] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
