### PR TITLE
Fix warning in is_zeroes_buffer

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -238,7 +238,7 @@ bool is_printable_string(const char *str, size_t len)
  */
 bool is_zeroes_buffer(const void *buf, size_t n)
 {
-    uint8_t *p = (uint8_t *) buf;
+    const uint8_t *p = buf;
     for (size_t i = 0; i < n; ++i) {
         if (p[i] != 0) {
             return false;


### PR DESCRIPTION
## Description

Fix cast-qual warning in is_zeroes_buffer()

```
public_sdk/src/os.c:241:18: error: cast discards 'const' qualifier from pointer target type [-Werror=cast-qual]
uint8_t *p = (uint8_t *) buf;
```

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_25
[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
