### PR TITLE
ensure __stack_chk_guard is the first symbol in bss

### DIFF
--- a/target/apex_m/script.ld
+++ b/target/apex_m/script.ld
@@ -131,6 +131,7 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+  ASSERT( __stack_chk_guard == _bss, "__stack_chk_guard must be the first variable in .bss" )
 
   /* The .init_array is initialized with functions with the constructor
    * attribute. Discard this section since there's no loader. */

--- a/target/apex_p/script.ld
+++ b/target/apex_p/script.ld
@@ -131,6 +131,7 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+  ASSERT( __stack_chk_guard == _bss, "__stack_chk_guard must be the first variable in .bss" )
 
   /* The .init_array is initialized with functions with the constructor
    * attribute. Discard this section since there's no loader. */

--- a/target/flex/script.ld
+++ b/target/flex/script.ld
@@ -134,6 +134,7 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+  ASSERT( __stack_chk_guard == _bss, "__stack_chk_guard must be the first variable in .bss" )
 
   /* The .init_array is initialized with functions with the constructor
    * attribute. Discard this section since there's no loader. */

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -133,6 +133,7 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+  ASSERT( __stack_chk_guard == _bss, "__stack_chk_guard must be the first variable in .bss" )
 
   /* The .init_array is initialized with functions with the constructor
    * attribute. Discard this section since there's no loader. */

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -133,6 +133,7 @@ SECTIONS
   } > SRAM
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+  ASSERT( __stack_chk_guard == _bss, "__stack_chk_guard must be the first variable in .bss" )
 
   /* The .init_array is initialized with functions with the constructor
     * attribute. Discard this section since there's no loader. */

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -134,6 +134,7 @@ SECTIONS
   } > SRAM = 0x00
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
+  ASSERT( __stack_chk_guard == _bss, "__stack_chk_guard must be the first variable in .bss" )
 
   /* The .init_array is initialized with functions with the constructor
    * attribute. Discard this section since there's no loader. */


### PR DESCRIPTION
## Description

ensure __stack_chk_guard is the first symbol in bss. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
