### PR TITLE
nbgl: align review-light final page vertical centering with reviews

### DIFF
--- a/lib_nbgl/src/nbgl_page.c
+++ b/lib_nbgl/src/nbgl_page.c
@@ -70,6 +70,10 @@ static void addContent(nbgl_pageContent_t *content,
             nbgl_contentCenter_t centeredInfo = {0};
             nbgl_layoutButton_t  buttonInfo;
 
+            if (!headerAdded) {
+                addEmptyHeader(layout, SMALL_CENTERING_HEADER);
+            }
+
             centeredInfo.icon        = content->infoButton.icon;
             centeredInfo.title       = content->infoButton.text;
             centeredInfo.illustrType = ICON_ILLUSTRATION;


### PR DESCRIPTION
## Description

The final confirmation page of `nbgl_useCaseReviewLight` (the page with the centered pictogram, "Confirm change?" / `finishTitle`, and the "Approve" black button) renders its centered icon + title approximately **16 / 20 / 12 px (Stax / Flex / Apex) higher** than the review's first page and the rest of the flow, producing a visible discontinuity.

### Root cause

In `addContent()` (`lib_nbgl/src/nbgl_page.c`), every content type that places content from the top of the main container inserts an empty top spacer of `SMALL_CENTERING_HEADER` when no real header is present:

- `CENTERED_INFO`
- `EXTENDED_CENTER` — used for the review **first** page
- `TAG_VALUE_LIST`
- `TAG_VALUE_DETAILS`
- `TAG_VALUE_CONFIRM`

…except `INFO_BUTTON` (and `INFO_LONG_PRESS`), which call `nbgl_layoutAddContentCenter` directly.

The empty header has two coupled effects (`lib_nbgl/src/nbgl_layout.c:2896-2897`): it shifts the main container's top down by `SMALL_CENTERING_HEADER` and shrinks its height by the same amount. For a `CENTER`-aligned child, the net effect is a downward move of `SMALL_CENTERING_HEADER / 2` px. Without the spacer, the `INFO_BUTTON` block ends up that much higher than every other page.

### Fix

Apply the same `if (!headerAdded) addEmptyHeader(layout, SMALL_CENTERING_HEADER);` guard to the `INFO_BUTTON` case so review-light's first and final pages share the same vertical layout.

### Affected public APIs

Sole users of the `INFO_BUTTON` content type via `addContent()`:

- `nbgl_useCaseReviewLight`
- `nbgl_useCaseStaticReviewLight` (deprecated)
- `nbgl_useCaseAction`

`INFO_LONG_PRESS` (regular-review hold-to-sign final page) has the same asymmetry but is **intentionally left out of this PR** to keep scope minimal — happy to address it in a follow-up after visual verification across review flows.

### Visual change

On affected pages the centered icon + title shifts down by:

| Target | Shift |
|---|---|
| Stax  | +16 px |
| Flex  | +20 px |
| Apex  | +12 px |

Other pages are unchanged.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Additional comments

Minimal repro: `~/dev/app-nbgl-tests` calls `nbgl_useCaseReviewLight` directly. Speculos before/after screenshots on Stax / Flex / Apex are the cleanest visual confirmation.