### PR TITLE
increase debug level to 3

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -60,9 +60,7 @@ CFLAGS   += --sysroot="$(SYSROOT)"
 # optimization and debugging levels
 ifneq ($(DEBUG),0)
     OPTI_LVL  = g
-    # any higher won't work with LLVM >= 14
-    # will be fixed in LLVM 20 : https://github.com/llvm/llvm-project/pull/116956
-    DBG_LVL   = 1
+    DBG_LVL   = 3
 else
     OPTI_LVL  = z
     DBG_LVL   = 0


### PR DESCRIPTION
## Description

increasing debug level to 3, made possible with the toolchain update to clang-21.

Related PR : https://github.com/LedgerHQ/app-boilerplate/pull/209

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
