### PR TITLE
SEPH: Add speculos-specific SEPH message

### DIFF
--- a/include/seproxyhal_protocol.h
+++ b/include/seproxyhal_protocol.h
@@ -297,6 +297,9 @@ enum seph_protocol_cmd_usb_prepare_type {
 // DBG : SCREEN DISPLAY
 #define SEPROXYHAL_TAG_DBG_SCREEN_DISPLAY_STATUS (0x5E)
 
+// CMD:  SEND SPECULOS CHAR
+#define SEPROXYHAL_TAG_NBGL_SEND_SPECULOS_TEXT_LINE (0x5A)
+
 ////////////
 // STATUS //
 ////////////

--- a/io/include/os_io_seph_cmd.h
+++ b/io/include/os_io_seph_cmd.h
@@ -78,6 +78,8 @@ int os_io_seph_cmd_piezo_play_tune(tune_index_e tune_index);
 void os_io_seph_cmd_serialized_nbgl(const uint8_t *buffer, uint16_t length);
 #endif  // HAVE_SERIALIZED_NBGL
 
+void os_io_seph_cmd_send_speculos_text_line(const char *text, size_t length);
+
 #ifdef HAVE_NOR_FLASH
 void os_io_seph_cmd_spi_cs(uint8_t select);
 #endif  // HAVE_NOR_FLASH

--- a/io/src/os_io_seph_cmd.c
+++ b/io/src/os_io_seph_cmd.c
@@ -18,6 +18,7 @@
 #include "os.h"
 #include "os_io.h"
 #include "os_io_seph_cmd.h"
+#include "seproxyhal_protocol.h"
 
 /* Private enumerations ------------------------------------------------------*/
 
@@ -284,6 +285,16 @@ void os_io_seph_cmd_serialized_nbgl(const uint8_t *buffer, uint16_t length)
     }
 }
 #endif  // HAVE_SERIALIZED_NBGL
+
+void os_io_seph_cmd_send_speculos_text_line(const char *text, size_t length)
+{
+    uint8_t buf[3] = {0};
+    buf[0]         = SEPROXYHAL_TAG_NBGL_SEND_SPECULOS_TEXT_LINE;
+    buf[1]         = length >> 8;
+    buf[2]         = length;
+    os_io_tx_cmd(OS_IO_PACKET_TYPE_SEPH, buf, 3, NULL);
+    os_io_tx_cmd(OS_IO_PACKET_TYPE_SEPH, (const uint8_t *) text, length, NULL);
+}
 
 #ifdef HAVE_NOR_FLASH
 void os_io_seph_cmd_spi_cs(uint8_t select)


### PR DESCRIPTION
## Description

Implement a SEPH message that will be used exclusively in Spculos
emulation context. This message contains a single line of text, to be
read and processed by speculos.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
