### PR TITLE
APDU handling fix for for a short 4-bytes APDU without Lc

### DIFF
--- a/io/src/os_io_default_apdu.c
+++ b/io/src/os_io_default_apdu.c
@@ -221,6 +221,12 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
     if (!buffer_in || !buffer_in_length || !buffer_out || !buffer_out_length) {
         return *post_action;
     }
+    // Every case below assumes at least a 4-byte header (CLA/INS/P1/P2).
+    // Without this guard, P1/P2 reads (and worse, Lc/data reads in some cases)
+    // would access bytes past the actually-received APDU.
+    if (buffer_in_length < APDU_OFF_LC) {
+        return SWO_WRONG_LENGTH;
+    }
     if (post_action) {
         *post_action = OS_IO_APDU_POST_ACTION_NONE;
     }
@@ -265,7 +271,13 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
                     err = SWO_WRONG_P1_P2;
                     goto end;
                 }
-                if (!buffer_in[APDU_OFF_LC]) {
+                // Case-1 APDU (no Lc) is equivalent to Lc=0. Bounds-check
+                // before reading APDU_OFF_LC, otherwise the result depends on
+                // whatever stale byte sits in G_io_rx_buffer past the
+                // actually-received APDU bytes - which differs per app and
+                // returns SWO_INCORRECT_P3_LENGTH (0x6c00) non-deterministically
+                // for `CLA INS P1 P2` with no Le.
+                if (buffer_in_length <= APDU_OFF_LC || !buffer_in[APDU_OFF_LC]) {
                     err = get_stack_consumption(buffer_in[APDU_OFF_P1],
                                                 buffer_in[APDU_OFF_P2],
                                                 buffer_out,
@@ -296,14 +308,31 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
 
 #if defined(HAVE_LEDGER_PKI)
             case DEFAULT_APDU_INS_LOAD_CERTIFICATE:
+                // Reject case-1 / truncated APDUs: the loader needs a real Lc
+                // plus Lc bytes of payload. Without these guards, Lc and data
+                // would be read from uninitialized G_io_rx_buffer past the
+                // actually-received APDU.
+                if (buffer_in_length <= APDU_OFF_LC
+                    || buffer_in_length
+                           < (size_t) APDU_OFF_DATA + (size_t) buffer_in[APDU_OFF_LC]) {
+                    err = SWO_INCORRECT_P3_LENGTH;
+                    goto end;
+                }
                 *buffer_out_length = 0;
                 err                = pki_load_certificate(
-                    &buffer_in[APDU_OFF_LC + 1], buffer_in[APDU_OFF_LC], buffer_in[APDU_OFF_P1]);
+                    &buffer_in[APDU_OFF_DATA], buffer_in[APDU_OFF_LC], buffer_in[APDU_OFF_P1]);
                 break;
 #endif  // HAVE_LEDGER_PKI
 
 #if defined(HAVE_ADDRESS_BOOK)
             case DEFAULT_APDU_INS_ADDRESS_BOOK:
+                // Same bounds discipline as LOAD_CERTIFICATE above.
+                if (buffer_in_length <= APDU_OFF_LC
+                    || buffer_in_length
+                           < (size_t) APDU_OFF_DATA + (size_t) buffer_in[APDU_OFF_LC]) {
+                    err = SWO_INCORRECT_P3_LENGTH;
+                    goto end;
+                }
                 *buffer_out_length = 0;
                 err                = addr_book_handle_apdu(&buffer_in[APDU_OFF_DATA],
                                             buffer_in[APDU_OFF_LC],

--- a/io/src/os_io_default_apdu.c
+++ b/io/src/os_io_default_apdu.c
@@ -218,7 +218,7 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
 {
     bolos_err_t err = SWO_CONDITIONS_NOT_SATISFIED;
 
-    if (!buffer_in || !buffer_in_length || !buffer_out || !buffer_out_length) {
+    if (!buffer_in || buffer_in_length == 0 || !buffer_out || !buffer_out_length) {
         return *post_action;
     }
     // Every case below assumes at least a 4-byte header (CLA/INS/P1/P2).
@@ -243,7 +243,7 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
                &buffer_in[APDU_OFF_DATA]);
         switch (buffer_in[APDU_OFF_INS]) {
             case DEFAULT_APDU_INS_GET_VERSION:
-                if (!buffer_in[APDU_OFF_P1] && !buffer_in[APDU_OFF_P2]) {
+                if (buffer_in[APDU_OFF_P1] == 0 && buffer_in[APDU_OFF_P2] == 0) {
                     err = get_version(buffer_out, buffer_out_length);
                 }
                 else {
@@ -254,7 +254,7 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
 
 #if defined(HAVE_SEED_COOKIE)
             case DEFAULT_APDU_INS_GET_SEED_COOKIE:
-                if (!buffer_in[APDU_OFF_P1] && !buffer_in[APDU_OFF_P2]) {
+                if (buffer_in[APDU_OFF_P1] == 0 && buffer_in[APDU_OFF_P2] == 0) {
                     err = get_seed_cookie(buffer_out, buffer_out_length);
                 }
                 else {
@@ -277,7 +277,7 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
                 // actually-received APDU bytes - which differs per app and
                 // returns SWO_INCORRECT_P3_LENGTH (0x6c00) non-deterministically
                 // for `CLA INS P1 P2` with no Le.
-                if (buffer_in_length <= APDU_OFF_LC || !buffer_in[APDU_OFF_LC]) {
+                if (buffer_in_length <= APDU_OFF_LC || buffer_in[APDU_OFF_LC] == 0) {
                     err = get_stack_consumption(buffer_in[APDU_OFF_P1],
                                                 buffer_in[APDU_OFF_P2],
                                                 buffer_out,
@@ -291,7 +291,7 @@ bolos_err_t os_io_handle_default_apdu(uint8_t                  *buffer_in,
 #endif  // DEBUG_OS_STACK_CONSUMPTION
 
             case DEFAULT_APDU_INS_APP_EXIT:
-                if (!buffer_in[APDU_OFF_P1] && !buffer_in[APDU_OFF_P2]) {
+                if (buffer_in[APDU_OFF_P1] == 0 && buffer_in[APDU_OFF_P2] == 0) {
                     *buffer_out_length = 0;
 #if !defined(HAVE_BOLOS)
                     if (post_action) {


### PR DESCRIPTION
## Description

- [x] Fixing by checking buffer_in_length (real received length) against LC field to prevent the case when more bytes than received were consumed from the input buffer (to avoid the situation with stale bytes in LC and data)
- [x] Checking APDU header fields as integer, not as boolean for better readability and maintenance 

App tests against API_LEVEL_26 derived branch with the same 2 commits cherry-picked:
- https://github.com/LedgerHQ/ledger-app-tester/actions/runs/26566298289 -  SDK=`apdu_handle_fix_26`, app-tester=`mbr/stack-protection`
- https://github.com/LedgerHQ/ledger-app-tester/actions/runs/26566334110 - SDK=`apdu_handle_fix_26`, app-tester=develop`
- https://github.com/LedgerHQ/ledger-app-tester/actions/runs/26573949917  - SDK=`mbr/clang-21-sp-small`, app-tester=`mbr/stack-protection`
- https://github.com/LedgerHQ/ledger-app-tester/actions/runs/26573967756  - SDK=`: mbr/clang-21-sp`, app-tester=`mbr/stack-protection`


## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
