### PR TITLE
fix: do not send apdu to app if device is locked

### DIFF
--- a/io_legacy/src/os_io_legacy.c
+++ b/io_legacy/src/os_io_legacy.c
@@ -399,6 +399,10 @@ int io_legacy_apdu_rx(uint8_t handle_ux_events)
                     G_io_tx_buffer[0] = err >> 8;
                     G_io_tx_buffer[1] = err;
                     status            = os_io_tx_cmd(io_os_legacy_apdu_type, G_io_tx_buffer, 2, 0);
+                    io_os_legacy_apdu_type = APDU_TYPE_NONE;
+                    if (status > 0) {
+                        status = 0;
+                    }
                 }
 #ifndef HAVE_BOLOS_NO_DEFAULT_APDU
                 else if (G_io_rx_buffer[APDU_OFF_CLA + 1] == DEFAULT_APDU_CLA) {


### PR DESCRIPTION
## Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ x] TARGET_API_LEVEL: API_LEVEL_25
[ x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
