### PR TITLE
Add compilation flag to allow not shuffle keyboard for tests

### DIFF
--- a/lib_nbgl/src/nbgl_layout_keyboard_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard_nanos.c
@@ -67,8 +67,12 @@ int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInf
     keyboard->obfuscated           = kbdInfo->obfuscated;
 
     if (kbdInfo->lettersOnly) {
+#ifdef KEYBOARD_NOT_SHUFFLED
+        keyboard->selectedCharIndex = 0;
+#else
         keyboard->selectedCharIndex = cx_rng_u32() % 26;
-        keyboard->mode              = MODE_LOWER_LETTERS;
+#endif
+        keyboard->mode = MODE_LOWER_LETTERS;
     }
     else {
         keyboard->mode = kbdInfo->mode;
@@ -107,12 +111,16 @@ int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout, uint8_t index, uint32_t key
         return -1;
     }
     if (keyboard->lettersOnly) {
+#ifdef KEYBOARD_NOT_SHUFFLED
+        keyboard->selectedCharIndex = 0;
+#else
         if (keyMask & (1 << 26)) {
             keyboard->selectedCharIndex = cx_rng_u32() % 26;
         }
         else {
             keyboard->selectedCharIndex = 0;
         }
+#endif
     }
     else {
         // if current keyMask was O and new one filters all keys,


### PR DESCRIPTION
## Description

Just for test, under compilation flag to be enabled in App side

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_25
[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.