### PR TITLE
add stack protector

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -75,7 +75,7 @@ CFLAGS   += -std=gnu99
 
 CFLAGS   += -Wall -Wextra
 CFLAGS   += -Wno-main
-CFLAGS   += -Werror=int-to-pointer-cast
+CFLAGS   += -Werror=int-to-pointer-cast -Wno-implicit-function-declaration
 
 # Additional Clang warnings
 CFLAGS   += -Wno-error=int-conversion -Wimplicit-fallthrough
@@ -96,6 +96,13 @@ LDFLAGS  += -fno-common -ffunction-sections -fdata-sections -fwhole-program -fus
 LDFLAGS  += -mno-unaligned-access
 LDFLAGS  += -Wl,--gc-sections -Wl,-Map,$(DBG_DIR)/app.map
 LDFLAGS  += -nostdlib -nodefaultlibs
+
+ENABLE_STACK_PROTECTOR ?= 0
+ifneq ($(ENABLE_STACK_PROTECTOR),0)
+	LDLIBS   += -Wl,--wrap=__stack_chk_fail -Wl,--wrap=__stack_chk_init
+	AFLAGS   += -fstack-protector-strong
+	CFLAGS   += -fstack-protector-strong
+endif
 
 ifeq ($(TARGET_NAME),TARGET_NANOX)
     CPU       = cortex-m3

--- a/Makefile.defines
+++ b/Makefile.defines
@@ -100,7 +100,7 @@ LDFLAGS  += -nostdlib -nodefaultlibs
 ENABLE_STACK_PROTECTOR ?= 0
 ifneq ($(ENABLE_STACK_PROTECTOR),0)
 	LDLIBS   += -Wl,--wrap=__stack_chk_fail -Wl,--wrap=__stack_chk_init
-	AFLAGS   += -fstack-protector-strong
+	AFLAGS   += -fstack-protector-strong -Wno-unused-command-line-argument
 	CFLAGS   += -fstack-protector-strong
 endif
 

--- a/src/stack_protector_init.S
+++ b/src/stack_protector_init.S
@@ -10,17 +10,22 @@
 .global __wrap___stack_chk_init
 .thumb_func
 __wrap___stack_chk_init:
+    // if r0 != 0, skip initialization and jump directly to main
+    // (don't overwrite parent canary during a libcall)
+    cmp r0, #0
+    bne 1f
+
     // save arguments passed to main
     push {r0-r3}
 
     // call cx_get_random_bytes(&__stack_chk_guard, sizeof(__stack_chk_guard));
     // we can't use the function cx_get_random_bytes because of PIC
     ldr r0, =SYSCALL_cx_get_random_bytes_ID
-    ldr r2, =__stack_chk_guard
+    mov r2, r9
     movs r3, #4
     push {r2-r3}
     mov r1, sp
-    svc 1
+    bl SVC_Call
     pop {r2-r3}
 
     // restore arguments

--- a/target/apex_m/script.ld
+++ b/target/apex_m/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -105,6 +107,9 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     _bss = .;
     *(.bss*)
     _ebss = .;
@@ -126,6 +131,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/apex_p/script.ld
+++ b/target/apex_p/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -105,6 +107,9 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     _bss = .;
     *(.bss*)
     _ebss = .;
@@ -126,6 +131,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/flex/script.ld
+++ b/target/flex/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -108,6 +110,9 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     _bss = .;
     *(.bss*)
     _ebss = .;
@@ -129,6 +134,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -107,6 +109,9 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     _bss = .;
     *(.bss*)
     _ebss = .;
@@ -128,6 +133,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -104,21 +104,15 @@ SECTIONS
 
   ASSERT( (_edata - _data) <= 0, ".data section must be empty" )
 
-  /* The .init_array is initialized with functions with the constructor
-   * attribute. Discard this section since there's no loader. */
-  /DISCARD/ : {
-    *(.init_array)
-  }
-
   .bss :
   {
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 
@@ -139,6 +133,12 @@ SECTIONS
   } > SRAM
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+    * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -48,7 +48,9 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure main is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    KEEP(*(.boot.ssp_init))
+    /* ensure main directly follows __stack_chk_init */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -108,6 +110,9 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
+    __stack_chk_guard = .;
+    PROVIDE(__stack_chk_guard = .);
+    . += 4;
     _bss = .;
     *(.bss*)
     _ebss = .;
@@ -129,6 +134,12 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+
+  /* The .init_array is initialized with functions with the constructor
+   * attribute. Discard this section since there's no loader. */
+  /DISCARD/ : {
+    *(.init_array)
+  }
 
   /****************************************************************/
   /* DEBUG                                                        */


### PR DESCRIPTION
## Description

- [x] Adding `ENABLE_STACK_PROTECTOR` option. This is an opt-in for apps that will define `ENABLE_STACK_PROTECTOR=1` in their `Makefile`.

PoC from #1128 by @bboilot-ledger 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
