### PR TITLE
Fix ADDRESS_BOOK_ALIAS address page on Nano

### DIFF
--- a/app_features/address_book/src/address_book_common.c
+++ b/app_features/address_book/src/address_book_common.c
@@ -172,7 +172,7 @@ void address_book_display_review(const nbgl_icon_details_t *icon,
 void address_book_handle_review_rejected(nbgl_callback_t finalize)
 {
     io_send_sw(SWO_INCORRECT_DATA);
-    nbgl_useCaseReviewStatus(STATUS_TYPE_OPERATION_REJECTED, finalize);
+    nbgl_useCaseStatus("Canceled", false, finalize);
 }
 
 /**

--- a/app_features/address_book/src/identity_edit_contact_name.c
+++ b/app_features/address_book/src/identity_edit_contact_name.c
@@ -299,7 +299,11 @@ static void ui_display(void)
     g_ab_ui.list.nbPairs = nbPairs;
     address_book_display_review(&LARGE_ADDRESS_BOOK_ICON,
                                 "Review change to contact details",
+#ifdef SCREEN_SIZE_WALLET
                                 "Confirm change?",
+#else
+                                "Confirm change",
+#endif
                                 review_choice);
 }
 

--- a/app_features/address_book/src/identity_edit_identifier.c
+++ b/app_features/address_book/src/identity_edit_identifier.c
@@ -409,7 +409,11 @@ static void ui_display(void)
     g_ab_ui.list.callback = get_edit_identifier_tagValue;
     address_book_display_review(&LARGE_ADDRESS_BOOK_ICON,
                                 "Review change to contact details",
+#ifdef SCREEN_SIZE_WALLET
                                 "Confirm change?",
+#else
+                                "Confirm change",
+#endif
                                 review_choice);
 }
 

--- a/app_features/address_book/src/identity_edit_scope.c
+++ b/app_features/address_book/src/identity_edit_scope.c
@@ -419,7 +419,11 @@ static void ui_display(void)
     g_ab_ui.list.nbPairs = nbPairs;
     address_book_display_review(&LARGE_ADDRESS_BOOK_ICON,
                                 "Review change to contact details",
+#ifdef SCREEN_SIZE_WALLET
                                 "Confirm change?",
+#else
+                                "Confirm change",
+#endif
                                 review_choice);
 }
 

--- a/app_features/address_book/src/identity_register.c
+++ b/app_features/address_book/src/identity_register.c
@@ -417,7 +417,11 @@ static void ui_display(void)
     g_ab_ui.list.callback = get_register_identity_tagValue;
     address_book_display_review(&LARGE_ADDRESS_BOOK_ICON,
                                 "Review contact details",
+#ifdef SCREEN_SIZE_WALLET
                                 "Confirm contact details?",
+#else
+                                "Confirm contact details",
+#endif
                                 review_choice);
 }
 

--- a/app_features/address_book/src/ledger_account_edit.c
+++ b/app_features/address_book/src/ledger_account_edit.c
@@ -331,7 +331,14 @@ static void ui_display(void)
     nbPairs++;
     g_ab_ui.list.pairs   = g_ab_ui.pairs;
     g_ab_ui.list.nbPairs = nbPairs;
-    address_book_display_review(NULL, "Edit account name", "Confirm edit?", review_choice);
+    address_book_display_review(NULL,
+                                "Edit account name",
+#ifdef SCREEN_SIZE_WALLET
+                                "Confirm edit?",
+#else
+                                "Confirm edit",
+#endif
+                                review_choice);
 }
 
 /* Exported functions --------------------------------------------------------*/

--- a/lib_nbgl/src/nbgl_layout_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_nanos.c
@@ -35,6 +35,9 @@
 // this is the maximum number of chars fitting in a line
 #define NB_MAX_CHAR_IN_LINE 20
 
+#define ELLIPSIS      "..."
+#define ELLIPSIS_SIZE sizeof(ELLIPSIS)  // includes '\0'
+
 /**********************
  *      MACROS
  **********************/
@@ -356,20 +359,20 @@ int nbgl_layoutAddText(nbgl_layout_t                  *layout,
                 button->obj.alignmentMarginY = 8 + 7;
                 textWidth                    = nbgl_getTextWidth(button->fontId, button->text);
                 if ((textWidth + BUTTON_MARGIN_Y) >= AVAILABLE_WIDTH) {
-                    static char tmpString2[NB_MAX_CHAR_IN_LINE];
+                    static char    tmpString2[NB_MAX_CHAR_IN_LINE];
+                    const uint16_t ellipsisWidth = nbgl_getTextWidth(button->fontId, ELLIPSIS);
                     nbgl_getTextMaxLenAndWidth(button->fontId,
                                                button->text,
-                                               AVAILABLE_WIDTH - BUTTON_MARGIN_Y,
+                                               AVAILABLE_WIDTH - BUTTON_MARGIN_Y - ellipsisWidth,
                                                &len,
                                                &width,
                                                true);
-                    button->obj.area.width = width + BUTTON_MARGIN_Y;
-                    // copy the first 'len' chars in the tmp string buffer (max is
-                    // NB_MAX_CHAR_IN_LINE-1)
-                    memcpy(tmpString2, button->text, MIN(len, (NB_MAX_CHAR_IN_LINE - 1)));
-                    // NULL termination
-                    tmpString2[MIN(len, (NB_MAX_CHAR_IN_LINE - 1))] = '\0';
-                    button->text                                    = PIC(tmpString2);
+                    button->obj.area.width = width + ellipsisWidth + BUTTON_MARGIN_Y;
+                    // copy the first 'len' chars then append ELLIPSIS (ELLIPSIS_SIZE includes '\0')
+                    uint16_t copyLen = MIN(len, (NB_MAX_CHAR_IN_LINE - ELLIPSIS_SIZE));
+                    memcpy(tmpString2, button->text, copyLen);
+                    memcpy(tmpString2 + copyLen, ELLIPSIS, ELLIPSIS_SIZE);
+                    button->text = PIC(tmpString2);
                 }
                 else {
                     button->obj.area.width = textWidth + BUTTON_MARGIN_Y;

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -3844,6 +3844,10 @@ void nbgl_useCaseAdvancedChoiceWithDetails(const nbgl_icon_details_t *centerIcon
 
     reset_callbacks_and_context();
 
+#ifdef HAVE_PIEZO_SOUND
+    os_io_seph_cmd_piezo_play_tune(TUNE_LOOK_AT_ME);
+#endif  // HAVE_PIEZO_SOUND
+
     onChoice                                = callback;
     layoutDescription.modal                 = false;
     layoutDescription.withLeftBorder        = true;

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -996,7 +996,8 @@ static void displayExtensionStep(nbgl_stepPosition_t pos)
                                         : context.review.extension->fullValue;
                 }
                 else if (has_scope && page == 1) {
-                    text = context.review.extension->fullValue;
+                    text    = context.review.extension->title;
+                    subText = context.review.extension->fullValue;
                 }
                 else if (has_tn) {
                     text = context.review.extension->explanation;

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -1087,8 +1087,15 @@ static void getLastPageInfo(bool approve, const nbgl_icon_details_t **icon, cons
     if (approve) {
         // Approve page
         *icon = &C_icon_validate_14;
-        if ((context.type == ADDRESS_REVIEW_USE_CASE)
-            || (context.operationType & ADDRESS_BOOK_OPERATION)) {
+        if (context.operationType & ADDRESS_BOOK_OPERATION) {
+            if ((context.type == REVIEW_USE_CASE) && (context.review.finishTitle != NULL)) {
+                *text = context.review.finishTitle;
+            }
+            else {
+                *text = "Confirm contact details";
+            }
+        }
+        else if (context.type == ADDRESS_REVIEW_USE_CASE) {
             *text = "Confirm";
         }
         else {


### PR DESCRIPTION
## Description

- ADDRESS_BOOK_ALIAS: Fix `title` and `text` on the page
- Fix Last page strings for Address Book for Nano
- Adjust Address Book UI wordings for Nano
- Ensure correct truncation with '...' on Nano
- Add 'Look At Me' notification in `nbgl_useCaseChoiceWithDetails`

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.