### PR TITLE
Fix nano BARS_LIST & CHOICES_LIST

### DIFF
--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -132,6 +132,11 @@ typedef struct {
                           ///< long pressed
     tune_index_e
         tuneId;  ///< if not @ref NBGL_NO_TUNE, a tune will be played when button is touched
+#ifndef HAVE_SE_TOUCH
+    bool bottomIcon;  ///< Nano only: when true and @ref icon is non-NULL, the icon is rendered at
+                      ///< the bottom of the screen (BOTTOM_MIDDLE) instead of above @ref text.
+                      ///< Same semantics as nbgl_contentCenteredInfo_t::bottomIcon.
+#endif                // HAVE_SE_TOUCH
 } nbgl_contentInfoButton_t;
 
 /**

--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -316,7 +316,14 @@ typedef struct {
     bool vertical;  ///< Nano only: if true, render as a vertical menu list with radio buttons
                     ///< (all choices visible) instead of the default one-choice-per-page
                     ///< horizontal flow. Default false preserves existing behaviour.
-#endif              // HAVE_SE_TOUCH
+    /**
+     * @brief Nano only and used in the horizontal flow (i.e. @ref vertical is false): per-content
+     * header text shown above the choice label, e.g. "Keyboard layout". When NULL the SDK falls
+     * back to context.home.appName (the app name) or context.content.title depending on the use
+     * case.
+     */
+    const char *title;
+#endif  // HAVE_SE_TOUCH
 
 } nbgl_contentRadioChoice_t;
 
@@ -332,7 +339,12 @@ typedef struct {
     bool vertical;  ///< Nano only: if true, render as a vertical menu list (all bars visible)
                     ///< instead of the default one-bar-per-page horizontal flow. Default false
                     ///< preserves existing behaviour.
-#endif              // HAVE_SE_TOUCH
+    /**
+     * @brief Nano only and used in the horizontal flow: per-content header text. Same semantics
+     * as nbgl_contentRadioChoice_t::title.
+     */
+    const char *title;
+#endif  // HAVE_SE_TOUCH
 } nbgl_contentBarsList_t;
 
 /**

--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -322,6 +322,11 @@ typedef struct {
     bool vertical;  ///< Nano only: if true, render as a vertical menu list with radio buttons
                     ///< (all choices visible) instead of the default one-choice-per-page
                     ///< horizontal flow. Default false preserves existing behaviour.
+    const nbgl_icon_details_t
+        *selectionIcon;  ///< Nano only and used in the horizontal flow (i.e. @ref vertical is
+                         ///< false): optional small icon drawn underneath the choice label on the
+                         ///< page corresponding to @ref initChoice, so the user can tell which
+                         ///< item is currently selected. NULL (default) means no marker.
     /**
      * @brief Nano only and used in the horizontal flow (i.e. @ref vertical is false): per-content
      * header text shown above the choice label, e.g. "Keyboard layout". When NULL the SDK falls

--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -312,6 +312,11 @@ typedef struct {
     uint8_t token;       ///< the token that will be used as argument of the callback
     tune_index_e
         tuneId;  ///< if not @ref NBGL_NO_TUNE, a tune will be played when selecting a radio button)
+#ifndef HAVE_SE_TOUCH
+    bool vertical;  ///< Nano only: if true, render as a vertical menu list with radio buttons
+                    ///< (all choices visible) instead of the default one-choice-per-page
+                    ///< horizontal flow. Default false preserves existing behaviour.
+#endif              // HAVE_SE_TOUCH
 
 } nbgl_contentRadioChoice_t;
 
@@ -323,6 +328,11 @@ typedef struct {
     const uint8_t     *tokens;    ///< array of tokens, one for each bar (nbBars items)
     uint8_t            nbBars;    ///< number of elements in barTexts and tokens array
     tune_index_e tuneId;  ///< if not @ref NBGL_NO_TUNE, a tune will be played when a bar is touched
+#ifndef HAVE_SE_TOUCH
+    bool vertical;  ///< Nano only: if true, render as a vertical menu list (all bars visible)
+                    ///< instead of the default one-bar-per-page horizontal flow. Default false
+                    ///< preserves existing behaviour.
+#endif              // HAVE_SE_TOUCH
 } nbgl_contentBarsList_t;
 
 /**

--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -71,6 +71,12 @@ typedef struct {
                        ///< Incompatible with @ref onTop: when both are set, @ref onTop is ignored
                        ///< (text is laid out via the standard text path and the icon stays pinned
                        ///< to the screen bottom).
+                       ///< Designed for short contextual hints (selection marker, sub-menu
+                       ///< chevron, ...): the icon should be small (~14 px) and @ref text1 /
+                       ///< @ref text2 should stay short. The Nano screen is only 64 px tall, so
+                       ///< the caller is responsible for keeping text1 + text2 + icon within
+                       ///< that budget — multi-line text1 combined with text2 will clip at the
+                       ///< top and overlap the icon at the bottom.
 #endif                // HAVE_SE_TOUCH
 } nbgl_contentCenteredInfo_t;
 
@@ -135,7 +141,9 @@ typedef struct {
 #ifndef HAVE_SE_TOUCH
     bool bottomIcon;  ///< Nano only: when true and @ref icon is non-NULL, the icon is rendered at
                       ///< the bottom of the screen (BOTTOM_MIDDLE) instead of above @ref text.
-                      ///< Same semantics as nbgl_contentCenteredInfo_t::bottomIcon.
+                      ///< Same semantics and same size budget as
+                      ///< nbgl_contentCenteredInfo_t::bottomIcon — keep @ref text and
+                      ///< @ref buttonText short to avoid clipping/overlap on the 64 px screen.
 #endif                // HAVE_SE_TOUCH
 } nbgl_contentInfoButton_t;
 

--- a/lib_nbgl/include/nbgl_content.h
+++ b/lib_nbgl/include/nbgl_content.h
@@ -65,6 +65,12 @@ typedef struct {
     nbgl_contentCenteredInfoStyle_t style;  ///< style to apply to this info
 #ifdef HAVE_SE_TOUCH
     int16_t offsetY;  ///< vertical shift to apply to this info (if >0, shift to bottom)
+#else                 // HAVE_SE_TOUCH
+    bool bottomIcon;   ///< Nano only: when true and @ref icon is non-NULL, the icon is rendered at
+                       ///< the bottom of the screen (BOTTOM_MIDDLE) instead of above @ref text1.
+                       ///< Incompatible with @ref onTop: when both are set, @ref onTop is ignored
+                       ///< (text is laid out via the standard text path and the icon stays pinned
+                       ///< to the screen bottom).
 #endif                // HAVE_SE_TOUCH
 } nbgl_contentCenteredInfo_t;
 

--- a/lib_nbgl/src/nbgl_layout_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_nanos.c
@@ -467,6 +467,29 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
         return -1;
     }
 
+    // When the caller asks for the icon to be at the screen bottom (and a
+    // primary text is provided), render the texts via nbgl_layoutAddText so
+    // the exact same geometry is used as on non-bottomIcon pages (sibling
+    // CHOICES_LIST entries reach the layout through nbgl_stepDrawText, which
+    // also calls nbgl_layoutAddText). The icon is then appended as a
+    // standalone BOTTOM_MIDDLE element. Falling back to the regular path
+    // when text1 is NULL keeps nbgl_layoutAddText's "main text mandatory"
+    // contract.
+    // Note: nbgl_layoutAddText always centers its container, so this branch
+    // ignores info->onTop — the combination bottomIcon=true && onTop=true is
+    // documented as incompatible on nbgl_contentCenteredInfo_t::bottomIcon.
+    if ((info->icon != NULL) && info->bottomIcon && (info->text1 != NULL)) {
+        nbgl_layoutAddText(layout, info->text1, info->text2, info->style);
+        image                  = (nbgl_image_t *) nbgl_objPoolGet(IMAGE, layoutInt->layer);
+        image->foregroundColor = WHITE;
+        image->buffer          = PIC(info->icon);
+        image->obj.area.bpp    = NBGL_BPP_1;
+        image->obj.alignment   = BOTTOM_MIDDLE;
+        image->obj.alignTo     = NULL;
+        layoutAddObject(layoutInt, (nbgl_obj_t *) image);
+        return 0;
+    }
+
     container = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
 
     // 3 children at max

--- a/lib_nbgl/src/nbgl_layout_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_nanos.c
@@ -479,7 +479,17 @@ int nbgl_layoutAddCenteredInfo(nbgl_layout_t *layout, const nbgl_layoutCenteredI
     // ignores info->onTop — the combination bottomIcon=true && onTop=true is
     // documented as incompatible on nbgl_contentCenteredInfo_t::bottomIcon.
     if ((info->icon != NULL) && info->bottomIcon && (info->text1 != NULL)) {
-        nbgl_layoutAddText(layout, info->text1, info->text2, info->style);
+        // bottomIcon pages put the meaningful content in text1 (the icon is
+        // only a contextual hint at the bottom — selection marker, sub-menu
+        // chevron, ...). Force BOLD_TEXT1_INFO when only text1 is set so the
+        // primary content is visually prominent; when text2 is also set, keep
+        // the caller's style (BOLD_TEXT1_INFO is already implied by the
+        // standard drawStep style selection in that case).
+        nbgl_contentCenteredInfoStyle_t style = info->style;
+        if ((style == REGULAR_INFO) && (info->text2 == NULL)) {
+            style = BOLD_TEXT1_INFO;
+        }
+        nbgl_layoutAddText(layout, info->text1, info->text2, style);
         image                  = (nbgl_image_t *) nbgl_objPoolGet(IMAGE, layoutInt->layer);
         image->foregroundColor = WHITE;
         image->buffer          = PIC(info->icon);

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -1485,7 +1485,13 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
                 break;
             }
             names = (char **) PIC(contentChoices->names);
-            if ((context.type == CONTENT_USE_CASE) && (context.content.title != NULL)) {
+            // The caller-provided per-content title wins over the contextual
+            // fallback (app name / use case title).
+            if (contentChoices->title != NULL) {
+                contentPage->text    = PIC(contentChoices->title);
+                contentPage->subText = (const char *) PIC(names[elemIdx]);
+            }
+            else if ((context.type == CONTENT_USE_CASE) && (context.content.title != NULL)) {
                 contentPage->text    = PIC(context.content.title);
                 contentPage->subText = (const char *) PIC(names[elemIdx]);
             }
@@ -1510,7 +1516,13 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
                 break;  // see CHOICES_LIST comment above
             }
             texts = (char **) PIC(contentBars->barTexts);
-            if ((context.type == CONTENT_USE_CASE) && (context.content.title != NULL)) {
+            // Same precedence as CHOICES_LIST: caller-provided title overrides
+            // the contextual fallback.
+            if (contentBars->title != NULL) {
+                contentPage->text    = PIC(contentBars->title);
+                contentPage->subText = PIC(texts[elemIdx]);
+            }
+            else if ((context.type == CONTENT_USE_CASE) && (context.content.title != NULL)) {
                 contentPage->text    = PIC(context.content.title);
                 contentPage->subText = PIC(texts[elemIdx]);
             }

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -759,11 +759,38 @@ static bool buttonGenericCallback(nbgl_buttonEvent_t event, nbgl_stepPosition_t 
                             break;
                     }
 
-                    if ((p_content) && (p_content->contentActionCallback != NULL)) {
-                        p_content->contentActionCallback(token, index, context.currentPage);
+                    bool used_action_callback
+                        = (p_content != NULL) && (p_content->contentActionCallback != NULL);
+                    ContextType_t prev_type = context.type;
+                    if (used_action_callback) {
+                        nbgl_contentActionCallback_t actionCallback
+                            = (nbgl_contentActionCallback_t) PIC(p_content->contentActionCallback);
+                        actionCallback(token, index, context.currentPage);
                     }
                     else if (context.content.controlsCallback != NULL) {
                         context.content.controlsCallback(token, index);
+                    }
+                    // If the callback swapped the use case (e.g. by entering
+                    // a new screen via display_home_page / nbgl_useCaseXxx),
+                    // the global context has already been reset — leave it
+                    // alone, do not try to redraw the previous layout.
+                    if (context.type != prev_type) {
+                        return false;
+                    }
+                    // After a CHOICES_LIST or BARS_LIST selection that went
+                    // through the per-content action callback (settings-style
+                    // flows), request a redraw of the current page so any
+                    // visual side effect of the pick (e.g. the selectionIcon
+                    // moving below the new initChoice) becomes visible.
+                    // The controlsCallback path (navigable content, generic
+                    // review, ...) is excluded because such callbacks
+                    // commonly route to a brand-new use case (review,
+                    // warning, ...) that owns the screen without resetting
+                    // context.type — forcing a redraw there would clobber it.
+                    if (used_action_callback
+                        && ((p_content->type == CHOICES_LIST) || (p_content->type == BARS_LIST))) {
+                        *pos = FORWARD_DIRECTION;
+                        return true;
                     }
                 }
             }

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -1514,6 +1514,15 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
             else {
                 contentPage->text = (const char *) PIC(names[elemIdx]);
             }
+            // Mark the currently-selected choice with the caller-provided icon
+            // placed at the bottom of the screen (see contentCenteredInfo
+            // bottomIcon handling in nbgl_layoutAddCenteredInfo). Skipped when
+            // the caller did not opt in.
+            if ((contentChoices->selectionIcon != NULL)
+                && (elemIdx == contentChoices->initChoice)) {
+                contentPage->icon       = PIC(contentChoices->selectionIcon);
+                contentPage->bottomIcon = true;
+            }
             break;
         case BARS_LIST:
             contentBars = (nbgl_contentBarsList_t *) PIC(&p_content->content.barsList);

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -739,6 +739,9 @@ static bool buttonGenericCallback(nbgl_buttonEvent_t event, nbgl_stepPosition_t 
                             token = p_content->content.switchesList.switches->token;
                             break;
                         case BARS_LIST:
+                            if (elemIdx >= p_content->content.barsList.nbBars) {
+                                return false;
+                            }
                             token = ((const uint8_t *) PIC(
                                 p_content->content.barsList.tokens))[elemIdx];
                             index = elemIdx;
@@ -1456,8 +1459,10 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
     }
     switch (p_content->type) {
         case CENTERED_INFO:
-            contentPage->text    = PIC(p_content->content.centeredInfo.text1);
-            contentPage->subText = PIC(p_content->content.centeredInfo.text2);
+            contentPage->text       = PIC(p_content->content.centeredInfo.text1);
+            contentPage->subText    = PIC(p_content->content.centeredInfo.text2);
+            contentPage->icon       = PIC(p_content->content.centeredInfo.icon);
+            contentPage->bottomIcon = p_content->content.centeredInfo.bottomIcon;
             break;
         case INFO_BUTTON:
             contentPage->icon       = PIC(p_content->content.infoButton.icon);

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -713,11 +713,13 @@ static bool buttonGenericCallback(nbgl_buttonEvent_t event, nbgl_stepPosition_t 
                             token = p_content->content.switchesList.switches->token;
                             break;
                         case BARS_LIST:
-                            token = p_content->content.barsList.tokens[context.currentPage];
+                            token = ((const uint8_t *) PIC(
+                                p_content->content.barsList.tokens))[elemIdx];
+                            index = elemIdx;
                             break;
                         case CHOICES_LIST:
                             token = p_content->content.choicesList.token;
-                            index = context.currentPage;
+                            index = elemIdx;
                             break;
                         case TAG_VALUE_LIST:
                             return false;
@@ -732,7 +734,7 @@ static bool buttonGenericCallback(nbgl_buttonEvent_t event, nbgl_stepPosition_t 
                     }
 
                     if ((p_content) && (p_content->contentActionCallback != NULL)) {
-                        p_content->contentActionCallback(token, 0, context.currentPage);
+                        p_content->contentActionCallback(token, index, context.currentPage);
                     }
                     else if (context.content.controlsCallback != NULL) {
                         context.content.controlsCallback(token, index);

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -428,17 +428,40 @@ static void onChoiceSelected(uint8_t choiceIndex)
         case BARS_LIST:
             contentBars = ((nbgl_contentBarsList_t *) PIC(&p_content->content.barsList));
             if (choiceIndex < contentBars->nbBars) {
-                token = contentBars->tokens[choiceIndex];
+                token = ((const uint8_t *) PIC(contentBars->tokens))[choiceIndex];
             }
             break;
         default:
             // Not supported as vertical MenuList
             break;
     }
-    if ((token != 255) && (context.content.controlsCallback != NULL)) {
-        context.content.controlsCallback(token, 0);
+    if (token != 255) {
+        // Prefer the per-content action callback (used by settings/content
+        // flows). Forward both the choice index and the absolute page so the
+        // app can react identically to the horizontal flow.
+        if (p_content->contentActionCallback != NULL) {
+            nbgl_contentActionCallback_t actionCallback = PIC(p_content->contentActionCallback);
+            actionCallback(token, choiceIndex, context.currentPage);
+            return;
+        }
+        if (context.content.controlsCallback != NULL) {
+            context.content.controlsCallback(token, choiceIndex);
+            return;
+        }
     }
-    else if (context.content.quitCallback != NULL) {
+    // Back entry (the extra item appended by drawStep at index nbChoices) or
+    // unknown selection: mirror the horizontal-flow Back behaviour in
+    // displaySettingsPage so SETTINGS_USE_CASE / GENERIC_SETTINGS / content
+    // callers all exit consistently.
+    if ((context.type == GENERIC_SETTINGS) && (context.home.quitCallback != NULL)) {
+        context.home.quitCallback();
+        return;
+    }
+    if (context.type == SETTINGS_USE_CASE) {
+        startUseCaseHome();
+        return;
+    }
+    if (context.content.quitCallback != NULL) {
         context.content.quitCallback();
     }
 }

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -1575,6 +1575,14 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
             else {
                 contentPage->text = PIC(texts[elemIdx]);
             }
+            // Sub-menu indicator: always pinned at the bottom of every bar's
+            // page. Mirrors the hardcoded PUSH_ICON ('>') that Stax/Flex draw
+            // on the right of touchable bars (see nbgl_page.c). On Nano the
+            // right button is reserved for navigation, so we pick a downward
+            // chevron and place it at the screen bottom via the centeredInfo
+            // bottomIcon path.
+            contentPage->icon       = &C_icon_down;
+            contentPage->bottomIcon = true;
             break;
         default:
             break;

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -1460,9 +1460,10 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
             contentPage->subText = PIC(p_content->content.centeredInfo.text2);
             break;
         case INFO_BUTTON:
-            contentPage->icon    = PIC(p_content->content.infoButton.icon);
-            contentPage->text    = PIC(p_content->content.infoButton.text);
-            contentPage->subText = PIC(p_content->content.infoButton.buttonText);
+            contentPage->icon       = PIC(p_content->content.infoButton.icon);
+            contentPage->text       = PIC(p_content->content.infoButton.text);
+            contentPage->subText    = PIC(p_content->content.infoButton.buttonText);
+            contentPage->bottomIcon = p_content->content.infoButton.bottomIcon;
             break;
         case TAG_VALUE_LIST:
             getPairData(&p_content->content.tagValueList,

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -1466,7 +1466,14 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
                 contentPage->text    = PIC(context.content.title);
                 contentPage->subText = (const char *) PIC(names[elemIdx]);
             }
-            else if ((context.type == GENERIC_SETTINGS) && (context.home.appName != NULL)) {
+            else if (((context.type == GENERIC_SETTINGS) || (context.type == SETTINGS_USE_CASE))
+                     && (context.home.appName != NULL)) {
+                // Both nbgl_useCaseGenericSettings (GENERIC_SETTINGS) and
+                // nbgl_useCaseHomeAndSettings -> Settings (SETTINGS_USE_CASE)
+                // populate context.home.appName, so use it as the page title
+                // for the latter too -- otherwise a horizontally-paged
+                // CHOICES_LIST would render the choice name only with no
+                // contextual header at all.
                 contentPage->text    = PIC(context.home.appName);
                 contentPage->subText = (const char *) PIC(names[elemIdx]);
             }

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -21,8 +21,6 @@
 /*********************
  *      DEFINES
  *********************/
-#define WITH_HORIZONTAL_CHOICES_LIST
-#define WITH_HORIZONTAL_BARS_LIST
 
 /**********************
  *      TYPEDEFS
@@ -1412,18 +1410,14 @@ static void displayInfoPage(nbgl_stepPosition_t pos)
 // function used to get the current page content
 static void getContentPage(bool toogle_state, PageContent_t *contentPage)
 {
-    uint8_t               elemIdx       = 0;
-    const nbgl_content_t *p_content     = NULL;
-    nbgl_content_t        content       = {0};
-    nbgl_contentSwitch_t *contentSwitch = NULL;
-#ifdef WITH_HORIZONTAL_CHOICES_LIST
+    uint8_t                    elemIdx        = 0;
+    const nbgl_content_t      *p_content      = NULL;
+    nbgl_content_t             content        = {0};
+    nbgl_contentSwitch_t      *contentSwitch  = NULL;
     nbgl_contentRadioChoice_t *contentChoices = NULL;
     char                     **names          = NULL;
-#endif
-#ifdef WITH_HORIZONTAL_BARS_LIST
-    nbgl_contentBarsList_t *contentBars = NULL;
-    char                  **texts       = NULL;
-#endif
+    nbgl_contentBarsList_t    *contentBars    = NULL;
+    char                     **texts          = NULL;
     p_content = getContentElemAtIdx(context.currentPage, &elemIdx, &content);
     if (p_content == NULL) {
         return;
@@ -1482,9 +1476,15 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
                 = ((const char *const *) PIC(p_content->content.infosList.infoContents))[elemIdx];
             break;
         case CHOICES_LIST:
-#ifdef WITH_HORIZONTAL_CHOICES_LIST
             contentChoices = (nbgl_contentRadioChoice_t *) PIC(&p_content->content.choicesList);
-            names          = (char **) PIC(contentChoices->names);
+            // When the content opts into the vertical layout, leave
+            // contentPage->text NULL so drawStep falls through to the menu-list
+            // rendering (all choices visible, with a radio button on
+            // initChoice). Default is the horizontal one-page-per-choice flow.
+            if (contentChoices->vertical) {
+                break;
+            }
+            names = (char **) PIC(contentChoices->names);
             if ((context.type == CONTENT_USE_CASE) && (context.content.title != NULL)) {
                 contentPage->text    = PIC(context.content.title);
                 contentPage->subText = (const char *) PIC(names[elemIdx]);
@@ -1503,12 +1503,13 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
             else {
                 contentPage->text = (const char *) PIC(names[elemIdx]);
             }
-#endif
             break;
         case BARS_LIST:
-#ifdef WITH_HORIZONTAL_BARS_LIST
             contentBars = (nbgl_contentBarsList_t *) PIC(&p_content->content.barsList);
-            texts       = (char **) PIC(contentBars->barTexts);
+            if (contentBars->vertical) {
+                break;  // see CHOICES_LIST comment above
+            }
+            texts = (char **) PIC(contentBars->barTexts);
             if ((context.type == CONTENT_USE_CASE) && (context.content.title != NULL)) {
                 contentPage->text    = PIC(context.content.title);
                 contentPage->subText = PIC(texts[elemIdx]);
@@ -1520,7 +1521,6 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
             else {
                 contentPage->text = PIC(texts[elemIdx]);
             }
-#endif
             break;
         default:
             break;

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -173,6 +173,9 @@ typedef struct PageContent_s {
     nbgl_state_t                  state;
     bool                          isCenteredInfo;
     bool                          isAction;
+    bool                          bottomIcon;  ///< if set alongside @ref icon, render the icon at
+                                               ///< the bottom of the screen instead of above the
+                                               ///< texts; forwarded to nbgl_layoutCenteredInfo_t
 } PageContent_t;
 
 typedef struct ReviewWithWarningContext_s {
@@ -584,7 +587,8 @@ static void drawStep(nbgl_stepPosition_t        pos,
                      const char                *subTxt,
                      nbgl_stepButtonCallback_t  onActionCallback,
                      bool                       modal,
-                     ForcedType_t               forcedType)
+                     ForcedType_t               forcedType,
+                     bool                       bottomIcon)
 {
     uint8_t                           elemIdx;
     nbgl_step_t                       newStep        = NULL;
@@ -649,10 +653,11 @@ static void drawStep(nbgl_stepPosition_t        pos,
     }
     else {
         nbgl_layoutCenteredInfo_t info;
-        info.icon  = icon;
-        info.text1 = txt;
-        info.text2 = subTxt;
-        info.onTop = false;
+        info.icon       = icon;
+        info.text1      = txt;
+        info.text2      = subTxt;
+        info.onTop      = false;
+        info.bottomIcon = bottomIcon;
         if ((subTxt != NULL) || (context.stepCallback != NULL) || context.forceAction) {
             info.style = BOLD_TEXT1_INFO;
         }
@@ -1281,7 +1286,7 @@ static void displayReviewPage(nbgl_stepPosition_t pos)
         }
     }
 
-    drawStep(pos, icon, text, subText, reviewCallback, false, forcedType);
+    drawStep(pos, icon, text, subText, reviewCallback, false, forcedType, false);
     nbgl_refresh();
 }
 
@@ -1378,7 +1383,7 @@ static void displayStreamingReviewPage(nbgl_stepPosition_t pos)
             break;
     }
 
-    drawStep(pos, icon, text, subText, streamingReviewCallback, false, forcedType);
+    drawStep(pos, icon, text, subText, streamingReviewCallback, false, forcedType, false);
     nbgl_refresh();
 }
 
@@ -1403,7 +1408,7 @@ static void displayInfoPage(nbgl_stepPosition_t pos)
         context.stepCallback = startUseCaseHome;
     }
 
-    drawStep(pos, icon, text, subText, infoCallback, false, FORCE_CENTERED_INFO);
+    drawStep(pos, icon, text, subText, infoCallback, false, FORCE_CENTERED_INFO, false);
     nbgl_refresh();
 }
 
@@ -1571,7 +1576,8 @@ static void displaySettingsPage(nbgl_stepPosition_t pos, bool toogle_state)
                  contentPage.subText,
                  settingsCallback,
                  false,
-                 NO_FORCED_TYPE);
+                 NO_FORCED_TYPE,
+                 contentPage.bottomIcon);
     }
 
     nbgl_refresh();
@@ -1736,7 +1742,7 @@ static void displayHomePage(nbgl_stepPosition_t pos)
         context.stepCallback = context.home.quitCallback;
     }
 
-    drawStep(pos, icon, text, subText, homeCallback, false, NO_FORCED_TYPE);
+    drawStep(pos, icon, text, subText, homeCallback, false, NO_FORCED_TYPE, false);
     nbgl_refresh();
 }
 
@@ -1805,7 +1811,7 @@ static void displayChoicePage(nbgl_stepPosition_t pos)
     }
     // other detail types (non-BAR_LIST) are not navigated on Nano
 
-    drawStep(pos, icon, text, subText, genericChoiceCallback, false, NO_FORCED_TYPE);
+    drawStep(pos, icon, text, subText, genericChoiceCallback, false, NO_FORCED_TYPE, false);
     nbgl_refresh();
 }
 
@@ -1837,7 +1843,7 @@ static void displayConfirm(nbgl_stepPosition_t pos)
             break;
     }
 
-    drawStep(pos, icon, text, subText, genericConfirmCallback, true, NO_FORCED_TYPE);
+    drawStep(pos, icon, text, subText, genericConfirmCallback, true, NO_FORCED_TYPE, false);
     nbgl_refresh();
 }
 
@@ -1883,7 +1889,8 @@ static void displayContent(nbgl_stepPosition_t pos, bool toogle_state)
                  contentPage.subText,
                  contentCallback,
                  false,
-                 forcedType);
+                 forcedType,
+                 contentPage.bottomIcon);
     }
     context.forceAction = false;
     nbgl_refresh();
@@ -1891,7 +1898,7 @@ static void displayContent(nbgl_stepPosition_t pos, bool toogle_state)
 
 static void displaySpinner(const char *text)
 {
-    drawStep(SINGLE_STEP, &C_icon_processing, text, NULL, NULL, false, false);
+    drawStep(SINGLE_STEP, &C_icon_processing, text, NULL, NULL, false, NO_FORCED_TYPE, false);
     nbgl_refresh();
 }
 
@@ -2854,7 +2861,8 @@ void nbgl_useCaseStatus(const char *message, bool isSuccess, nbgl_callback_t qui
              NULL,
              statusButtonCallback,
              false,
-             NO_FORCED_TYPE);
+             NO_FORCED_TYPE,
+             false);
 }
 
 /**


### PR DESCRIPTION
## Description

- forward correct index to CHOICES_LIST/BARS_LIST callbacks
- show app name as header for SETTINGS_USE_CASE CHOICES_LIST/BARS_LIST
- route vertical menu picks through per-content callback
- expose vertical layout opt-in for CHOICES_LIST/BARS_LIST
- add per-content title to CHOICES_LIST/BARS_LIST
- add bottomIcon option to nbgl_contentCenteredInfo_t
- add selectionIcon marker for CHOICES_LIST horizontal flow
- redraw CHOICES_LIST/BARS_LIST page after settings-style pick
- Add flag to display icon in bottom for BUTTON_INFO
- Add botton icon with BARS_LIST to indicate a sub-page; also use bold formatting

Tested here: https://github.com/LedgerHQ/ledger-app-tester/actions/runs/26515972039 (app-openpgp error is expected)

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26