### PR TITLE
NBGL: Fix uninitialized nbgl_layoutCenteredInfo_t

### DIFF
--- a/lib_nbgl/src/nbgl_flow.c
+++ b/lib_nbgl/src/nbgl_flow.c
@@ -107,7 +107,7 @@ static void drawStep(FlowContext_t             *ctx,
                      const char                *txt,
                      const char                *subTxt)
 {
-    nbgl_layoutCenteredInfo_t info;
+    nbgl_layoutCenteredInfo_t info = {0};
     if ((ctx->loop) && (ctx->nbSteps > 1)) {
         pos |= NEITHER_FIRST_NOR_LAST_STEP;
     }


### PR DESCRIPTION
Uninitialized `centered info` structure in NBGL lead to undefined behavior after the introduction of a new field in the structure.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26
