### PR TITLE
Full LLVM

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -50,7 +50,7 @@ ifeq ($(CC),)
 CC        = clang
 endif
 
-SYSROOT = $(shell $(GCCPATH)arm-none-eabi-gcc -print-sysroot)
+SYSROOT = $(shell arm-none-eabi-gcc -print-sysroot)
 ifeq ($(SYSROOT),)
     # path for Debian-based systems
     SYSROOT = /usr/lib/arm-none-eabi

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -155,8 +155,8 @@ LINK_DEPENDENCIES += $(APP_CUSTOM_LINK_DEPENDENCIES)
 $(BIN_DIR)/app.elf: $(LINK_DEPENDENCIES)
 	@echo "[LINK] $(BIN_DIR)/app.elf"
 	$(L)$(call link_cmdline,$(OBJECT_FILES) $(LDLIBS),$(BIN_DIR)/app.elf)
-	$(L)$(GCCPATH)arm-none-eabi-objcopy -O ihex -S $(BIN_DIR)/app.elf $(BIN_DIR)/app.hex
-	$(L)$(GCCPATH)arm-none-eabi-objdump -S -d $(BIN_DIR)/app.elf > $(DBG_DIR)/app.asm
+	$(L)llvm-objcopy -O ihex -S $(BIN_DIR)/app.elf $(BIN_DIR)/app.hex
+	$(L)llvm-objdump -S -d $(BIN_DIR)/app.elf > $(DBG_DIR)/app.asm
 
 # This targets are generated along $(OBJ_DIR)/app.elf but we can't make them co-target
 # otherwise building with `make -j` fails due to multiple threads running simultaneously


### PR DESCRIPTION
## Description

With the move to LLVM 21, debug builds are riddled with these errors :
`arm-none-eabi-objdump: DWARF error: mangled line number section (bad file number)`
Switching the remaining two GNU commands to LLVM fixes it.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
