### PR TITLE
Add use cases into TLV fuzzing library

### DIFF
--- a/fuzzing/libs/lib_tlv.cmake
+++ b/fuzzing/libs/lib_tlv.cmake
@@ -3,12 +3,23 @@ include(${BOLOS_SDK}/fuzzing/macros/macros.cmake)
 include(${BOLOS_SDK}/fuzzing/libs/lib_cxng.cmake)
 include(${BOLOS_SDK}/fuzzing/mock/mock.cmake)
 
-file(GLOB LIB_TLV_SOURCES "${BOLOS_SDK}/lib_tlv/*.c")
+file(
+    GLOB
+    LIB_TLV_SOURCES
+    "${BOLOS_SDK}/lib_tlv/*.c"
+    "${BOLOS_SDK}/lib_tlv/use_cases/*.c"
+)
 
 add_library(tlv ${LIB_TLV_SOURCES})
 target_compile_options(tlv PUBLIC ${COMPILATION_FLAGS})
 target_link_libraries(tlv PUBLIC macros mock cxng)
 target_include_directories(
-  tlv
-  PUBLIC "${BOLOS_SDK}/include/" "${BOLOS_SDK}/target/${TARGET}/include"
-         "${BOLOS_SDK}/lib_tlv/" "${BOLOS_SDK}/lib_cxng/include")
+    tlv
+    PUBLIC
+    "${BOLOS_SDK}/include"
+    "${BOLOS_SDK}/target/${TARGET}/include"
+    "${BOLOS_SDK}/lib_cxng/include"
+    "${BOLOS_SDK}/lib_pki"
+    "${BOLOS_SDK}/lib_tlv"
+    "${BOLOS_SDK}/lib_tlv/use_cases"
+)


### PR DESCRIPTION
## Description

So apps using TLV use-cases don't have issues compiling their fuzzer.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
