### PR TITLE
Fix selection of BIP39 words that prefix others on Nano

### DIFF
--- a/lib_nbgl/include/nbgl_layout.h
+++ b/lib_nbgl/include/nbgl_layout.h
@@ -355,7 +355,12 @@ typedef struct {
     const char **buttons;  ///< array of 4 strings for buttons (last ones can be NULL)
     int firstButtonToken;  ///< first token used for buttons, provided in onActionCallback (the next
                            ///< 3 values will be used for other buttons)
-    uint8_t nbUsedButtons;  ///< the number of actually used buttons
+    uint8_t  nbUsedButtons;  ///< the number of actually used (displayed) buttons
+    uint16_t nbCandidates;   ///< total number of matching candidates, which may be greater than
+                             ///< @ref nbUsedButtons when the displayed buttons are capped. On Nano
+                             ///< it is used to decide when the whole candidate list fits in the
+                             ///< selection page. If left to 0, @ref nbUsedButtons is used instead
+                             ///< (legacy behaviour).
 } nbgl_layoutSuggestionButtons_t;
 
 /**

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -2110,11 +2110,22 @@ static void keyboardCallback(char touchedKey)
     if (context.keyboard.content.type == KEYBOARD_WITH_SUGGESTIONS) {
         // if suggestions are displayed, we update them at each key press
         context.keyboard.getSuggestButtons(&context.keyboard.content, &mask);
-        if ((context.keyboard.content.suggestionButtons.nbUsedButtons > 0)
-            && (context.keyboard.content.suggestionButtons.nbUsedButtons
-                < NB_MAX_SUGGESTION_BUTTONS)) {
-            // On Nano, when we have few suggestions, display a selection page
-            // instead of continuing with keyboard entry
+        const nbgl_layoutSuggestionButtons_t *suggestions
+            = &context.keyboard.content.suggestionButtons;
+        // On Nano, when all the matching candidates can be displayed, switch to a selection page
+        // instead of continuing with keyboard entry. When the caller provides the real number of
+        // candidates (nbCandidates != 0), rely on it: this lets a fully-typed word that is also
+        // the prefix of other words (e.g. "can") be selected even though the displayed buttons are
+        // capped at NB_MAX_SUGGESTION_BUTTONS. Otherwise fall back to the legacy heuristic based on
+        // the number of displayed buttons.
+        bool allCandidatesFit;
+        if (suggestions->nbCandidates != 0) {
+            allCandidatesFit = (suggestions->nbCandidates <= NB_MAX_SUGGESTION_BUTTONS);
+        }
+        else {
+            allCandidatesFit = (suggestions->nbUsedButtons < NB_MAX_SUGGESTION_BUTTONS);
+        }
+        if ((suggestions->nbUsedButtons > 0) && allCandidatesFit) {
             displaySuggestionSelection();
             return;  // Don't update keyboard, we're in suggestion mode
         }


### PR DESCRIPTION
## Description

On Nano the keyboard could not select a fully-typed word when that word is also the prefix of NB_MAX_SUGGESTION_BUTTONS or more other words: the suggestion selection page was never offered and any extra letter moved away from the word. "can" was the only affected word in the English BIP39 list (can, canal, cancel, candy, cannon, canoe, canvas, canyon = 8 words).

Report the real (uncapped) candidate count through the new nbCandidates field of the keyboard suggestions, so the SDK can offer the selection page as soon as all candidates fit.

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.