### PR TITLE
Fix unit-tests workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,8 +20,10 @@ jobs:
       - name: Clone
         uses: actions/checkout@v6
 
-      - name: Install package libbsd-dev
-        run: apt-get install -y libbsd-dev curl gpg
+      - name: Install curl
+        run: |
+          apt-get update
+          apt-get install -y curl
 
       - name: Find test directories
         id: find-tests


### PR DESCRIPTION
## Description

Following a recent app-builder container update.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
