### PR TITLE
Add support for multi identifier in a group

### DIFF
--- a/app_features/address_book/doc/address_book_spec.md
+++ b/app_features/address_book/doc/address_book_spec.md
@@ -126,6 +126,7 @@ Commands that require multi-chunk transport:
 - **Edit Identifier** (§5.3, up to 428 B)
 - **Edit Scope** (§5.4, up to 380 B)
 - **Provide Contact** (§5.7, up to 362 B)
+- **Register Identity** (§5.1, up to 312 B) — only when `GROUP_HANDLE` + `HMAC_PROOF` are present **and** the identifier exceeds ~38 bytes (i.e. non-Ethereum chains); Ethereum stays within 255 B ✓
 
 ---
 
@@ -247,27 +248,42 @@ Registers a `(name, scope, identifier)` tuple on the device. The `ACCOUNT_IDENTI
 
 The response contains two independent **HMAC Proofs of Registration** (`HMAC_PROOF` and `HMAC_REST`) that cryptographically bind the contact to this device.
 
+#### Two operating modes
+
+**New group (default):** `GROUP_HANDLE` and `HMAC_PROOF` are omitted. The device generates a fresh `gid`, computes a new `group_handle`, and returns `group_handle + HMAC_PROOF + HMAC_REST`. The wallet stores all three alongside the first `(scope, identifier)` record.
+
+**Link to existing group (optional):** `GROUP_HANDLE` and `HMAC_PROOF` are both provided. The device verifies the `group_handle` MAC and the `HMAC_PROOF` (proving the wallet owns the contact), then computes only a new `HMAC_REST` for the new `(scope, identifier)`. The response echoes back the same `group_handle` and `HMAC_PROOF`, with a freshly computed `HMAC_REST`.
+
+> Both optional tags must be present together or both absent — providing only one is rejected.
+
+This allows a wallet to register multiple addresses for the same contact (e.g. the same person's Ethereum Mainnet and Base addresses) under a single `group_handle`. A subsequent rename via Edit Contact Name then invalidates the shared `HMAC_PROOF` for all addresses at once.
+
 #### TLV payload
 
-| Tag Name           | Value | Mandatory | Max size | Description                                                           |
-|--------------------|-------|-----------|----------|-----------------------------------------------------------------------|
-| STRUCT_TYPE        | 0x01  | Yes       | 1 B      | 0x2d (`TYPE_REGISTER_IDENTITY`)                                       |
-| STRUCT_VERSION     | 0x02  | Yes       | 1 B      | 0x01                                                                  |
-| CONTACT_NAME       | 0xf0  | Yes       | 32 B     | Contact name (max 32 printable ASCII chars)                           |
-| SCOPE              | 0xf1  | Yes       | 32 B     | Context string (e.g. "Ethereum", "Bitcoin legacy", "Solana USDC")     |
-| ACCOUNT_IDENTIFIER | 0xf2  | Yes       | 80 B     | Blockchain identifier (address or pubkey, chain-dependent)            |
-| DERIVATION_PATH    | 0x21  | Yes       | 41 B     | BIP32 derivation path (used to derive the HMAC key)                   |
-| CHAIN_ID           | 0x23  | Cond.     | 8 B      | Chain ID (mandatory for Ethereum)                                     |
-| BLOCKCHAIN_FAMILY  | 0x51  | Yes       | 1 B      | Blockchain family                                                     |
+| Tag Name           | Value | Mandatory | Max size | Description                                                                          |
+|--------------------|-------|-----------|----------|--------------------------------------------------------------------------------------|
+| STRUCT_TYPE        | 0x01  | Yes       | 1 B      | 0x2d (`TYPE_REGISTER_IDENTITY`)                                                      |
+| STRUCT_VERSION     | 0x02  | Yes       | 1 B      | 0x01                                                                                 |
+| CONTACT_NAME       | 0xf0  | Yes       | 32 B     | Contact name (max 32 printable ASCII chars)                                          |
+| SCOPE              | 0xf1  | Yes       | 32 B     | Context string (e.g. "Ethereum", "Bitcoin legacy", "Solana USDC")                    |
+| ACCOUNT_IDENTIFIER | 0xf2  | Yes       | 80 B     | Blockchain identifier (address or pubkey, chain-dependent)                           |
+| DERIVATION_PATH    | 0x21  | Yes       | 41 B     | BIP32 derivation path (used to derive the HMAC key)                                  |
+| CHAIN_ID           | 0x23  | Cond.     | 8 B      | Chain ID (mandatory for Ethereum)                                                    |
+| BLOCKCHAIN_FAMILY  | 0x51  | Yes       | 1 B      | Blockchain family                                                                    |
+| GROUP_HANDLE       | 0xf6  | Optional  | 64 B     | Existing group handle — links this identifier to an existing contact group           |
+| HMAC_PROOF         | 0x29  | Optional  | 32 B     | `HMAC_PROOF` for the existing group — required when `GROUP_HANDLE` is present        |
 
-> **Payload size:** worst case (Ethereum, max path depth, max identifier, with scope) = **212 B** — fits in a single short APDU ✓
+> **Payload size (new group):** worst case (max identifier, max path depth) = **212 B** — fits in a single short APDU ✓
+>
+> **Payload size (existing group):** adds `GROUP_HANDLE` (66 B with TLV overhead) + `HMAC_PROOF` (34 B) = up to **312 B** for a maximum-size identifier. For Ethereum (20-byte address) the total remains within 255 B ✓. For other chains with large identifiers, multi-chunk transport (see §3) is required.
 
 #### Flow
 
 1. Parse TLV payload.
-2. Call `handle_check_identity()` (coin-app entrypoint) for chain-specific validation.
-3. Display to user: contact_name + scope + identifier.
-4. On confirm: generate `gid`, compute `group_handle`, `HMAC_PROOF`, and `HMAC_REST`, return all three.
+2. If `GROUP_HANDLE` is present: verify its MAC (constant-time), extract `gid`, re-derive `HMAC_PROOF` over `(gid, contact_name)` and compare (constant-time) — proves the wallet owns the existing group.
+3. Call `handle_check_identity()` (coin-app entrypoint) for chain-specific validation.
+4. Display to user: contact_name + scope + identifier.
+5. On confirm: generate `gid` and compute `group_handle` + `HMAC_PROOF` (new group), or reuse the verified `gid` and echo them back (existing group); then compute `HMAC_REST` for the new `(scope, identifier)`.
 
 ```mermaid
 sequenceDiagram
@@ -275,17 +291,24 @@ sequenceDiagram
     participant D as Device
     participant U as User
 
-    W->>D: CMD_REGISTER_IDENTITY (contact_name + scope + identifier + path + ...)
+    W->>D: CMD_REGISTER_IDENTITY (contact_name + scope + identifier + path [+ group_handle + hmac_proof] + ...)
     D->>D: Parse TLV
+    alt GROUP_HANDLE + HMAC_PROOF provided (existing group)
+        D->>D: Verify group_handle MAC, extract gid
+        D->>D: Re-derive HMAC_PROOF(gid, contact_name), compare — proves wallet owns the group
+    end
     D->>D: handle_check_identity() [coin-app]
     D->>U: Display: contact_name / scope / identifier
     U->>D: Confirm
-    D->>D: Generate gid (32 random bytes)
-    D->>D: group_handle = gid || HMAC-SHA256(K_group, gid)
-    D->>D: HMAC_PROOF = HMAC-SHA256(key, gid|name_len|name)
+    alt New group
+        D->>D: Generate gid, compute group_handle = gid || HMAC-SHA256(K_group, gid)
+        D->>D: HMAC_PROOF = HMAC-SHA256(key, gid|name_len|name)
+    else Existing group
+        Note right of D: Echo back received group_handle and hmac_proof
+    end
     D->>D: HMAC_REST = HMAC-SHA256(key, gid|scope_len|scope|id_len|identifier|family[|chain_id])
     D->>W: 0x2d | group_handle(64) | hmac_proof(32) | hmac_rest(32)  [9000]
-    W->>W: Store group_handle + hmac_proof + hmac_rest with contact record
+    W->>W: Store group_handle + hmac_proof + hmac_rest with (scope, identifier) record
 ```
 
 #### Response (on confirm)
@@ -295,9 +318,9 @@ type(1) | group_handle(64) | hmac_proof(32) | hmac_rest(32)  — total 129 bytes
 ```
 
 - `type` = `0x2d` (`TYPE_REGISTER_IDENTITY`)
-- `group_handle` = `gid(32) | HMAC-SHA256(K_group, gid)(32)` — opaque token to re-send on edits
-- `hmac_proof` = HMAC-SHA256 over: `gid(32) | name_len(1) | contact_name`
-- `hmac_rest` = HMAC-SHA256 over: `gid(32) | scope_len(1) | scope | identifier_len(1) | identifier | family(1) [ | chain_id(8) ]`
+- `group_handle` = `gid(32) | HMAC-SHA256(K_group, gid)(32)` — opaque token to re-send on edits; freshly generated (new group) or echoed back (existing group)
+- `hmac_proof` = HMAC-SHA256 over: `gid(32) | name_len(1) | contact_name` — freshly computed (new group) or echoed back (existing group)
+- `hmac_rest` = HMAC-SHA256 over: `gid(32) | scope_len(1) | scope | identifier_len(1) | identifier | family(1) [ | chain_id(8) ]` — always freshly computed for the new `(scope, identifier)` pair
 
 ### 5.2 Edit Contact Name
 

--- a/app_features/address_book/doc/address_book_spec.md
+++ b/app_features/address_book/doc/address_book_spec.md
@@ -281,7 +281,7 @@ This allows a wallet to register multiple addresses for the same contact (e.g. t
 
 1. Parse TLV payload.
 2. If `GROUP_HANDLE` is present: verify its MAC (constant-time), extract `gid`, re-derive `HMAC_PROOF` over `(gid, contact_name)` and compare (constant-time) — proves the wallet owns the existing group.
-3. Call `handle_check_identity()` (coin-app entrypoint) for chain-specific validation.
+3. Call `handle_check_register_identity()` (coin-app entrypoint) for chain-specific validation.
 4. Display to user: contact_name + scope + identifier.
 5. On confirm: generate `gid` and compute `group_handle` + `HMAC_PROOF` (new group), or reuse the verified `gid` and echo them back (existing group); then compute `HMAC_REST` for the new `(scope, identifier)`.
 
@@ -536,7 +536,7 @@ Registers a name for a Ledger-owned account, identified by its derivation path a
 #### Flow
 
 1. Parse TLV payload.
-2. Call `handle_check_ledger_account()` (coin-app entrypoint).
+2. Call `handle_check_register_ledger_account()` (coin-app entrypoint).
 3. Call `display_register_ledger_account_review()` (coin-app entrypoint) — the app owns the UI.
 4. On confirm: compute HMAC Proof of Registration and return it.
 
@@ -636,7 +636,7 @@ type(1) | hmac_proof(32)
 - **Structure type:** `0x33` (`TYPE_PROVIDE_CONTACT`)
 - **Guard:** `HAVE_ADDRESS_BOOK`
 
-Sent by the wallet **before a transaction** to let the device substitute a human-readable contact name (and scope) for a raw blockchain address on the review screen. The device verifies both HMAC proofs to guarantee that the contact was legitimately registered on this device, then exposes the validated data to the coin app via the `handle_provide_contact()` callback.
+Sent by the wallet **before a transaction** to let the device substitute a human-readable contact name (and scope) for a raw blockchain address on the review screen. The device verifies both HMAC proofs to guarantee that the contact was legitimately registered on this device, then exposes the validated data to the coin app via the `handle_provide_identity()` callback.
 
 #### TLV payload
 
@@ -662,7 +662,7 @@ Sent by the wallet **before a transaction** to let the device substitute a human
 2. Verify `group_handle` MAC (constant-time) and extract `gid`.
 3. Re-derive `HMAC_PROOF` over `(gid, contact_name)` and compare with `hmac_proof` (constant-time) — proves the name was registered on this device.
 4. Re-derive `HMAC_REST` over `(gid, scope, identifier, family [, chain_id])` and compare with `hmac_rest` (constant-time) — proves the scope and identifier were registered on this device.
-5. Call `handle_provide_contact()` (coin-app entrypoint) — passes the validated contact data for the app to store and use during the upcoming transaction review.
+5. Call `handle_provide_identity()` (coin-app entrypoint) — passes the validated contact data for the app to store and use during the upcoming transaction review.
 6. Return `9000` (no data).
 
 ```mermaid
@@ -698,7 +698,7 @@ sequenceDiagram
 
 Sent by the wallet **before a transaction** to let the device substitute the human-readable account name for the raw Ethereum address of a previously-registered Ledger Account. Unlike Provide Contact (§5.7), there is no external identifier, no `group_handle`, no `scope`, and no `HMAC_REST` — the only proof required is the `HMAC_PROOF` returned by Register Ledger Account.
 
-The device verifies the HMAC Proof of Registration, then derives the Ethereum address from the BIP32 path and exposes the validated `(address → name)` mapping to the coin app via `handle_provide_ledger_account_contact()`.
+The device verifies the HMAC Proof of Registration, then derives the Ethereum address from the BIP32 path and exposes the validated `(address → name)` mapping to the coin app via `handle_provide_ledger_account()`.
 
 #### TLV payload
 
@@ -718,7 +718,7 @@ The device verifies the HMAC Proof of Registration, then derives the Ethereum ad
 
 1. Parse TLV payload.
 2. Re-derive HMAC over `(account_name, family [, chain_id])` at the given BIP32 path and compare with `hmac_proof` (constant-time) — proves the account was registered on this device.
-3. Call `handle_provide_ledger_account_contact()` (coin-app entrypoint) — the app derives the Ethereum address from the BIP32 path, stores the `(address → name)` mapping for use during the upcoming transaction review.
+3. Call `handle_provide_ledger_account()` (coin-app entrypoint) — the app derives the Ethereum address from the BIP32 path, stores the `(address → name)` mapping for use during the upcoming transaction review.
 4. Return `9000` (no data).
 
 ```mermaid

--- a/app_features/address_book/doc/address_book_spec.md
+++ b/app_features/address_book/doc/address_book_spec.md
@@ -287,28 +287,25 @@ This allows a wallet to register multiple addresses for the same contact (e.g. t
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
-    participant U as User
 
-    W->>D: CMD_REGISTER_IDENTITY (contact_name + scope + identifier + path [+ group_handle + hmac_proof] + ...)
-    D->>D: Parse TLV
+    Wallet->>Device: CMD_REGISTER_IDENTITY (contact_name + scope + identifier + path [+ group_handle + hmac_proof] + ...)
+    Device->>Device: Parse TLV
     alt GROUP_HANDLE + HMAC_PROOF provided (existing group)
-        D->>D: Verify group_handle MAC, extract gid
-        D->>D: Re-derive HMAC_PROOF(gid, contact_name), compare — proves wallet owns the group
+        Device->>Device: Verify group_handle MAC, extract gid
+        Device->>Device: Re-derive HMAC_PROOF(gid, contact_name), compare — proves wallet owns the group
     end
-    D->>D: handle_check_identity() [coin-app]
-    D->>U: Display: contact_name / scope / identifier
-    U->>D: Confirm
+    Device->>Device: handle_check_register_identity() [coin-app]
+    Device->>User: Display: contact_name / scope / identifier
+    User->>Device: Confirm
     alt New group
-        D->>D: Generate gid, compute group_handle = gid || HMAC-SHA256(K_group, gid)
-        D->>D: HMAC_PROOF = HMAC-SHA256(key, gid|name_len|name)
+        Device->>Device: Generate gid, compute group_handle = gid || HMAC-SHA256(K_group, gid)
+        Device->>Device: HMAC_PROOF = HMAC-SHA256(key, gid|name_len|name)
     else Existing group
-        Note right of D: Echo back received group_handle and hmac_proof
+        Note right of Device: Echo back received group_handle and hmac_proof
     end
-    D->>D: HMAC_REST = HMAC-SHA256(key, gid|scope_len|scope|id_len|identifier|family[|chain_id])
-    D->>W: 0x2d | group_handle(64) | hmac_proof(32) | hmac_rest(32)  [9000]
-    W->>W: Store group_handle + hmac_proof + hmac_rest with (scope, identifier) record
+    Device->>Device: HMAC_REST = HMAC-SHA256(key, gid|scope_len|scope|id_len|identifier|family[|chain_id])
+    Device->>Wallet: 0x2d | group_handle(64) | hmac_proof(32) | hmac_rest(32)  [9000]
+    Wallet->>Wallet: Store group_handle + hmac_proof + hmac_rest with (scope, identifier) record
 ```
 
 #### Response (on confirm)
@@ -354,21 +351,19 @@ Changes the `CONTACT_NAME` of an existing contact. Because `HMAC_PROOF` covers o
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
-    participant U as User
 
-    Note over W: Has: group_handle, previous_name, hmac_proof (from registration)
-    W->>D: CMD_EDIT_CONTACT_NAME (group_handle + previous_name + new_name + hmac_proof + path)
-    D->>D: Parse TLV
-    D->>D: Verify group_handle MAC, extract gid
-    D->>D: Re-derive HMAC_PROOF(gid, previous_name), compare with hmac_proof
-    Note right of D: Proves contact registered on this device
-    D->>U: Display: previous_name → new_name
-    U->>D: Confirm
-    D->>D: HMAC_PROOF = HMAC-SHA256(key, gid|name_len|new_name)
-    D->>W: 0x2e | hmac_proof(32)  [9000]
-    W->>W: Replace stored hmac_proof and contact name
+    Note over Wallet: Has: group_handle, previous_name, hmac_proof (from registration)
+    Wallet->>Device: CMD_EDIT_CONTACT_NAME (group_handle + previous_name + new_name + hmac_proof + path)
+    Device->>Device: Parse TLV
+    Device->>Device: Verify group_handle MAC, extract gid
+    Device->>Device: Re-derive HMAC_PROOF(gid, previous_name), compare with hmac_proof
+    Note right of Device: Proves contact registered on this device
+    Device->>User: Display: previous_name → new_name
+    User->>Device: Confirm
+    Device->>Device: HMAC_PROOF = HMAC-SHA256(key, gid|name_len|new_name)
+    Device->>Wallet: 0x2e | hmac_proof(32)  [9000]
+    Device->>Device: on_edit_contact_name_applied() [coin-app] — update cached name in place
+    Wallet->>Wallet: Replace stored hmac_proof and contact name
 ```
 
 #### Response (on confirm)
@@ -419,23 +414,21 @@ Changes the `IDENTIFIER` of an existing contact while keeping the same `contact_
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
-    participant U as User
 
-    Note over W: Has: group_handle, contact_name, previous_identifier, hmac_proof, hmac_rest (from registration)
-    W->>D: CMD_EDIT_IDENTIFIER (group_handle + contact_name + new_identifier + previous_identifier + hmac_proof + hmac_rest + path + ...)
-    D->>D: Parse TLV
-    D->>D: Verify group_handle MAC, extract gid
-    D->>D: Re-derive HMAC_PROOF(gid, contact_name), compare with hmac_proof
-    D->>D: Re-derive HMAC_REST(gid, scope, previous_identifier, family[, chain_id]), compare with hmac_rest
-    Note right of D: Proves contact (name + identifier) registered on this device
-    D->>D: handle_check_edit_identifier() [coin-app]
-    D->>U: Display: contact_name / previous_identifier → new_identifier
-    U->>D: Confirm
-    D->>D: HMAC_REST = HMAC-SHA256(key, gid|scope_len|scope|id_len|new_identifier|family[|chain_id])
-    D->>W: 0x31 | hmac_rest(32)  [9000]
-    W->>W: Replace stored hmac_rest and identifier with new values
+    Note over Wallet: Has: group_handle, contact_name, previous_identifier, hmac_proof, hmac_rest (from registration)
+    Wallet->>Device: CMD_EDIT_IDENTIFIER (group_handle + contact_name + new_identifier + previous_identifier + hmac_proof + hmac_rest + path + ...)
+    Device->>Device: Parse TLV
+    Device->>Device: Verify group_handle MAC, extract gid
+    Device->>Device: Re-derive HMAC_PROOF(gid, contact_name), compare with hmac_proof
+    Device->>Device: Re-derive HMAC_REST(gid, scope, previous_identifier, family[, chain_id]), compare with hmac_rest
+    Note right of Device: Proves contact (name + identifier) registered on this device
+    Device->>Device: handle_check_edit_identifier() [coin-app]
+    Device->>User: Display: contact_name / previous_identifier → new_identifier
+    User->>Device: Confirm
+    Device->>Device: HMAC_REST = HMAC-SHA256(key, gid|scope_len|scope|id_len|new_identifier|family[|chain_id])
+    Device->>Wallet: 0x31 | hmac_rest(32)  [9000]
+    Device->>Device: on_edit_identifier_applied() [coin-app] — update cached identifier in place
+    Wallet->>Wallet: Replace stored hmac_rest and identifier with new values
 ```
 
 #### Response (on confirm)
@@ -485,22 +478,20 @@ Changes the `SCOPE` of an existing contact while keeping the same `contact_name`
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
-    participant U as User
 
-    Note over W: Has: group_handle, contact_name, previous_scope, hmac_proof, hmac_rest (from registration)
-    W->>D: CMD_EDIT_SCOPE (group_handle + contact_name + new_scope + previous_scope + hmac_proof + hmac_rest + identifier + path + ...)
-    D->>D: Parse TLV
-    D->>D: Verify group_handle MAC, extract gid
-    D->>D: Re-derive HMAC_PROOF(gid, contact_name), compare with hmac_proof
-    D->>D: Re-derive HMAC_REST(gid, previous_scope, identifier, family[, chain_id]), compare with hmac_rest
-    Note right of D: Proves contact (name + scope) registered on this device
-    D->>U: Display: contact_name / previous_scope → new_scope
-    U->>D: Confirm
-    D->>D: HMAC_REST = HMAC-SHA256(key, gid|scope_len|new_scope|id_len|identifier|family[|chain_id])
-    D->>W: 0x32 | hmac_rest(32)  [9000]
-    W->>W: Replace stored hmac_rest and contact scope
+    Note over Wallet: Has: group_handle, contact_name, previous_scope, hmac_proof, hmac_rest (from registration)
+    Wallet->>Device: CMD_EDIT_SCOPE (group_handle + contact_name + new_scope + previous_scope + hmac_proof + hmac_rest + identifier + path + ...)
+    Device->>Device: Parse TLV
+    Device->>Device: Verify group_handle MAC, extract gid
+    Device->>Device: Re-derive HMAC_PROOF(gid, contact_name), compare with hmac_proof
+    Device->>Device: Re-derive HMAC_REST(gid, previous_scope, identifier, family[, chain_id]), compare with hmac_rest
+    Note right of Device: Proves contact (name + scope) registered on this device
+    Device->>User: Display: contact_name / previous_scope → new_scope
+    User->>Device: Confirm
+    Device->>Device: HMAC_REST = HMAC-SHA256(key, gid|scope_len|new_scope|id_len|identifier|family[|chain_id])
+    Device->>Wallet: 0x32 | hmac_rest(32)  [9000]
+    Device->>Device: on_edit_scope_applied() [coin-app] — update cached scope in place
+    Wallet->>Wallet: Replace stored hmac_rest and contact scope
 ```
 
 #### Response (on confirm)
@@ -542,20 +533,17 @@ Registers a name for a Ledger-owned account, identified by its derivation path a
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
-    participant U as User
 
-    W->>D: CMD_REGISTER_LEDGER_ACCOUNT (contact_name + path + family + ...)
-    D->>D: Parse TLV
-    D->>D: handle_check_ledger_account() [coin-app]
-    D->>D: display_register_ledger_account_review() [coin-app]
-    D->>U: Display: account name + address
-    U->>D: Confirm
-    D->>D: Derive HMAC key at BIP32 path (Ledger Account KDF)
-    D->>D: HMAC-SHA256(key, name_len|name|family[|chain_id])
-    D->>W: 0x2f | hmac_proof(32)  [9000]
-    W->>W: Store hmac_proof with account record
+    Wallet->>Device: CMD_REGISTER_LEDGER_ACCOUNT (contact_name + path + family + ...)
+    Device->>Device: Parse TLV
+    Device->>Device: handle_check_register_ledger_account() [coin-app]
+    Device->>Device: display_register_ledger_account_review() [coin-app]
+    Device->>User: Display: account name + address
+    User->>Device: Confirm
+    Device->>Device: Derive HMAC key at BIP32 path (Ledger Account KDF)
+    Device->>Device: HMAC-SHA256(key, name_len|name|family[|chain_id])
+    Device->>Wallet: 0x2f | hmac_proof(32)  [9000]
+    Wallet->>Wallet: Store hmac_proof with account record
 ```
 
 #### Response (on confirm)
@@ -603,20 +591,18 @@ Display is handled entirely by the SDK. The coin app only provides `finalize_ui_
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
-    participant U as User
 
-    Note over W: Has: previous_name, hmac_proof (from registration)
-    W->>D: CMD_EDIT_LEDGER_ACCOUNT (previous_name + new_name + hmac_proof + path + family + ...)
-    D->>D: Parse TLV
-    D->>D: Re-derive HMAC(previous_name, family[, chain_id]), compare with hmac_proof
-    Note right of D: Proves account registered on this device
-    D->>U: Display: previous_name → new_name
-    U->>D: Confirm
-    D->>D: HMAC-SHA256(key, new_name_len|new_name|family[|chain_id])
-    D->>W: 0x30 | hmac_proof(32)  [9000]
-    W->>W: Replace stored hmac_proof with new account record
+    Note over Wallet: Has: previous_name, hmac_proof (from registration)
+    Wallet->>Device: CMD_EDIT_LEDGER_ACCOUNT (previous_name + new_name + hmac_proof + path + family + ...)
+    Device->>Device: Parse TLV
+    Device->>Device: Re-derive HMAC(previous_name, family[, chain_id]), compare with hmac_proof
+    Note right of Device: Proves account registered on this device
+    Device->>User: Display: previous_name → new_name
+    User->>Device: Confirm
+    Device->>Device: HMAC-SHA256(key, new_name_len|new_name|family[|chain_id])
+    Device->>Wallet: 0x30 | hmac_proof(32)  [9000]
+    Device->>Device: on_edit_ledger_account_applied() [coin-app] — update cached account name in place
+    Wallet->>Wallet: Replace stored hmac_proof with new account record
 ```
 
 #### Response (on confirm)
@@ -667,19 +653,17 @@ Sent by the wallet **before a transaction** to let the device substitute a human
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
 
-    Note over W: Has: group_handle, contact_name, scope, identifier, hmac_proof, hmac_rest
-    W->>D: CMD_PROVIDE_CONTACT (group_handle + contact_name + scope + identifier + hmac_proof + hmac_rest + path + ...)
-    D->>D: Parse TLV
-    D->>D: Verify group_handle MAC, extract gid
-    D->>D: Re-derive HMAC_PROOF(gid, contact_name), compare with hmac_proof
-    D->>D: Re-derive HMAC_REST(gid, scope, identifier, family[, chain_id]), compare with hmac_rest
-    Note right of D: Both proofs valid — contact legitimately registered on this device
-    D->>D: handle_provide_contact() [coin-app] — store contact data for transaction review
-    D->>W: 9000
-    Note over W: Wallet sends the transaction APDU next
+    Note over Wallet: Has: group_handle, contact_name, scope, identifier, hmac_proof, hmac_rest
+    Wallet->>Device: CMD_PROVIDE_CONTACT (group_handle + contact_name + scope + identifier + hmac_proof + hmac_rest + path + ...)
+    Device->>Device: Parse TLV
+    Device->>Device: Verify group_handle MAC, extract gid
+    Device->>Device: Re-derive HMAC_PROOF(gid, contact_name), compare with hmac_proof
+    Device->>Device: Re-derive HMAC_REST(gid, scope, identifier, family[, chain_id]), compare with hmac_rest
+    Note right of Device: Both proofs valid — contact legitimately registered on this device
+    Device->>Device: handle_provide_identity() [coin-app] — store contact data for transaction review
+    Device->>Wallet: 9000
+    Note over Wallet: Wallet sends the transaction APDU next
 ```
 
 #### Response
@@ -723,17 +707,15 @@ The device verifies the HMAC Proof of Registration, then derives the Ethereum ad
 
 ```mermaid
 sequenceDiagram
-    participant W as Wallet
-    participant D as Device
 
-    Note over W: Has: account_name, bip32_path, chain_id, hmac_proof (from registration)
-    W->>D: CMD_PROVIDE_LEDGER_ACCOUNT_CONTACT (account_name + bip32_path + chain_id + family + hmac_proof)
-    D->>D: Parse TLV
-    D->>D: Re-derive HMAC(account_name, family[, chain_id]) at bip32_path, compare with hmac_proof
-    Note right of D: Proof valid — account legitimately registered on this device
-    D->>D: handle_provide_ledger_account_contact() [coin-app] — derive address, store mapping
-    D->>W: 9000
-    Note over W: Wallet sends the transaction APDU next
+    Note over Wallet: Has: account_name, bip32_path, chain_id, hmac_proof (from registration)
+    Wallet->>Device: CMD_PROVIDE_LEDGER_ACCOUNT_CONTACT (account_name + bip32_path + chain_id + family + hmac_proof)
+    Device->>Device: Parse TLV
+    Device->>Device: Re-derive HMAC(account_name, family[, chain_id]) at bip32_path, compare with hmac_proof
+    Note right of Device: Proof valid — account legitimately registered on this device
+    Device->>Device: handle_provide_ledger_account() [coin-app] — derive address, store mapping
+    Device->>Wallet: 9000
+    Note over Wallet: Wallet sends the transaction APDU next
 ```
 
 #### Response
@@ -746,22 +728,34 @@ sequenceDiagram
 
 ## 6. Coin-app entrypoints
 
-| Entrypoint                               | Signature                      | Guard                              | Called when                                                    | Expected return                      |
-|------------------------------------------|--------------------------------|------------------------------------|----------------------------------------------------------------|--------------------------------------|
-| `handle_check_identity`                  | `(identity_t *)`               | `HAVE_ADDRESS_BOOK`                | Before displaying Register Identity                            | `true` to proceed, `false` to reject |
-| `get_register_identity_tagValue`         | `(pair *, index)`              | `HAVE_ADDRESS_BOOK`                | NBGL tag-value callback during review                          | Fills pair for display               |
-| `finalize_ui_register_identity`          | `(void)`                       | `HAVE_ADDRESS_BOOK`                | After user choice                                              | Cleanup + return to idle             |
-| `finalize_ui_edit_contact_name`          | `(void)`                       | `HAVE_ADDRESS_BOOK`                | After Edit Contact Name user choice                            | Return to idle (SDK handles display) |
-| `handle_check_edit_identifier`           | `(edit_identifier_t *)`        | `HAVE_ADDRESS_BOOK`                | Before displaying Edit Identifier                              | `true` to proceed, `false` to reject |
-| `get_edit_identifier_tagValue`           | `(pair *, index)`              | `HAVE_ADDRESS_BOOK`                | NBGL tag-value callback during review                          | Fills pair for display               |
-| `finalize_ui_edit_identifier`            | `(void)`                       | `HAVE_ADDRESS_BOOK`                | After user choice                                              | Cleanup + return to idle             |
-| `finalize_ui_edit_scope`                 | `(void)`                       | `HAVE_ADDRESS_BOOK`                | After Edit Scope user choice                                   | Return to idle (SDK handles display) |
-| `handle_check_ledger_account`            | `(ledger_account_t *)`         | `HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT` | Before displaying Register Ledger Account                      | `true` to proceed, `false` to reject |
-| `display_register_ledger_account_review` | `(nbgl_choiceCallback_t)`      | `HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT` | App owns full review UI                                        | Calls SDK callback on confirm/reject |
-| `finalize_ui_register_ledger_account`    | `(void)`                       | `HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT` | After user choice                                              | Cleanup + return to idle             |
-| `finalize_ui_edit_ledger_account`        | `(void)`                       | `HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT` | After Edit Ledger Account user choice                          | Return to idle (SDK handles display) |
-| `handle_provide_contact`                 | `(const identity_t *)`         | `HAVE_ADDRESS_BOOK`                | After Provide Contact HMAC verification                        | `true` to accept, `false` to reject  |
-| `handle_provide_ledger_account_contact`  | `(const ledger_account_t *)`   | `HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT` | After Provide Ledger Account Contact HMAC verification         | `true` to accept, `false` to reject  |
+The SDK calls coin-app functions following four naming patterns:
+
+| Pattern                       | Role                                                                   | Return                                   |
+|-------------------------------|------------------------------------------------------------------------|------------------------------------------|
+| `handle_check_XXX(params)`    | Chain-specific validation after TLV parsing, before review display     | `true` to proceed, `false` to reject     |
+| `get_XXX_tagValue(index)`     | NBGL review callback — return one tag-value pair by index              | Tag-value pair, `NULL` when out of range |
+| `finalize_ui_XXX()`           | Post-choice cleanup and return to idle (confirm and reject)            | —                                        |
+| `on_edit_XXX_applied(edit)`   | Update cached contact in place (confirmed edits only, after HMAC sent) | —                                        |
+
+The required callbacks depend on the sub-command.
+
+| Sub-command                 | `handle_check` | `get_tagValue` | `finalize_ui` | `on_edit_applied` |
+|-----------------------------|:--------------:|:--------------:|:-------------:|:-----------------:|
+| `register_identity`         | ✓              | ✓              | ✓             | —                 |
+| `edit_contact_name`         | —              | —              | ✓             | ✓                 |
+| `edit_identifier`           | ✓              | ✓              | ✓             | ✓                 |
+| `edit_scope`                | —              | —              | ✓             | ✓                 |
+| `register_ledger_account`   | ✓ ¹            | — ¹            | ✓             | —                 |
+| `edit_ledger_account`       | —              | —              | ✓             | ✓                 |
+
+> ¹ Register Ledger Account replaces the `handle_check` + `get_tagValue` pair with a single `display_register_ledger_account_review` callback — the coin app owns the full review UI and calls the SDK-provided choice callback on confirm or reject.
+
+Two additional entrypoints handle contact provisioning (no UI, called silently before a transaction):
+
+| Entrypoint                      | Called when                                            | Return                             |
+|---------------------------------|--------------------------------------------------------|------------------------------------|
+| `handle_provide_identity`       | After Provide Identity Contact HMAC verification       | `true` to store, `false` to reject |
+| `handle_provide_ledger_account` | After Provide Ledger Account Contact HMAC verification | `true` to store, `false` to reject |
 
 ---
 
@@ -770,7 +764,7 @@ sequenceDiagram
 | Value  | Constant                               | Meaning                                                  |
 |--------|----------------------------------------|----------------------------------------------------------|
 | 0x9000 | `SWO_SUCCESS`                          | Operation successful                                     |
-| 0x6A80 | `SWO_INCORRECT_DATA`                   | Malformed TLV, user rejection, or failed HMAC            |
-| 0x6982 | `SWO_SECURITY_CONDITION_NOT_SATISFIED` | HMAC verification failed                                 |
+| 0x6A80 | `SWO_INCORRECT_DATA`                   | Malformed TLV, invalid group handle, or user rejection   |
+| 0x6982 | `SWO_SECURITY_CONDITION_NOT_SATISFIED` | HMAC_PROOF or HMAC_REST proof verification failed        |
 | 0x6984 | `SWO_CONDITIONS_NOT_SATISFIED`         | Unknown sub-command or unsupported configuration         |
 | 0x6B00 | `SWO_WRONG_PARAMETER_VALUE`            | Coin-app rejected the data (chain, address format, etc.) |

--- a/app_features/address_book/doc/mainpage.dox
+++ b/app_features/address_book/doc/mainpage.dox
@@ -12,6 +12,8 @@ The feature provides:
 
 - Binding a contact name and scope to an external identifier (e.g. an Ethereum address) via
   the @b Register @b Identity flow
+- Linking @b multiple @b addresses to a single contact by re-calling Register Identity with
+  an existing @c group_handle — all addresses then share the same name and rename atomically
 - Binding an account name to a BIP32 derivation path managed by the device via the
   @b Register @b Ledger @b Account flow
 - Updating existing bindings (name, identifier, scope) via dedicated @b Edit flows — each
@@ -155,6 +157,11 @@ hmac_proof = HMAC-SHA256(K_account, message)
 -# <b>Two independent Identity HMACs</b>: @c HMAC_PROOF covers only @c gid + name, while
    @c HMAC_REST covers @c gid + scope + identifier + network.  This allows the wallet to rename
    a contact without re-presenting the identifier or scope, and vice-versa.
+-# <b>Multi-address contacts</b>: Register Identity can be called with an existing
+   @c group_handle + @c HMAC_PROOF to link a second @c (scope, identifier) pair to the same
+   @c gid.  The device verifies ownership before issuing a new @c HMAC_REST.  Because all
+   addresses share the same @c gid, a single Edit Contact Name invalidates the @c HMAC_PROOF
+   for every address in the group simultaneously.
 -# <b>Triple KDF</b>: Separate salts for Group Handle, Identity, and Ledger Account prevent
    cross-feature key reuse even at the same BIP32 derivation path.
 -# <b>No secrets leave the device</b>: The BIP32 private key, KDF keys, and @c gid are

--- a/app_features/address_book/doc/mainpage.dox
+++ b/app_features/address_book/doc/mainpage.dox
@@ -221,8 +221,8 @@ Key functions provided by the Address Book module:
 
 - address_book_generate_group_handle(): Generate gid and compute authenticated group_handle
 - address_book_verify_group_handle(): Verify group_handle MAC and extract gid
-- address_book_compute_hmac_name(): Compute HMAC_PROOF over (gid, name)
-- address_book_verify_hmac_name(): Verify HMAC_PROOF (constant-time)
+- address_book_compute_hmac_proof(): Compute HMAC_PROOF over (gid, name)
+- address_book_verify_hmac_proof(): Verify HMAC_PROOF (constant-time)
 - address_book_compute_hmac_rest(): Compute HMAC_REST over (gid, scope, identifier, network)
 - address_book_verify_hmac_rest(): Verify HMAC_REST (constant-time)
 - address_book_send_register_identity_response(): Send type(1) | group_handle(64) | hmac_proof(32) | hmac_rest(32)

--- a/app_features/address_book/doc/mainpage.dox
+++ b/app_features/address_book/doc/mainpage.dox
@@ -179,7 +179,7 @@ Applications must implement the following callbacks to support Address Book:
 
 <b>Register Identity</b>:
 @code{.c}
-bool handle_check_identity(identity_t *params);
+bool handle_check_register_identity(identity_t *params);
 nbgl_contentTagValue_t *get_register_identity_tagValue(nbgl_contentTagValue_t *pair, uint8_t index);
 void finalize_ui_register_identity(void);
 @endcode
@@ -199,7 +199,7 @@ void finalize_ui_edit_scope(void);
 
 <b>Register Ledger Account</b> (requires @c HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT):
 @code{.c}
-bool handle_check_ledger_account(ledger_account_t *params);
+bool handle_check_register_ledger_account(ledger_account_t *params);
 void display_register_ledger_account_review(nbgl_choiceCallback_t choice_callback);
 void finalize_ui_register_ledger_account(void);
 void finalize_ui_edit_ledger_account(void);
@@ -207,12 +207,12 @@ void finalize_ui_edit_ledger_account(void);
 
 <b>Provide Contact</b>:
 @code{.c}
-bool handle_provide_contact(const identity_t *contact);
+bool handle_provide_identity(const identity_t *contact);
 @endcode
 
 <b>Provide Ledger Account Contact</b> (requires @c HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT):
 @code{.c}
-bool handle_provide_ledger_account_contact(const ledger_account_t *account);
+bool handle_provide_ledger_account(const ledger_account_t *account);
 @endcode
 
 @subsection address_book_functions Core Crypto Functions

--- a/app_features/address_book/include/address_book.h
+++ b/app_features/address_book/include/address_book.h
@@ -55,7 +55,7 @@ typedef enum {
  *   + 34 (scope, max 32 B)
  *   + 82 (new identifier, max 80 B)
  *   + 82 (previous identifier, max 80 B)
- *   + 34 (hmac_name, 32 B)
+ *   + 34 (hmac_proof, 32 B)
  *   + 34 (hmac_rest, 32 B)
  *   + 43 (derivation_path: depth(1) + 10×4 B)
  *   + 10 (chain_id, 8 B)

--- a/app_features/address_book/include/address_book_crypto.h
+++ b/app_features/address_book/include/address_book_crypto.h
@@ -32,15 +32,15 @@ bool address_book_verify_group_handle(const path_bip32_t *bip32_path,
                                       const uint8_t       group_handle[GROUP_HANDLE_SIZE],
                                       uint8_t             gid_out[GID_SIZE]);
 
-bool address_book_compute_hmac_name(const path_bip32_t *bip32_path,
+bool address_book_compute_hmac_proof(const path_bip32_t *bip32_path,
+                                     const uint8_t       gid[GID_SIZE],
+                                     const char         *name,
+                                     uint8_t             hmac_out[CX_SHA256_SIZE]);
+
+bool address_book_verify_hmac_proof(const path_bip32_t *bip32_path,
                                     const uint8_t       gid[GID_SIZE],
                                     const char         *name,
-                                    uint8_t             hmac_out[CX_SHA256_SIZE]);
-
-bool address_book_verify_hmac_name(const path_bip32_t *bip32_path,
-                                   const uint8_t       gid[GID_SIZE],
-                                   const char         *name,
-                                   const uint8_t       hmac_expected[CX_SHA256_SIZE]);
+                                    const uint8_t       hmac_expected[CX_SHA256_SIZE]);
 
 bool address_book_compute_hmac_rest(const path_bip32_t *bip32_path,
                                     const uint8_t       gid[GID_SIZE],
@@ -79,9 +79,9 @@ bool address_book_verify_hmac_proof_ledger_account(const path_bip32_t *bip32_pat
 /** type(1) | hmac(32) — for Edit operations. */
 bool address_book_send_hmac_proof(uint8_t type, const uint8_t hmac_proof[CX_SHA256_SIZE]);
 
-/** type(1) | group_handle(64) | hmac_name(32) | hmac_rest(32) = 129 B — for Register Identity. */
+/** type(1) | group_handle(64) | hmac_proof(32) | hmac_rest(32) = 129 B — for Register Identity. */
 bool address_book_send_register_identity_response(const uint8_t group_handle[GROUP_HANDLE_SIZE],
-                                                  const uint8_t hmac_name[CX_SHA256_SIZE],
+                                                  const uint8_t hmac_proof[CX_SHA256_SIZE],
                                                   const uint8_t hmac_rest[CX_SHA256_SIZE]);
 
 #endif  // HAVE_ADDRESS_BOOK

--- a/app_features/address_book/include/address_book_entrypoints.h
+++ b/app_features/address_book/include/address_book_entrypoints.h
@@ -70,6 +70,29 @@ void finalize_ui_register_identity(void);
  */
 nbgl_contentTagValue_t *get_register_identity_tagValue(uint8_t pairIndex);
 
+/*************** Exported functions prototypes: Edit Contact Name **************/
+
+/**
+ * @brief Handle called to finalize the UI flow for editing a contact name.
+ *
+ * Called after the user has confirmed or rejected the edit.
+ * The new HMAC proof has already been sent to the host at this point.
+ * The app should release any UI resources and return the device to idle.
+ */
+void finalize_ui_edit_contact_name(void);
+
+/**
+ * @brief Notification that a contact name edit was successfully applied.
+ *
+ * Called only when the user confirmed the edit and the new HMAC proof was
+ * successfully sent to the host. The app should use this to update in place
+ * all cached contacts whose name matches @p edit->previous_contact_name,
+ * replacing it with @p edit->contact_name so that no re-provide is needed.
+ *
+ * @param[in] edit Parsed edit data (previous_contact_name, contact_name)
+ */
+void on_edit_contact_name_applied(const edit_contact_name_t *edit);
+
 /*************** Exported functions prototypes: Edit Identifier ***************/
 
 /**
@@ -110,16 +133,18 @@ nbgl_contentTagValue_t *get_edit_identifier_tagValue(uint8_t pairIndex);
  */
 void finalize_ui_edit_identifier(void);
 
-/*************** Exported functions prototypes: Edit Contact Name **************/
-
 /**
- * @brief Handle called to finalize the UI flow for editing a contact name.
+ * @brief Notification that an identifier edit was successfully applied.
  *
- * Called after the user has confirmed or rejected the edit.
- * The new HMAC proof has already been sent to the host at this point.
- * The app should release any UI resources and return the device to idle.
+ * Called only when the user confirmed the edit and the new HMAC proof was
+ * successfully sent to the host. The app should use this to update in place
+ * the cached contact entry for (@p edit->previous_identifier,
+ * @p edit->identity.chain_id), replacing the identifier with
+ * @p edit->identity.identifier so that no re-provide is needed.
+ *
+ * @param[in] edit Parsed edit data (previous_identifier, identity)
  */
-void finalize_ui_edit_contact_name(void);
+void on_edit_identifier_applied(const edit_identifier_t *edit);
 
 /*************** Exported functions prototypes: Edit Scope ****************/
 
@@ -131,6 +156,19 @@ void finalize_ui_edit_contact_name(void);
  * The app should release any UI resources and return the device to idle.
  */
 void finalize_ui_edit_scope(void);
+
+/**
+ * @brief Notification that a scope edit was successfully applied.
+ *
+ * Called only when the user confirmed the edit and the new HMAC proof was
+ * successfully sent to the host. The app should use this to update in place
+ * the cached contact entry for (@p edit->identity.identifier,
+ * @p edit->identity.chain_id), replacing the scope with @p edit->identity.scope
+ * so that no re-provide is needed.
+ *
+ * @param[in] edit Parsed edit data (previous_scope, identity)
+ */
+void on_edit_scope_applied(const edit_scope_t *edit);
 
 /*************** Exported functions prototypes: Provide Contact ***********/
 
@@ -195,6 +233,19 @@ void finalize_ui_register_ledger_account(void);
  * The app should release any UI resources and return the device to idle.
  */
 void finalize_ui_edit_ledger_account(void);
+
+/**
+ * @brief Notification that a Ledger Account edit was successfully applied.
+ *
+ * Called only when the user confirmed the edit and the new HMAC proof was
+ * successfully sent to the host. The app should use this to update in place
+ * the cached Ledger Account contact derived from @p edit->ledger_account,
+ * replacing the account name with @p edit->ledger_account.account_name so
+ * that no re-provide is needed.
+ *
+ * @param[in] edit Parsed edit data (previous_account_name, ledger_account)
+ */
+void on_edit_ledger_account_applied(const edit_ledger_account_t *edit);
 
 /*************** Exported functions prototypes: Provide Ledger Account Contact */
 

--- a/app_features/address_book/include/address_book_entrypoints.h
+++ b/app_features/address_book/include/address_book_entrypoints.h
@@ -47,7 +47,7 @@ in order to validate the content of the payload, or finalize/cleanup the UI flow
  *                   identifier, identifier_len, bip32_path)
  * @return true if the identity is acceptable, false to reject
  */
-bool handle_check_identity(identity_t *params);
+bool handle_check_register_identity(identity_t *params);
 
 /**
  * @brief Handle called to finalize the UI flow for registering an Identity.
@@ -184,7 +184,7 @@ void on_edit_scope_applied(const edit_scope_t *edit);
  *                    identifier_len, blockchain_family, chain_id)
  * @return true if the contact was accepted and stored, false to reject
  */
-bool handle_provide_contact(const identity_t *contact);
+bool handle_provide_identity(const identity_t *contact);
 
 #ifdef HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT
 
@@ -202,12 +202,12 @@ bool handle_provide_contact(const identity_t *contact);
  *                   chain_id, blockchain_family)
  * @return true if the account is acceptable, false to reject
  */
-bool handle_check_ledger_account(ledger_account_t *params);
+bool handle_check_register_ledger_account(ledger_account_t *params);
 
 /**
  * @brief Handle called to display the Ledger Account registration review screen.
  *
- * Called after handle_check_ledger_account() succeeds. The app must display
+ * Called after handle_check_register_ledger_account() succeeds. The app must display
  * the review UI and invoke @p choice_callback on confirmation or rejection.
  * The app owns the UI flow from this point and is responsible for adapting
  * the display to the target device (touch vs Nano).
@@ -261,7 +261,7 @@ void on_edit_ledger_account_applied(const edit_ledger_account_t *edit);
  *                    chain_id, blockchain_family)
  * @return true if the contact was accepted and stored, false to reject
  */
-bool handle_provide_ledger_account_contact(const ledger_account_t *account);
+bool handle_provide_ledger_account(const ledger_account_t *account);
 
 #endif  // HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT
 

--- a/app_features/address_book/include/identity.h
+++ b/app_features/address_book/include/identity.h
@@ -106,4 +106,34 @@ bolos_err_t edit_identifier(uint8_t *buffer_in, size_t buffer_in_length);
 bolos_err_t edit_scope(uint8_t *buffer_in, size_t buffer_in_length);
 bolos_err_t provide_contact(uint8_t *buffer_in, size_t buffer_in_length);
 
+/**
+ * @brief Return a read-only pointer to the parsed Edit Contact Name data.
+ *
+ * Valid from the moment edit_contact_name() has finished parsing until the
+ * next call to edit_contact_name(), which overwrites the static buffer.
+ *
+ * @return Pointer to the current EDIT_CONTACT_NAME static (never NULL)
+ */
+const edit_contact_name_t *get_edit_contact_name(void);
+
+/**
+ * @brief Return a read-only pointer to the parsed Edit Identifier data.
+ *
+ * Valid from the moment edit_identifier() has finished parsing until the
+ * next call to edit_identifier(), which overwrites the static buffer.
+ *
+ * @return Pointer to the current EDIT_IDENTIFIER static (never NULL)
+ */
+const edit_identifier_t *get_edit_identifier(void);
+
+/**
+ * @brief Return a read-only pointer to the parsed Edit Scope data.
+ *
+ * Valid from the moment edit_scope() has finished parsing until the
+ * next call to edit_scope(), which overwrites the static buffer.
+ *
+ * @return Pointer to the current EDIT_SCOPE static (never NULL)
+ */
+const edit_scope_t *get_edit_scope(void);
+
 #endif  // HAVE_ADDRESS_BOOK

--- a/app_features/address_book/include/ledger_account.h
+++ b/app_features/address_book/include/ledger_account.h
@@ -55,3 +55,13 @@ typedef struct {
 bolos_err_t register_ledger_account(uint8_t *buffer_in, size_t buffer_in_length);
 bolos_err_t edit_ledger_account(uint8_t *buffer_in, size_t buffer_in_length);
 bolos_err_t provide_ledger_account_contact(uint8_t *buffer_in, size_t buffer_in_length);
+
+/**
+ * @brief Return a read-only pointer to the parsed Edit Ledger Account data.
+ *
+ * Valid from the moment edit_ledger_account() has finished parsing until the
+ * next call to edit_ledger_account(), which overwrites the static buffer.
+ *
+ * @return Pointer to the current EDIT_LEDGER_ACCOUNT static (never NULL)
+ */
+const edit_ledger_account_t *get_edit_ledger_account(void);

--- a/app_features/address_book/src/address_book_crypto.c
+++ b/app_features/address_book/src/address_book_crypto.c
@@ -26,7 +26,7 @@
  *
  * HMAC messages:
  *  - Group KDF:          SHA256("AddressBook-Group"         || privkey.d)
- *  - Identity HMAC_NAME: gid(32) | name_len(1) | name
+ *  - Identity HMAC_PROOF: gid(32) | name_len(1) | name
  *  - Identity HMAC_REST: gid(32) | scope_len(1) | scope | id_len(1) | identifier |
  *                        family(1) [| chain_id(8) for FAMILY_ETHEREUM]
  *  - Ledger Account:     name_len(1) | name | family(1) [| chain_id(8) for FAMILY_ETHEREUM]
@@ -147,16 +147,16 @@ bool address_book_send_hmac_proof(uint8_t type, const uint8_t hmac_proof[CX_SHA2
 /**
  * @brief Send the Register Identity response carrying the group handle and both HMACs
  *
- * Response format: TYPE_REGISTER_IDENTITY(1) | group_handle(64) | hmac_name(32) | hmac_rest(32)
+ * Response format: TYPE_REGISTER_IDENTITY(1) | group_handle(64) | hmac_proof(32) | hmac_rest(32)
  * = 129 B
  *
  * @param[in] group_handle Device-authenticated group handle (gid || MAC)
- * @param[in] hmac_name    HMAC over (gid, name)
+ * @param[in] hmac_proof    HMAC over (gid, name)
  * @param[in] hmac_rest    HMAC over (gid, scope, identifier, family [, chain_id])
  * @return true if sent successfully, false otherwise
  */
 bool address_book_send_register_identity_response(const uint8_t group_handle[GROUP_HANDLE_SIZE],
-                                                  const uint8_t hmac_name[CX_SHA256_SIZE],
+                                                  const uint8_t hmac_proof[CX_SHA256_SIZE],
                                                   const uint8_t hmac_rest[CX_SHA256_SIZE])
 {
     size_t tx = 0;
@@ -164,7 +164,7 @@ bool address_book_send_register_identity_response(const uint8_t group_handle[GRO
     G_io_tx_buffer[tx++] = TYPE_REGISTER_IDENTITY;
     memmove(&G_io_tx_buffer[tx], group_handle, GROUP_HANDLE_SIZE);
     tx += GROUP_HANDLE_SIZE;
-    memmove(&G_io_tx_buffer[tx], hmac_name, CX_SHA256_SIZE);
+    memmove(&G_io_tx_buffer[tx], hmac_proof, CX_SHA256_SIZE);
     tx += CX_SHA256_SIZE;
     memmove(&G_io_tx_buffer[tx], hmac_rest, CX_SHA256_SIZE);
     tx += CX_SHA256_SIZE;
@@ -248,7 +248,7 @@ end:
 }
 
 /**
- * @brief Compute HMAC_NAME for an Identity contact.
+ * @brief Compute HMAC_PROOF for an Identity contact.
  *
  * HMAC key: SHA256("AddressBook-Identity" || privkey.d)
  * HMAC message: gid(32) | name_len(1) | name
@@ -259,10 +259,10 @@ end:
  * @param[out] hmac_out    Output buffer for the 32-byte HMAC
  * @return true if successful, false otherwise
  */
-bool address_book_compute_hmac_name(const path_bip32_t *bip32_path,
-                                    const uint8_t       gid[GID_SIZE],
-                                    const char         *name,
-                                    uint8_t             hmac_out[CX_SHA256_SIZE])
+bool address_book_compute_hmac_proof(const path_bip32_t *bip32_path,
+                                     const uint8_t       gid[GID_SIZE],
+                                     const char         *name,
+                                     uint8_t             hmac_out[CX_SHA256_SIZE])
 {
     static const uint8_t salt[]   = "AddressBook-Identity";
     cx_hmac_sha256_t     hmac_ctx = {0};
@@ -290,7 +290,7 @@ end:
 }
 
 /**
- * @brief Verify HMAC_NAME for an Identity contact.
+ * @brief Verify HMAC_PROOF for an Identity contact.
  *
  * @param[in] bip32_path   BIP32 path used at registration
  * @param[in] gid          32-byte contact ID
@@ -298,19 +298,19 @@ end:
  * @param[in] hmac_expected 32-byte HMAC to verify against
  * @return true if valid, false otherwise
  */
-bool address_book_verify_hmac_name(const path_bip32_t *bip32_path,
-                                   const uint8_t       gid[GID_SIZE],
-                                   const char         *name,
-                                   const uint8_t       hmac_expected[CX_SHA256_SIZE])
+bool address_book_verify_hmac_proof(const path_bip32_t *bip32_path,
+                                    const uint8_t       gid[GID_SIZE],
+                                    const char         *name,
+                                    const uint8_t       hmac_expected[CX_SHA256_SIZE])
 {
     uint8_t hmac_computed[CX_SHA256_SIZE] = {0};
     bool    success                       = false;
 
-    if (!address_book_compute_hmac_name(bip32_path, gid, name, hmac_computed)) {
+    if (!address_book_compute_hmac_proof(bip32_path, gid, name, hmac_computed)) {
         goto end;
     }
     if (os_secure_memcmp(hmac_computed, hmac_expected, CX_SHA256_SIZE) != 0) {
-        PRINTF("HMAC_NAME mismatch\n");
+        PRINTF("HMAC_PROOF mismatch\n");
         goto end;
     }
     success = true;

--- a/app_features/address_book/src/identity_edit_contact_name.c
+++ b/app_features/address_book/src/identity_edit_contact_name.c
@@ -271,6 +271,7 @@ static void review_choice(bool confirm)
 {
     if (confirm) {
         if (build_and_send_response()) {
+            on_edit_contact_name_applied(&EDIT_CONTACT_NAME);
             nbgl_useCaseStatus("Contact name changed", true, finalize_ui_edit_contact_name);
         }
         else {
@@ -313,6 +314,20 @@ static void ui_display(void)
 }
 
 /* Exported functions --------------------------------------------------------*/
+
+/**
+ * @brief Return a read-only pointer to the parsed Edit Contact Name data.
+ *
+ * The returned pointer is valid from the moment edit_contact_name() has
+ * finished parsing until the next call to edit_contact_name(), which
+ * overwrites the static buffer.
+ *
+ * @return Pointer to the current EDIT_CONTACT_NAME static (never NULL)
+ */
+const edit_contact_name_t *get_edit_contact_name(void)
+{
+    return &EDIT_CONTACT_NAME;
+}
 
 /**
  * @brief Edit the CONTACT_NAME of an existing Identity contact.

--- a/app_features/address_book/src/identity_edit_contact_name.c
+++ b/app_features/address_book/src/identity_edit_contact_name.c
@@ -19,15 +19,15 @@
  * @brief Edit Contact Name flow (P1=0x02, struct type 0x2e)
  *
  * Allows changing the CONTACT_NAME of an existing Identity contact.
- * Because HMAC_NAME covers only (gid, name), the wallet does not need
+ * Because HMAC_PROOF covers only (gid, name), the wallet does not need
  * to transmit the identifier, scope, or network fields.
  *
  * Flow:
  *  1. Parse TLV payload (gid + new_name + previous_name +
  *     derivation_path + hmac_proof)
- *  2. Verify HMAC_NAME over (gid, previous_name)
+ *  2. Verify HMAC_PROOF over (gid, previous_name)
  *  3. Display UI: old name → new name
- *  4. On confirm: compute new HMAC_NAME over (gid, new_name) and send
+ *  4. On confirm: compute new HMAC_PROOF over (gid, new_name) and send
  *
  * Active under HAVE_ADDRESS_BOOK.
  */
@@ -58,7 +58,7 @@
 typedef struct {
     edit_contact_name_t *edit;
     TLV_reception_t      received_tags;
-    uint8_t              hmac_proof[CX_SHA256_SIZE];  ///< HMAC_NAME of the previous registration
+    uint8_t              hmac_proof[CX_SHA256_SIZE];  ///< HMAC_PROOF of the previous registration
     uint8_t group_handle[GROUP_HANDLE_SIZE];          ///< Group handle from wallet (verified later)
 } s_edit_contact_name_ctx;
 
@@ -70,7 +70,7 @@ typedef struct {
     X(0xf3, TAG_PREVIOUS_NAME, handle_previous_name, ENFORCE_UNIQUE_TAG)      \
     X(0xf6, TAG_GROUP_HANDLE, handle_group_handle, ENFORCE_UNIQUE_TAG)        \
     X(0x21, TAG_DERIVATION_PATH, handle_derivation_path, ENFORCE_UNIQUE_TAG)  \
-    X(0x29, TAG_HMAC_NAME, handle_hmac_proof, ENFORCE_UNIQUE_TAG)
+    X(0x29, TAG_HMAC_PROOF, handle_hmac_proof, ENFORCE_UNIQUE_TAG)
 
 /* Private variables ---------------------------------------------------------*/
 static edit_contact_name_t        EDIT_CONTACT_NAME = {0};
@@ -215,7 +215,7 @@ static bool verify_fields(const s_edit_contact_name_ctx *context)
                                           TAG_PREVIOUS_NAME,
                                           TAG_GROUP_HANDLE,
                                           TAG_DERIVATION_PATH,
-                                          TAG_HMAC_NAME);
+                                          TAG_HMAC_PROOF);
     if (!result) {
         PRINTF("[Edit Contact Name] Missing mandatory fields!\n");
     }
@@ -247,18 +247,18 @@ static void print_payload(const s_edit_contact_name_ctx *context)
  */
 static bool build_and_send_response(void)
 {
-    uint8_t hmac_name[CX_SHA256_SIZE] = {0};
+    uint8_t hmac_proof[CX_SHA256_SIZE] = {0};
 
-    if (!address_book_compute_hmac_name(&EDIT_CONTACT_NAME.bip32_path,
-                                        EDIT_CONTACT_NAME.gid,
-                                        EDIT_CONTACT_NAME.contact_name,
-                                        hmac_name)) {
-        PRINTF("[Edit Contact Name] Error: Failed to compute new HMAC_NAME\n");
+    if (!address_book_compute_hmac_proof(&EDIT_CONTACT_NAME.bip32_path,
+                                         EDIT_CONTACT_NAME.gid,
+                                         EDIT_CONTACT_NAME.contact_name,
+                                         hmac_proof)) {
+        PRINTF("[Edit Contact Name] Error: Failed to compute new HMAC_PROOF\n");
         return false;
     }
 
-    bool ok = address_book_send_hmac_proof(TYPE_EDIT_CONTACT_NAME, hmac_name);
-    explicit_bzero(hmac_name, sizeof(hmac_name));
+    bool ok = address_book_send_hmac_proof(TYPE_EDIT_CONTACT_NAME, hmac_proof);
+    explicit_bzero(hmac_proof, sizeof(hmac_proof));
     return ok;
 }
 
@@ -362,12 +362,12 @@ bolos_err_t edit_contact_name(uint8_t *buffer_in, size_t buffer_in_length)
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
-    // Verify the wallet holds a valid HMAC_NAME for the previous name
-    if (!address_book_verify_hmac_name(&EDIT_CONTACT_NAME.bip32_path,
-                                       EDIT_CONTACT_NAME.gid,
-                                       EDIT_CONTACT_NAME.previous_contact_name,
-                                       ctx.hmac_proof)) {
-        PRINTF("[Edit Contact Name] HMAC_NAME verification failed\n");
+    // Verify the wallet holds a valid HMAC_PROOF for the previous name
+    if (!address_book_verify_hmac_proof(&EDIT_CONTACT_NAME.bip32_path,
+                                        EDIT_CONTACT_NAME.gid,
+                                        EDIT_CONTACT_NAME.previous_contact_name,
+                                        ctx.hmac_proof)) {
+        PRINTF("[Edit Contact Name] HMAC_PROOF verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 

--- a/app_features/address_book/src/identity_edit_identifier.c
+++ b/app_features/address_book/src/identity_edit_identifier.c
@@ -384,6 +384,7 @@ static void review_choice(bool confirm)
 {
     if (confirm) {
         if (build_and_send_response()) {
+            on_edit_identifier_applied(&EDIT_IDENTIFIER);
             if (EDIT_IDENTIFIER.identity.blockchain_family == FAMILY_ETHEREUM) {
                 nbgl_useCaseStatus("Address changed", true, finalize_ui_edit_identifier);
             }
@@ -423,6 +424,20 @@ static void ui_display(void)
 }
 
 /* Exported functions --------------------------------------------------------*/
+
+/**
+ * @brief Return a read-only pointer to the parsed Edit Identifier data.
+ *
+ * The returned pointer is valid from the moment edit_identifier() has
+ * finished parsing until the next call to edit_identifier(), which
+ * overwrites the static buffer.
+ *
+ * @return Pointer to the current EDIT_IDENTIFIER static (never NULL)
+ */
+const edit_identifier_t *get_edit_identifier(void)
+{
+    return &EDIT_IDENTIFIER;
+}
 
 /**
  * @brief Edit the IDENTIFIER of an existing Identity contact.

--- a/app_features/address_book/src/identity_edit_identifier.c
+++ b/app_features/address_book/src/identity_edit_identifier.c
@@ -26,8 +26,8 @@
  *     address_book.c)
  *  2. Parse TLV payload (contact_name + scope + new_identifier +
  *     previous_identifier + gid + derivation_path +
- *     hmac_name_proof + hmac_rest_proof)
- *  3. Verify HMAC_NAME over (gid, contact_name)
+ *     hmac_proof + hmac_rest)
+ *  3. Verify HMAC_PROOF over (gid, contact_name)
  *  4. Verify HMAC_REST over (gid, scope, previous_identifier, family[, chain_id])
  *  5. Coin-app notification: handle_check_edit_identifier()
  *  6. Display UI: contact name, previous identifier → new identifier
@@ -61,9 +61,9 @@
 typedef struct {
     edit_identifier_t *edit;
     TLV_reception_t    received_tags;
-    uint8_t            hmac_name[CX_SHA256_SIZE];  ///< HMAC_NAME — verifies contact name
-    uint8_t            hmac_rest[CX_SHA256_SIZE];  ///< HMAC_REST — verifies previous identifier
-    uint8_t group_handle[GROUP_HANDLE_SIZE];       ///< Group handle from wallet (verified later)
+    uint8_t            hmac_proof[CX_SHA256_SIZE];  ///< HMAC_PROOF — verifies contact name
+    uint8_t            hmac_rest[CX_SHA256_SIZE];   ///< HMAC_REST — verifies previous identifier
+    uint8_t group_handle[GROUP_HANDLE_SIZE];        ///< Group handle from wallet (verified later)
 } s_edit_ctx;
 
 /* Private macros-------------------------------------------------------------*/
@@ -77,7 +77,7 @@ typedef struct {
     X(0xf6, TAG_GROUP_HANDLE, handle_group_handle, ENFORCE_UNIQUE_TAG)               \
     X(0x21, TAG_DERIVATION_PATH, handle_derivation_path, ENFORCE_UNIQUE_TAG)         \
     X(0x23, TAG_CHAIN_ID, handle_chain_id, ENFORCE_UNIQUE_TAG)                       \
-    X(0x29, TAG_HMAC_NAME, handle_hmac_name, ENFORCE_UNIQUE_TAG)                     \
+    X(0x29, TAG_HMAC_PROOF, handle_hmac_proof, ENFORCE_UNIQUE_TAG)                   \
     X(0xf7, TAG_HMAC_REST, handle_hmac_rest, ENFORCE_UNIQUE_TAG)                     \
     X(0x51, TAG_BLOCKCHAIN_FAMILY, handle_blockchain_family, ENFORCE_UNIQUE_TAG)
 
@@ -252,20 +252,21 @@ static bool handle_blockchain_family(const tlv_data_t *data, s_edit_ctx *context
 }
 
 /**
- * @brief Handler for tag \ref HMAC_NAME
+ * @brief Handler for tag \ref HMAC_PROOF
  *
  * @param[in] data the tlv data
  * @param[in] context the received payload
  * @return whether the handling was successful
  */
-static bool handle_hmac_name(const tlv_data_t *data, s_edit_ctx *context)
+static bool handle_hmac_proof(const tlv_data_t *data, s_edit_ctx *context)
 {
     buffer_t buf = {0};
     if (!get_buffer_from_tlv_data(data, &buf, CX_SHA256_SIZE, CX_SHA256_SIZE)) {
-        PRINTF("[Edit Identifier] HMAC_NAME: invalid length (expected %d bytes)\n", CX_SHA256_SIZE);
+        PRINTF("[Edit Identifier] HMAC_PROOF: invalid length (expected %d bytes)\n",
+               CX_SHA256_SIZE);
         return false;
     }
-    memmove(context->hmac_name, buf.ptr, CX_SHA256_SIZE);
+    memmove(context->hmac_proof, buf.ptr, CX_SHA256_SIZE);
     return true;
 }
 
@@ -306,7 +307,7 @@ static bool verify_fields(const s_edit_ctx *context)
                                           TAG_GROUP_HANDLE,
                                           TAG_DERIVATION_PATH,
                                           TAG_BLOCKCHAIN_FAMILY,
-                                          TAG_HMAC_NAME,
+                                          TAG_HMAC_PROOF,
                                           TAG_HMAC_REST);
     if (!result) {
         PRINTF("[Edit Identifier] Missing mandatory fields!\n");
@@ -472,12 +473,12 @@ bolos_err_t edit_identifier(uint8_t *buffer_in, size_t buffer_in_length)
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
-    // Verify that the wallet holds a valid HMAC_NAME for the contact name
-    if (!address_book_verify_hmac_name(&EDIT_IDENTIFIER.identity.bip32_path,
-                                       EDIT_IDENTIFIER.identity.gid,
-                                       EDIT_IDENTIFIER.identity.contact_name,
-                                       ctx.hmac_name)) {
-        PRINTF("[Edit Identifier] HMAC_NAME verification failed\n");
+    // Verify that the wallet holds a valid HMAC_PROOF for the contact name
+    if (!address_book_verify_hmac_proof(&EDIT_IDENTIFIER.identity.bip32_path,
+                                        EDIT_IDENTIFIER.identity.gid,
+                                        EDIT_IDENTIFIER.identity.contact_name,
+                                        ctx.hmac_proof)) {
+        PRINTF("[Edit Identifier] HMAC_PROOF verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 

--- a/app_features/address_book/src/identity_edit_scope.c
+++ b/app_features/address_book/src/identity_edit_scope.c
@@ -412,7 +412,7 @@ static void ui_display(void)
     ui_pairs[nbPairs].item  = "Contact name";
     ui_pairs[nbPairs].value = EDIT_SCOPE.identity.contact_name;
     nbPairs++;
-    ui_pairs[nbPairs].item  = "Previous address name";
+    ui_pairs[nbPairs].item  = "Old address name";
     ui_pairs[nbPairs].value = EDIT_SCOPE.previous_scope;
     nbPairs++;
     ui_pairs[nbPairs].item  = "New address name";

--- a/app_features/address_book/src/identity_edit_scope.c
+++ b/app_features/address_book/src/identity_edit_scope.c
@@ -382,6 +382,7 @@ static void review_choice(bool confirm)
 {
     if (confirm) {
         if (build_and_send_response()) {
+            on_edit_scope_applied(&EDIT_SCOPE);
             if (EDIT_SCOPE.identity.blockchain_family == FAMILY_BITCOIN) {
                 nbgl_useCaseStatus("Scope changed", true, finalize_ui_edit_scope);
             }
@@ -432,6 +433,20 @@ static void ui_display(void)
 }
 
 /* Exported functions --------------------------------------------------------*/
+
+/**
+ * @brief Return a read-only pointer to the parsed Edit Scope data.
+ *
+ * The returned pointer is valid from the moment edit_scope() has finished
+ * parsing until the next call to edit_scope(), which overwrites the static
+ * buffer.
+ *
+ * @return Pointer to the current EDIT_SCOPE static (never NULL)
+ */
+const edit_scope_t *get_edit_scope(void)
+{
+    return &EDIT_SCOPE;
+}
 
 /**
  * @brief Edit the SCOPE of an existing Identity contact.

--- a/app_features/address_book/src/identity_edit_scope.c
+++ b/app_features/address_book/src/identity_edit_scope.c
@@ -26,8 +26,8 @@
  *     address_book.c)
  *  2. Parse TLV payload (contact_name + new_scope + previous_scope +
  *     identifier + gid + derivation_path + chain_id +
- *     blockchain_family + hmac_name_proof + hmac_rest_proof)
- *  3. Verify HMAC_NAME over (gid, contact_name)
+ *     blockchain_family + hmac_proof + hmac_rest)
+ *  3. Verify HMAC_PROOF over (gid, contact_name)
  *  4. Verify HMAC_REST over (gid, previous_scope, identifier, family[, chain_id])
  *  5. Display UI: old scope → new scope
  *  6. On confirm: compute new HMAC_REST over (gid, new_scope, identifier,
@@ -60,7 +60,7 @@
 typedef struct {
     edit_scope_t   *edit;
     TLV_reception_t received_tags;
-    uint8_t         hmac_name[CX_SHA256_SIZE];        ///< HMAC_NAME — verifies contact name
+    uint8_t         hmac_proof[CX_SHA256_SIZE];       ///< HMAC_PROOF — verifies contact name
     uint8_t         hmac_rest[CX_SHA256_SIZE];        ///< HMAC_REST — verifies previous scope
     uint8_t         group_handle[GROUP_HANDLE_SIZE];  ///< Group handle from wallet (verified later)
 } s_edit_scope_ctx;
@@ -76,7 +76,7 @@ typedef struct {
     X(0xf6, TAG_GROUP_HANDLE, handle_group_handle, ENFORCE_UNIQUE_TAG)        \
     X(0x21, TAG_DERIVATION_PATH, handle_derivation_path, ENFORCE_UNIQUE_TAG)  \
     X(0x23, TAG_CHAIN_ID, handle_chain_id, ENFORCE_UNIQUE_TAG)                \
-    X(0x29, TAG_HMAC_NAME, handle_hmac_name, ENFORCE_UNIQUE_TAG)              \
+    X(0x29, TAG_HMAC_PROOF, handle_hmac_proof, ENFORCE_UNIQUE_TAG)            \
     X(0xf7, TAG_HMAC_REST, handle_hmac_rest, ENFORCE_UNIQUE_TAG)              \
     X(0x51, TAG_BLOCKCHAIN_FAMILY, handle_blockchain_family, ENFORCE_UNIQUE_TAG)
 
@@ -252,20 +252,20 @@ static bool handle_blockchain_family(const tlv_data_t *data, s_edit_scope_ctx *c
 }
 
 /**
- * @brief Handler for tag \ref HMAC_NAME
+ * @brief Handler for tag \ref HMAC_PROOF
  *
  * @param[in] data the tlv data
  * @param[in] context the received payload
  * @return whether the handling was successful
  */
-static bool handle_hmac_name(const tlv_data_t *data, s_edit_scope_ctx *context)
+static bool handle_hmac_proof(const tlv_data_t *data, s_edit_scope_ctx *context)
 {
     buffer_t buf = {0};
     if (!get_buffer_from_tlv_data(data, &buf, CX_SHA256_SIZE, CX_SHA256_SIZE)) {
-        PRINTF("[Edit Scope] HMAC_NAME: invalid length (expected %d bytes)\n", CX_SHA256_SIZE);
+        PRINTF("[Edit Scope] HMAC_PROOF: invalid length (expected %d bytes)\n", CX_SHA256_SIZE);
         return false;
     }
-    memmove(context->hmac_name, buf.ptr, CX_SHA256_SIZE);
+    memmove(context->hmac_proof, buf.ptr, CX_SHA256_SIZE);
     return true;
 }
 
@@ -307,7 +307,7 @@ static bool verify_fields(const s_edit_scope_ctx *context)
                                           TAG_GROUP_HANDLE,
                                           TAG_DERIVATION_PATH,
                                           TAG_BLOCKCHAIN_FAMILY,
-                                          TAG_HMAC_NAME,
+                                          TAG_HMAC_PROOF,
                                           TAG_HMAC_REST);
     if (!result) {
         PRINTF("[Edit Scope] Missing mandatory fields!\n");
@@ -481,12 +481,12 @@ bolos_err_t edit_scope(uint8_t *buffer_in, size_t buffer_in_length)
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
-    // Verify that the wallet holds a valid HMAC_NAME for the contact name
-    if (!address_book_verify_hmac_name(&EDIT_SCOPE.identity.bip32_path,
-                                       EDIT_SCOPE.identity.gid,
-                                       EDIT_SCOPE.identity.contact_name,
-                                       ctx.hmac_name)) {
-        PRINTF("[Edit Scope] HMAC_NAME verification failed\n");
+    // Verify that the wallet holds a valid HMAC_PROOF for the contact name
+    if (!address_book_verify_hmac_proof(&EDIT_SCOPE.identity.bip32_path,
+                                        EDIT_SCOPE.identity.gid,
+                                        EDIT_SCOPE.identity.contact_name,
+                                        ctx.hmac_proof)) {
+        PRINTF("[Edit Scope] HMAC_PROOF verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 

--- a/app_features/address_book/src/identity_provide_contact.c
+++ b/app_features/address_book/src/identity_provide_contact.c
@@ -31,7 +31,7 @@
  *  3. Verify group_handle → extract gid
  *  4. Verify HMAC_PROOF over (gid, contact_name)
  *  5. Verify HMAC_REST over (gid, scope, identifier, family[, chain_id])
- *  6. Call handle_provide_contact() so the coin app can store the contact
+ *  6. Call handle_provide_identity() so the coin app can store the contact
  *  7. Return SWO_SUCCESS (9000, no data)
  *
  * Active under HAVE_ADDRESS_BOOK.
@@ -378,7 +378,7 @@ bolos_err_t provide_contact(uint8_t *buffer_in, size_t buffer_in_length)
     }
 
     // Pass verified contact to the coin app for storage
-    if (!handle_provide_contact(&PROVIDE_CONTACT_IDENTITY)) {
+    if (!handle_provide_identity(&PROVIDE_CONTACT_IDENTITY)) {
         PRINTF("[Provide Contact] Rejected by coin application\n");
         return SWO_WRONG_PARAMETER_VALUE;
     }

--- a/app_features/address_book/src/identity_provide_contact.c
+++ b/app_features/address_book/src/identity_provide_contact.c
@@ -75,7 +75,7 @@ typedef struct {
     X(0x21, TAG_DERIVATION_PATH, handle_derivation_path, ENFORCE_UNIQUE_TAG)     \
     X(0x23, TAG_CHAIN_ID, handle_chain_id, ENFORCE_UNIQUE_TAG)                   \
     X(0x51, TAG_BLOCKCHAIN_FAMILY, handle_blockchain_family, ENFORCE_UNIQUE_TAG) \
-    X(0x29, TAG_HMAC_NAME, handle_hmac_proof, ENFORCE_UNIQUE_TAG)                \
+    X(0x29, TAG_HMAC_PROOF, handle_hmac_proof, ENFORCE_UNIQUE_TAG)               \
     X(0xf7, TAG_HMAC_REST, handle_hmac_rest, ENFORCE_UNIQUE_TAG)
 
 /* Private variables ---------------------------------------------------------*/
@@ -281,7 +281,7 @@ static bool verify_fields(const s_provide_contact_ctx *context)
                                           TAG_GROUP_HANDLE,
                                           TAG_DERIVATION_PATH,
                                           TAG_BLOCKCHAIN_FAMILY,
-                                          TAG_HMAC_NAME,
+                                          TAG_HMAC_PROOF,
                                           TAG_HMAC_REST);
     if (!result) {
         PRINTF("[Provide Contact] Missing mandatory fields!\n");
@@ -356,10 +356,10 @@ bolos_err_t provide_contact(uint8_t *buffer_in, size_t buffer_in_length)
     }
 
     // Verify HMAC_PROOF over (gid, contact_name)
-    if (!address_book_verify_hmac_name(&PROVIDE_CONTACT_IDENTITY.bip32_path,
-                                       PROVIDE_CONTACT_IDENTITY.gid,
-                                       PROVIDE_CONTACT_IDENTITY.contact_name,
-                                       ctx.hmac_proof)) {
+    if (!address_book_verify_hmac_proof(&PROVIDE_CONTACT_IDENTITY.bip32_path,
+                                        PROVIDE_CONTACT_IDENTITY.gid,
+                                        PROVIDE_CONTACT_IDENTITY.contact_name,
+                                        ctx.hmac_proof)) {
         PRINTF("[Provide Contact] HMAC_PROOF verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }

--- a/app_features/address_book/src/identity_register.c
+++ b/app_features/address_book/src/identity_register.c
@@ -55,21 +55,34 @@
 typedef struct {
     identity_t     *identity;
     TLV_reception_t received_tags;
+    uint8_t         group_handle[GROUP_HANDLE_SIZE];  ///< Optional: existing group handle
+    uint8_t         hmac_name[CX_SHA256_SIZE];        ///< Optional: HMAC_NAME for existing group
 } s_identity_ctx;
 
+// Persistent data for the optional "link to existing group" extension.
+// Populated in register_identity() and consumed by the review_choice() callback.
+typedef struct {
+    uint8_t group_handle[GROUP_HANDLE_SIZE];
+    uint8_t hmac_name[CX_SHA256_SIZE];
+    bool    active;
+} s_reg_ext_t;
+
 /* Private macros-------------------------------------------------------------*/
-#define REGISTER_IDENTITY_TAGS(X)                                             \
-    X(0x01, TAG_STRUCTURE_TYPE, handle_struct_type, ENFORCE_UNIQUE_TAG)       \
-    X(0x02, TAG_STRUCTURE_VERSION, handle_struct_version, ENFORCE_UNIQUE_TAG) \
-    X(0xf0, TAG_CONTACT_NAME, handle_contact_name, ENFORCE_UNIQUE_TAG)        \
-    X(0xf1, TAG_SCOPE, handle_scope, ENFORCE_UNIQUE_TAG)                      \
-    X(0xf2, TAG_ACCOUNT_IDENTIFIER, handle_identifier, ENFORCE_UNIQUE_TAG)    \
-    X(0x21, TAG_DERIVATION_PATH, handle_derivation_path, ENFORCE_UNIQUE_TAG)  \
-    X(0x23, TAG_CHAIN_ID, handle_chain_id, ENFORCE_UNIQUE_TAG)                \
-    X(0x51, TAG_BLOCKCHAIN_FAMILY, handle_blockchain_family, ENFORCE_UNIQUE_TAG)
+#define REGISTER_IDENTITY_TAGS(X)                                                \
+    X(0x01, TAG_STRUCTURE_TYPE, handle_struct_type, ENFORCE_UNIQUE_TAG)          \
+    X(0x02, TAG_STRUCTURE_VERSION, handle_struct_version, ENFORCE_UNIQUE_TAG)    \
+    X(0xf0, TAG_CONTACT_NAME, handle_contact_name, ENFORCE_UNIQUE_TAG)           \
+    X(0xf1, TAG_SCOPE, handle_scope, ENFORCE_UNIQUE_TAG)                         \
+    X(0xf2, TAG_ACCOUNT_IDENTIFIER, handle_identifier, ENFORCE_UNIQUE_TAG)       \
+    X(0x21, TAG_DERIVATION_PATH, handle_derivation_path, ENFORCE_UNIQUE_TAG)     \
+    X(0x23, TAG_CHAIN_ID, handle_chain_id, ENFORCE_UNIQUE_TAG)                   \
+    X(0x51, TAG_BLOCKCHAIN_FAMILY, handle_blockchain_family, ENFORCE_UNIQUE_TAG) \
+    X(0xf6, TAG_GROUP_HANDLE, handle_group_handle, ENFORCE_UNIQUE_TAG)           \
+    X(0x29, TAG_HMAC_NAME, handle_hmac_name, ENFORCE_UNIQUE_TAG)
 
 /* Private variables ---------------------------------------------------------*/
 static identity_t                 IDENTITY     = {0};
+static s_reg_ext_t                REG_EXT      = {0};
 static nbgl_contentTagValueList_t ui_pairsList = {0};
 
 /* Private functions ---------------------------------------------------------*/
@@ -197,6 +210,44 @@ static bool handle_blockchain_family(const tlv_data_t *data, s_identity_ctx *con
     return address_book_handle_blockchain_family(data, &context->identity->blockchain_family);
 }
 
+/**
+ * @brief Handler for tag \ref GROUP_HANDLE (optional — links to an existing group)
+ *
+ * @param[in] data the tlv data
+ * @param[in] context the received payload
+ * @return whether the handling was successful
+ */
+static bool handle_group_handle(const tlv_data_t *data, s_identity_ctx *context)
+{
+    buffer_t buf = {0};
+    if (!get_buffer_from_tlv_data(data, &buf, GROUP_HANDLE_SIZE, GROUP_HANDLE_SIZE)) {
+        PRINTF("[Register Identity] GROUP_HANDLE: invalid length (expected %d bytes)\n",
+               GROUP_HANDLE_SIZE);
+        return false;
+    }
+    memmove(context->group_handle, buf.ptr, GROUP_HANDLE_SIZE);
+    return true;
+}
+
+/**
+ * @brief Handler for tag \ref HMAC_NAME (optional — proves ownership of an existing group)
+ *
+ * @param[in] data the tlv data
+ * @param[in] context the received payload
+ * @return whether the handling was successful
+ */
+static bool handle_hmac_name(const tlv_data_t *data, s_identity_ctx *context)
+{
+    buffer_t buf = {0};
+    if (!get_buffer_from_tlv_data(data, &buf, CX_SHA256_SIZE, CX_SHA256_SIZE)) {
+        PRINTF("[Register Identity] HMAC_NAME: invalid length (expected %d bytes)\n",
+               CX_SHA256_SIZE);
+        return false;
+    }
+    memmove(context->hmac_name, buf.ptr, CX_SHA256_SIZE);
+    return true;
+}
+
 DEFINE_TLV_PARSER(REGISTER_IDENTITY_TAGS, NULL, identity_tlv_parser)
 
 /**
@@ -225,6 +276,13 @@ static bool verify_fields(const s_identity_ctx *context)
             PRINTF("Missing CHAIN_ID for Ethereum family in Register Identity descriptor!\n");
             return false;
         }
+    }
+    // GROUP_HANDLE and HMAC_NAME are optional, but must be provided together
+    bool has_group_handle = TLV_CHECK_RECEIVED_TAGS(context->received_tags, TAG_GROUP_HANDLE);
+    bool has_hmac_name    = TLV_CHECK_RECEIVED_TAGS(context->received_tags, TAG_HMAC_NAME);
+    if (has_group_handle != has_hmac_name) {
+        PRINTF("GROUP_HANDLE and HMAC_NAME must be provided together!\n");
+        return false;
     }
     return true;
 }
@@ -265,7 +323,11 @@ static void print_payload(const s_identity_ctx *context)
 /**
  * @brief Build and send response
  *
- * Generate group_handle, compute both HMAC proofs, and send them to the host.
+ * Two paths depending on whether an existing group was provided:
+ *  - New group: generate group_handle, compute hmac_name + hmac_rest.
+ *  - Existing group: verify received group_handle + hmac_name, then compute only hmac_rest
+ *    for the new (scope, identifier) pair.
+ *
  * Response format: TYPE_REGISTER_IDENTITY(1) | group_handle(64) | hmac_name(32) | hmac_rest(32)
  * = 129 B
  *
@@ -276,28 +338,59 @@ static bool build_and_send_response(void)
     uint8_t group_handle[GROUP_HANDLE_SIZE] = {0};
     uint8_t hmac_name[CX_SHA256_SIZE]       = {0};
     uint8_t hmac_rest[CX_SHA256_SIZE]       = {0};
+    uint8_t gid[GID_SIZE]                   = {0};
     bool    ok                              = false;
 
-    if (!address_book_generate_group_handle(&IDENTITY.bip32_path, group_handle)) {
-        PRINTF("[Register Identity] Error: Failed to generate group handle\n");
-        goto end;
+    if (REG_EXT.active) {
+        // Verify the provided group handle and extract the GID
+        if (!address_book_verify_group_handle(&IDENTITY.bip32_path, REG_EXT.group_handle, gid)) {
+            PRINTF("[Register Identity] Error: Group handle verification failed\n");
+            goto end;
+        }
+        // Verify that the caller owns the group (proves knowledge of contact_name + gid)
+        if (!address_book_verify_hmac_name(
+                &IDENTITY.bip32_path, gid, IDENTITY.contact_name, REG_EXT.hmac_name)) {
+            PRINTF("[Register Identity] Error: HMAC_NAME verification failed\n");
+            goto end;
+        }
+        // Compute hmac_rest for the new (scope, identifier) pair under the existing group
+        if (!address_book_compute_hmac_rest(&IDENTITY.bip32_path,
+                                            gid,
+                                            IDENTITY.scope,
+                                            IDENTITY.identifier,
+                                            IDENTITY.identifier_len,
+                                            IDENTITY.blockchain_family,
+                                            IDENTITY.chain_id,
+                                            hmac_rest)) {
+            PRINTF("[Register Identity] Error: Failed to compute HMAC_REST for new address\n");
+            goto end;
+        }
+        // Echo back the verified group_handle and hmac_name; only hmac_rest is new
+        memmove(group_handle, REG_EXT.group_handle, GROUP_HANDLE_SIZE);
+        memmove(hmac_name, REG_EXT.hmac_name, CX_SHA256_SIZE);
     }
-    // gid is the first GID_SIZE bytes of group_handle
-    if (!address_book_compute_hmac_name(
-            &IDENTITY.bip32_path, group_handle, IDENTITY.contact_name, hmac_name)) {
-        PRINTF("[Register Identity] Error: Failed to compute HMAC_NAME\n");
-        goto end;
-    }
-    if (!address_book_compute_hmac_rest(&IDENTITY.bip32_path,
-                                        group_handle,
-                                        IDENTITY.scope,
-                                        IDENTITY.identifier,
-                                        IDENTITY.identifier_len,
-                                        IDENTITY.blockchain_family,
-                                        IDENTITY.chain_id,
-                                        hmac_rest)) {
-        PRINTF("[Register Identity] Error: Failed to compute HMAC_REST\n");
-        goto end;
+    else {
+        if (!address_book_generate_group_handle(&IDENTITY.bip32_path, group_handle)) {
+            PRINTF("[Register Identity] Error: Failed to generate group handle\n");
+            goto end;
+        }
+        // gid is the first GID_SIZE bytes of group_handle
+        if (!address_book_compute_hmac_name(
+                &IDENTITY.bip32_path, group_handle, IDENTITY.contact_name, hmac_name)) {
+            PRINTF("[Register Identity] Error: Failed to compute HMAC_NAME\n");
+            goto end;
+        }
+        if (!address_book_compute_hmac_rest(&IDENTITY.bip32_path,
+                                            group_handle,
+                                            IDENTITY.scope,
+                                            IDENTITY.identifier,
+                                            IDENTITY.identifier_len,
+                                            IDENTITY.blockchain_family,
+                                            IDENTITY.chain_id,
+                                            hmac_rest)) {
+            PRINTF("[Register Identity] Error: Failed to compute HMAC_REST\n");
+            goto end;
+        }
     }
     ok = address_book_send_register_identity_response(group_handle, hmac_name, hmac_rest);
 
@@ -305,6 +398,7 @@ end:
     explicit_bzero(group_handle, sizeof(group_handle));
     explicit_bzero(hmac_name, sizeof(hmac_name));
     explicit_bzero(hmac_rest, sizeof(hmac_rest));
+    explicit_bzero(gid, sizeof(gid));
     return ok;
 }
 
@@ -364,9 +458,9 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
     const buffer_t payload = {.ptr = buffer_in, .size = buffer_in_length};
     s_identity_ctx ctx     = {0};
 
-    // Init the structure
-    ctx.identity = &IDENTITY;
     memset(&IDENTITY, 0, sizeof(IDENTITY));
+    memset(&REG_EXT, 0, sizeof(REG_EXT));
+    ctx.identity = &IDENTITY;
 
     // Parse using SDK TLV parser
     if (!identity_tlv_parser(&payload, &ctx, &ctx.received_tags)) {
@@ -377,6 +471,13 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
         return SWO_INCORRECT_DATA;
     }
     print_payload(&ctx);
+
+    // Copy optional group extension data into the persistent static before ctx goes out of scope
+    if (TLV_CHECK_RECEIVED_TAGS(ctx.received_tags, TAG_GROUP_HANDLE)) {
+        REG_EXT.active = true;
+        memmove(REG_EXT.group_handle, ctx.group_handle, GROUP_HANDLE_SIZE);
+        memmove(REG_EXT.hmac_name, ctx.hmac_name, CX_SHA256_SIZE);
+    }
 
     // Check the Identity validity according to the Coin application logic
     if (!handle_check_identity(ctx.identity)) {

--- a/app_features/address_book/src/identity_register.c
+++ b/app_features/address_book/src/identity_register.c
@@ -369,7 +369,7 @@ static bool build_and_send_response(void)
         }
         // group_handle layout: gid(32) | MAC(K_group, gid)(32) — use only the GID prefix here
         const uint8_t *gid = group_handle;
-        if (!address_book_compute_hmac_name(
+        if (!address_book_compute_hmac_proof(
                 &REG.identity.bip32_path, gid, REG.identity.contact_name, hmac_proof)) {
             PRINTF("[Register Identity] Error: Failed to compute HMAC_PROOF\n");
             goto end;
@@ -473,12 +473,12 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
         if (!address_book_verify_group_handle(
                 &REG.identity.bip32_path, REG.group_handle, REG.gid)) {
             PRINTF("[Register Identity] Error: Group handle verification failed\n");
-            return SWO_INCORRECT_DATA;
+            return SWO_SECURITY_CONDITION_NOT_SATISFIED;
         }
-        if (!address_book_verify_hmac_name(
+        if (!address_book_verify_hmac_proof(
                 &REG.identity.bip32_path, REG.gid, REG.identity.contact_name, REG.hmac_proof)) {
             PRINTF("[Register Identity] Error: HMAC_PROOF verification failed\n");
-            return SWO_INCORRECT_DATA;
+            return SWO_SECURITY_CONDITION_NOT_SATISFIED;
         }
     }
 

--- a/app_features/address_book/src/identity_register.c
+++ b/app_features/address_book/src/identity_register.c
@@ -20,7 +20,7 @@
  *
  * Flow:
  *  1. Parse TLV payload (name + scope + identifier + derivation_path)
- *  2. Coin-app validation: handle_check_identity()
+ *  2. Coin-app validation: handle_check_register_identity()
  *  3. Display UI: contact name + identifier
  *  4. On confirm: compute HMAC Proof of Registration and send to host
  *
@@ -480,7 +480,7 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
     }
 
     // Check the Identity validity according to the Coin application logic
-    if (!handle_check_identity(ctx.identity)) {
+    if (!handle_check_register_identity(ctx.identity)) {
         PRINTF("[Register Identity] Error: Identity rejected by coin application\n");
         return SWO_WRONG_PARAMETER_VALUE;
     }

--- a/app_features/address_book/src/identity_register.c
+++ b/app_features/address_book/src/identity_register.c
@@ -52,20 +52,21 @@
 
 /* Private types, structures, unions -----------------------------------------*/
 
+// Single persistent state for the Register Identity flow.
+// Lives from register_identity() through the review_choice() callback.
 typedef struct {
-    identity_t     *identity;
-    TLV_reception_t received_tags;
-    uint8_t         group_handle[GROUP_HANDLE_SIZE];  ///< Optional: existing group handle
-    uint8_t         hmac_name[CX_SHA256_SIZE];        ///< Optional: HMAC_NAME for existing group
-} s_identity_ctx;
-
-// Persistent data for the optional "link to existing group" extension.
-// Populated in register_identity() and consumed by the review_choice() callback.
-typedef struct {
+    identity_t identity;
+    // optional "link to existing group" extension:
     uint8_t group_handle[GROUP_HANDLE_SIZE];
-    uint8_t hmac_name[CX_SHA256_SIZE];
+    uint8_t hmac_proof[CX_SHA256_SIZE];
+    uint8_t gid[GID_SIZE];  ///< GID extracted by pre-UI group-handle verification
     bool    active;
-} s_reg_ext_t;
+} s_register_state_t;
+
+typedef struct {
+    s_register_state_t *state;
+    TLV_reception_t     received_tags;
+} s_identity_ctx;
 
 /* Private macros-------------------------------------------------------------*/
 #define REGISTER_IDENTITY_TAGS(X)                                                \
@@ -78,11 +79,10 @@ typedef struct {
     X(0x23, TAG_CHAIN_ID, handle_chain_id, ENFORCE_UNIQUE_TAG)                   \
     X(0x51, TAG_BLOCKCHAIN_FAMILY, handle_blockchain_family, ENFORCE_UNIQUE_TAG) \
     X(0xf6, TAG_GROUP_HANDLE, handle_group_handle, ENFORCE_UNIQUE_TAG)           \
-    X(0x29, TAG_HMAC_NAME, handle_hmac_name, ENFORCE_UNIQUE_TAG)
+    X(0x29, TAG_HMAC_PROOF, handle_hmac_proof, ENFORCE_UNIQUE_TAG)
 
 /* Private variables ---------------------------------------------------------*/
-static identity_t                 IDENTITY     = {0};
-static s_reg_ext_t                REG_EXT      = {0};
+static s_register_state_t         REG          = {0};
 static nbgl_contentTagValueList_t ui_pairsList = {0};
 
 /* Private functions ---------------------------------------------------------*/
@@ -130,8 +130,9 @@ static bool handle_struct_version(const tlv_data_t *data, s_identity_ctx *contex
  */
 static bool handle_contact_name(const tlv_data_t *data, s_identity_ctx *context)
 {
-    if (!address_book_handle_printable_string(
-            data, context->identity->contact_name, sizeof(context->identity->contact_name))) {
+    if (!address_book_handle_printable_string(data,
+                                              context->state->identity.contact_name,
+                                              sizeof(context->state->identity.contact_name))) {
         PRINTF("CONTACT_NAME: failed to parse\n");
         return false;
     }
@@ -148,7 +149,7 @@ static bool handle_contact_name(const tlv_data_t *data, s_identity_ctx *context)
 static bool handle_scope(const tlv_data_t *data, s_identity_ctx *context)
 {
     if (!address_book_handle_printable_string(
-            data, context->identity->scope, sizeof(context->identity->scope))) {
+            data, context->state->identity.scope, sizeof(context->state->identity.scope))) {
         PRINTF("SCOPE: failed to parse\n");
         return false;
     }
@@ -169,8 +170,8 @@ static bool handle_identifier(const tlv_data_t *data, s_identity_ctx *context)
         PRINTF("IDENTIFIER: failed to extract\n");
         return false;
     }
-    memmove(context->identity->identifier, buf.ptr, buf.size);
-    context->identity->identifier_len = (uint8_t) buf.size;
+    memmove(context->state->identity.identifier, buf.ptr, buf.size);
+    context->state->identity.identifier_len = (uint8_t) buf.size;
     return true;
 }
 
@@ -183,7 +184,7 @@ static bool handle_identifier(const tlv_data_t *data, s_identity_ctx *context)
  */
 static bool handle_derivation_path(const tlv_data_t *data, s_identity_ctx *context)
 {
-    return address_book_handle_derivation_path(data, &context->identity->bip32_path);
+    return address_book_handle_derivation_path(data, &context->state->identity.bip32_path);
 }
 
 /**
@@ -195,7 +196,7 @@ static bool handle_derivation_path(const tlv_data_t *data, s_identity_ctx *conte
  */
 static bool handle_chain_id(const tlv_data_t *data, s_identity_ctx *context)
 {
-    return address_book_handle_chain_id(data, &context->identity->chain_id);
+    return address_book_handle_chain_id(data, &context->state->identity.chain_id);
 }
 
 /**
@@ -207,7 +208,7 @@ static bool handle_chain_id(const tlv_data_t *data, s_identity_ctx *context)
  */
 static bool handle_blockchain_family(const tlv_data_t *data, s_identity_ctx *context)
 {
-    return address_book_handle_blockchain_family(data, &context->identity->blockchain_family);
+    return address_book_handle_blockchain_family(data, &context->state->identity.blockchain_family);
 }
 
 /**
@@ -225,26 +226,26 @@ static bool handle_group_handle(const tlv_data_t *data, s_identity_ctx *context)
                GROUP_HANDLE_SIZE);
         return false;
     }
-    memmove(context->group_handle, buf.ptr, GROUP_HANDLE_SIZE);
+    memmove(context->state->group_handle, buf.ptr, GROUP_HANDLE_SIZE);
     return true;
 }
 
 /**
- * @brief Handler for tag \ref HMAC_NAME (optional — proves ownership of an existing group)
+ * @brief Handler for tag \ref HMAC_PROOF (optional — proves ownership of an existing group)
  *
  * @param[in] data the tlv data
  * @param[in] context the received payload
  * @return whether the handling was successful
  */
-static bool handle_hmac_name(const tlv_data_t *data, s_identity_ctx *context)
+static bool handle_hmac_proof(const tlv_data_t *data, s_identity_ctx *context)
 {
     buffer_t buf = {0};
     if (!get_buffer_from_tlv_data(data, &buf, CX_SHA256_SIZE, CX_SHA256_SIZE)) {
-        PRINTF("[Register Identity] HMAC_NAME: invalid length (expected %d bytes)\n",
+        PRINTF("[Register Identity] HMAC_PROOF: invalid length (expected %d bytes)\n",
                CX_SHA256_SIZE);
         return false;
     }
-    memmove(context->hmac_name, buf.ptr, CX_SHA256_SIZE);
+    memmove(context->state->hmac_proof, buf.ptr, CX_SHA256_SIZE);
     return true;
 }
 
@@ -270,18 +271,18 @@ static bool verify_fields(const s_identity_ctx *context)
         PRINTF("Missing mandatory fields in Register Identity descriptor!\n");
         return false;
     }
-    if (context->identity->blockchain_family == FAMILY_ETHEREUM) {
+    if (context->state->identity.blockchain_family == FAMILY_ETHEREUM) {
         result = TLV_CHECK_RECEIVED_TAGS(context->received_tags, TAG_CHAIN_ID);
         if (!result) {
             PRINTF("Missing CHAIN_ID for Ethereum family in Register Identity descriptor!\n");
             return false;
         }
     }
-    // GROUP_HANDLE and HMAC_NAME are optional, but must be provided together
+    // GROUP_HANDLE and HMAC_PROOF are optional, but must be provided together
     bool has_group_handle = TLV_CHECK_RECEIVED_TAGS(context->received_tags, TAG_GROUP_HANDLE);
-    bool has_hmac_name    = TLV_CHECK_RECEIVED_TAGS(context->received_tags, TAG_HMAC_NAME);
-    if (has_group_handle != has_hmac_name) {
-        PRINTF("GROUP_HANDLE and HMAC_NAME must be provided together!\n");
+    bool has_hmac_proof   = TLV_CHECK_RECEIVED_TAGS(context->received_tags, TAG_HMAC_PROOF);
+    if (has_group_handle != has_hmac_proof) {
+        PRINTF("GROUP_HANDLE and HMAC_PROOF must be provided together!\n");
         return false;
     }
     return true;
@@ -300,23 +301,26 @@ static void print_payload(const s_identity_ctx *context)
 
     PRINTF("****************************************************************************\n");
     PRINTF("[Register Identity] - Retrieved Descriptor:\n");
-    PRINTF("[Register Identity] -    Contact name:        %s\n", context->identity->contact_name);
-    if (context->identity->scope[0] != '\0') {
-        PRINTF("[Register Identity] -    Contact scope:       %s\n", context->identity->scope);
+    PRINTF("[Register Identity] -    Contact name:        %s\n",
+           context->state->identity.contact_name);
+    if (context->state->identity.scope[0] != '\0') {
+        PRINTF("[Register Identity] -    Contact scope:       %s\n",
+               context->state->identity.scope);
     }
-    if (bip32_path_format_simple(&context->identity->bip32_path, out, sizeof(out))) {
+    if (bip32_path_format_simple(&context->state->identity.bip32_path, out, sizeof(out))) {
         PRINTF("[Register Identity] -    Derivation path[%d]: %s\n",
-               context->identity->bip32_path.length,
+               context->state->identity.bip32_path.length,
                out);
     }
     else {
         PRINTF("[Register Identity] -    Derivation path length[%d] (failed to format)\n",
-               context->identity->bip32_path.length);
+               context->state->identity.bip32_path.length);
     }
     PRINTF("[Register Identity] -    Blockchain family:   %s\n",
-           FAMILY_AS_STR(context->identity->blockchain_family));
-    if (context->identity->blockchain_family == FAMILY_ETHEREUM) {
-        PRINTF("[Register Identity] -    Chain ID:            %llu\n", context->identity->chain_id);
+           FAMILY_AS_STR(context->state->identity.blockchain_family));
+    if (context->state->identity.blockchain_family == FAMILY_ETHEREUM) {
+        PRINTF("[Register Identity] -    Chain ID:            %llu\n",
+               context->state->identity.chain_id);
     }
 }
 
@@ -324,11 +328,11 @@ static void print_payload(const s_identity_ctx *context)
  * @brief Build and send response
  *
  * Two paths depending on whether an existing group was provided:
- *  - New group: generate group_handle, compute hmac_name + hmac_rest.
- *  - Existing group: verify received group_handle + hmac_name, then compute only hmac_rest
- *    for the new (scope, identifier) pair.
+ *  - New group: generate group_handle, compute hmac_proof + hmac_rest.
+ *  - Existing group: group_handle + hmac_proof already verified pre-UI; echo them back and
+ *    compute only hmac_rest for the new (scope, identifier) pair.
  *
- * Response format: TYPE_REGISTER_IDENTITY(1) | group_handle(64) | hmac_name(32) | hmac_rest(32)
+ * Response format: TYPE_REGISTER_IDENTITY(1) | group_handle(64) | hmac_proof(32) | hmac_rest(32)
  * = 129 B
  *
  * @return true if successful, false otherwise
@@ -336,69 +340,58 @@ static void print_payload(const s_identity_ctx *context)
 static bool build_and_send_response(void)
 {
     uint8_t group_handle[GROUP_HANDLE_SIZE] = {0};
-    uint8_t hmac_name[CX_SHA256_SIZE]       = {0};
+    uint8_t hmac_proof[CX_SHA256_SIZE]      = {0};
     uint8_t hmac_rest[CX_SHA256_SIZE]       = {0};
-    uint8_t gid[GID_SIZE]                   = {0};
     bool    ok                              = false;
 
-    if (REG_EXT.active) {
-        // Verify the provided group handle and extract the GID
-        if (!address_book_verify_group_handle(&IDENTITY.bip32_path, REG_EXT.group_handle, gid)) {
-            PRINTF("[Register Identity] Error: Group handle verification failed\n");
-            goto end;
-        }
-        // Verify that the caller owns the group (proves knowledge of contact_name + gid)
-        if (!address_book_verify_hmac_name(
-                &IDENTITY.bip32_path, gid, IDENTITY.contact_name, REG_EXT.hmac_name)) {
-            PRINTF("[Register Identity] Error: HMAC_NAME verification failed\n");
-            goto end;
-        }
-        // Compute hmac_rest for the new (scope, identifier) pair under the existing group
-        if (!address_book_compute_hmac_rest(&IDENTITY.bip32_path,
-                                            gid,
-                                            IDENTITY.scope,
-                                            IDENTITY.identifier,
-                                            IDENTITY.identifier_len,
-                                            IDENTITY.blockchain_family,
-                                            IDENTITY.chain_id,
+    if (REG.active) {
+        // group_handle and HMAC_PROOF were already verified before the UI — use the
+        // pre-extracted GID directly and only compute the new HMAC_REST.
+        if (!address_book_compute_hmac_rest(&REG.identity.bip32_path,
+                                            REG.gid,
+                                            REG.identity.scope,
+                                            REG.identity.identifier,
+                                            REG.identity.identifier_len,
+                                            REG.identity.blockchain_family,
+                                            REG.identity.chain_id,
                                             hmac_rest)) {
             PRINTF("[Register Identity] Error: Failed to compute HMAC_REST for new address\n");
             goto end;
         }
-        // Echo back the verified group_handle and hmac_name; only hmac_rest is new
-        memmove(group_handle, REG_EXT.group_handle, GROUP_HANDLE_SIZE);
-        memmove(hmac_name, REG_EXT.hmac_name, CX_SHA256_SIZE);
+        // Echo back the verified group_handle and hmac_proof; only hmac_rest is new
+        memmove(group_handle, REG.group_handle, GROUP_HANDLE_SIZE);
+        memmove(hmac_proof, REG.hmac_proof, CX_SHA256_SIZE);
     }
     else {
-        if (!address_book_generate_group_handle(&IDENTITY.bip32_path, group_handle)) {
+        if (!address_book_generate_group_handle(&REG.identity.bip32_path, group_handle)) {
             PRINTF("[Register Identity] Error: Failed to generate group handle\n");
             goto end;
         }
-        // gid is the first GID_SIZE bytes of group_handle
+        // group_handle layout: gid(32) | MAC(K_group, gid)(32) — use only the GID prefix here
+        const uint8_t *gid = group_handle;
         if (!address_book_compute_hmac_name(
-                &IDENTITY.bip32_path, group_handle, IDENTITY.contact_name, hmac_name)) {
-            PRINTF("[Register Identity] Error: Failed to compute HMAC_NAME\n");
+                &REG.identity.bip32_path, gid, REG.identity.contact_name, hmac_proof)) {
+            PRINTF("[Register Identity] Error: Failed to compute HMAC_PROOF\n");
             goto end;
         }
-        if (!address_book_compute_hmac_rest(&IDENTITY.bip32_path,
-                                            group_handle,
-                                            IDENTITY.scope,
-                                            IDENTITY.identifier,
-                                            IDENTITY.identifier_len,
-                                            IDENTITY.blockchain_family,
-                                            IDENTITY.chain_id,
+        if (!address_book_compute_hmac_rest(&REG.identity.bip32_path,
+                                            gid,
+                                            REG.identity.scope,
+                                            REG.identity.identifier,
+                                            REG.identity.identifier_len,
+                                            REG.identity.blockchain_family,
+                                            REG.identity.chain_id,
                                             hmac_rest)) {
             PRINTF("[Register Identity] Error: Failed to compute HMAC_REST\n");
             goto end;
         }
     }
-    ok = address_book_send_register_identity_response(group_handle, hmac_name, hmac_rest);
+    ok = address_book_send_register_identity_response(group_handle, hmac_proof, hmac_rest);
 
 end:
     explicit_bzero(group_handle, sizeof(group_handle));
-    explicit_bzero(hmac_name, sizeof(hmac_name));
+    explicit_bzero(hmac_proof, sizeof(hmac_proof));
     explicit_bzero(hmac_rest, sizeof(hmac_rest));
-    explicit_bzero(gid, sizeof(gid));
     return ok;
 }
 
@@ -458,11 +451,11 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
     const buffer_t payload = {.ptr = buffer_in, .size = buffer_in_length};
     s_identity_ctx ctx     = {0};
 
-    memset(&IDENTITY, 0, sizeof(IDENTITY));
-    memset(&REG_EXT, 0, sizeof(REG_EXT));
-    ctx.identity = &IDENTITY;
+    // Init the structure
+    memset(&REG, 0, sizeof(REG));
+    ctx.state = &REG;
 
-    // Parse using SDK TLV parser
+    // Parse using SDK TLV parser — handlers write directly into REG via ctx.state
     if (!identity_tlv_parser(&payload, &ctx, &ctx.received_tags)) {
         PRINTF("[Register Identity] Failed to parse TLV payload\n");
         return SWO_INCORRECT_DATA;
@@ -472,15 +465,25 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
     }
     print_payload(&ctx);
 
-    // Copy optional group extension data into the persistent static before ctx goes out of scope
+    // Validate group-handle integrity and caller ownership before showing the UI.
+    // These are input checks (wallet-supplied data) — failing here returns an error
+    // immediately; only internal crypto operations remain post-confirm.
     if (TLV_CHECK_RECEIVED_TAGS(ctx.received_tags, TAG_GROUP_HANDLE)) {
-        REG_EXT.active = true;
-        memmove(REG_EXT.group_handle, ctx.group_handle, GROUP_HANDLE_SIZE);
-        memmove(REG_EXT.hmac_name, ctx.hmac_name, CX_SHA256_SIZE);
+        REG.active = true;
+        if (!address_book_verify_group_handle(
+                &REG.identity.bip32_path, REG.group_handle, REG.gid)) {
+            PRINTF("[Register Identity] Error: Group handle verification failed\n");
+            return SWO_INCORRECT_DATA;
+        }
+        if (!address_book_verify_hmac_name(
+                &REG.identity.bip32_path, REG.gid, REG.identity.contact_name, REG.hmac_proof)) {
+            PRINTF("[Register Identity] Error: HMAC_PROOF verification failed\n");
+            return SWO_INCORRECT_DATA;
+        }
     }
 
     // Check the Identity validity according to the Coin application logic
-    if (!handle_check_register_identity(ctx.identity)) {
+    if (!handle_check_register_identity(&REG.identity)) {
         PRINTF("[Register Identity] Error: Identity rejected by coin application\n");
         return SWO_WRONG_PARAMETER_VALUE;
     }

--- a/app_features/address_book/src/ledger_account_edit.c
+++ b/app_features/address_book/src/ledger_account_edit.c
@@ -306,6 +306,7 @@ static void review_choice(bool confirm)
 {
     if (confirm) {
         if (build_and_send_response()) {
+            on_edit_ledger_account_applied(&EDIT_LEDGER_ACCOUNT);
             nbgl_useCaseStatus("Account name changed", true, finalize_ui_edit_ledger_account);
         }
         else {
@@ -348,6 +349,20 @@ static void ui_display(void)
 }
 
 /* Exported functions --------------------------------------------------------*/
+
+/**
+ * @brief Return a read-only pointer to the parsed Edit Ledger Account data.
+ *
+ * The returned pointer is valid from the moment edit_ledger_account() has
+ * finished parsing until the next call to edit_ledger_account(), which
+ * overwrites the static buffer.
+ *
+ * @return Pointer to the current EDIT_LEDGER_ACCOUNT static (never NULL)
+ */
+const edit_ledger_account_t *get_edit_ledger_account(void)
+{
+    return &EDIT_LEDGER_ACCOUNT;
+}
 
 /**
  * @brief Edit the name of an existing Ledger Account

--- a/app_features/address_book/src/ledger_account_provide_contact.c
+++ b/app_features/address_book/src/ledger_account_provide_contact.c
@@ -33,7 +33,7 @@
  *  2. Parse TLV payload (contact_name + derivation_path + chain_id + blockchain_family
  *     + hmac_proof)
  *  3. Verify HMAC Proof of Registration
- *  4. Call handle_provide_ledger_account_contact() so the coin app can store the contact
+ *  4. Call handle_provide_ledger_account() so the coin app can store the contact
  *  5. Return SWO_SUCCESS (9000, no data)
  *
  * Active under HAVE_ADDRESS_BOOK && HAVE_ADDRESS_BOOK_LEDGER_ACCOUNT.
@@ -290,7 +290,7 @@ bolos_err_t provide_ledger_account_contact(uint8_t *buffer_in, size_t buffer_in_
     }
 
     // Pass verified contact to the coin app for storage
-    if (!handle_provide_ledger_account_contact(&PROVIDE_LEDGER_ACCOUNT)) {
+    if (!handle_provide_ledger_account(&PROVIDE_LEDGER_ACCOUNT)) {
         PRINTF("[Provide Ledger Account] Rejected by coin application\n");
         return SWO_WRONG_PARAMETER_VALUE;
     }

--- a/app_features/address_book/src/ledger_account_register.c
+++ b/app_features/address_book/src/ledger_account_register.c
@@ -21,7 +21,7 @@
  * Flow:
  *  1. Parse TLV payload (account name + derivation path + chain ID +
  *     blockchain family)
- *  2. Coin-app validation: handle_check_ledger_account()
+ *  2. Coin-app validation: handle_check_register_ledger_account()
  *  3. Display UI: account name + derivation path
  *  4. On confirm: compute HMAC Proof of Registration and send to host
  *
@@ -302,7 +302,7 @@ bolos_err_t register_ledger_account(uint8_t *buffer_in, size_t buffer_in_length)
     print_payload(&ctx);
 
     // Check the account validity according to the Coin application logic
-    if (!handle_check_ledger_account(ctx.ledger_account)) {
+    if (!handle_check_register_ledger_account(ctx.ledger_account)) {
         PRINTF("[Ledger Account] Error: Account rejected by coin application\n");
         return SWO_WRONG_PARAMETER_VALUE;
     }


### PR DESCRIPTION
## Description

Fix:
- Extend the command Identifier Register to allow adding more identifier to an existing Contact
- Provide-cache stale after Edit-*: App entries were not invalidated/cleaned after a rename/edit

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.
