### PR TITLE
Fix header path priority during build

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -20,25 +20,29 @@ ifeq ($(USE_NBGL),0)
     SDK_SOURCE_PATH += lib_bagl lib_ux
 else
     SDK_SOURCE_PATH += lib_ux_nbgl
-    NBGL_SOURCES := $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_layout*.[csS]')
-    NBGL_SOURCES += $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_page*.[csS]')
-    NBGL_SOURCES += $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_step*.[csS]')
-    NBGL_SOURCES += $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_use_case*.[csS]')
-    NBGL_INCLUDE_PATH := lib_nbgl
+    # Only the high-level NBGL layer is compiled into the app (the low-level NBGL is
+    # provided by the OS), so individual source files are listed instead of adding
+    # the whole lib_nbgl directory to SDK_SOURCE_PATH.
+    SDK_SOURCE_FILES += $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_layout*.[csS]')
+    SDK_SOURCE_FILES += $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_page*.[csS]')
+    SDK_SOURCE_FILES += $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_step*.[csS]')
+    SDK_SOURCE_FILES += $(shell find $(BOLOS_SDK)/lib_nbgl/src -name 'nbgl_use_case*.[csS]')
+    # lib_nbgl headers must be reachable even though not all its sources are compiled.
+    SDK_HEADER_PATH += lib_nbgl
 endif
 
 ifneq ($(IS_STANDARD_APP),1)
 ifneq ($(DISABLE_OS_IO_STACK_USE), 1)
 ifeq (,$(filter $(DEFINES),HAVE_LEGACY_PID))
-DEFINES += USE_OS_IO_STACK
+    DEFINES += USE_OS_IO_STACK
 endif
 endif
 endif
 
 define uniq =
-  $(eval seen :=)
-  $(foreach _,$1,$(if $(filter $_,${seen}),,$(eval seen += $_)))
-  ${seen}
+    $(eval seen :=)
+    $(foreach _,$1,$(if $(filter $_,${seen}),,$(eval seen += $_)))
+    ${seen}
 endef
 
 define check_duplicate =
@@ -57,48 +61,67 @@ INCLUDES_PATH_SDK_BASE += ${BOLOS_SDK}
 
 #include the lib_cxng definition by default if not asked otherwise
 ifeq ($(NO_CXNG),)
-INCLUDES_PATH_SDK_BASE += $(BOLOS_SDK)/lib_cxng/include
+    INCLUDES_PATH_SDK_BASE += $(BOLOS_SDK)/lib_cxng/include
 endif
 
 # Get absolute App root directory to ensure correct stem replacement
 APP_DIR := $(shell git rev-parse --show-toplevel)
 ifeq ($(APP_DIR),)
-MSG := "[ERROR] You should be inside a git repo (you can use 'git init')"
+    MSG := "[ERROR] You should be inside a git repo (you can use 'git init')"
 ifneq ($(ENABLE_SDK_WERROR),0)
-$(error $(MSG))
+    $(error $(MSG))
 else
-$(warning $(MSG))
+    $(warning $(MSG))
 endif
 endif
 
-# Extract BOLOS_SDK source files added by the App Makefile
-APP_SRC_FROM_SDK = $(filter $(BOLOS_SDK)/%, $(APP_SOURCE_FILES))
+# Extract/Filter BOLOS_SDK source files added by the App Makefile
+SDK_SOURCE_FROM_APP = $(filter $(BOLOS_SDK)/%, $(APP_SOURCE_FILES))
+
 # Extract generated and glyphs source files added by the App Makefile
-APP_SRC_GEN = $(filter $(GEN_SRC_DIR)/%, $(APP_SOURCE_FILES))
-# Extract proto source files added by the App Makefile
-APP_SRC_PROTOC = $(filter %.pb.c, $(APP_SOURCE_FILES) $(SOURCE_FILES)) $(shell find $(APP_SOURCE_PATH) -name '*.pb.c')
-# Filter remaining real source files from App (proto filtered globally hereafter)
-APP_SRC_FILTER = $(filter-out $(APP_SRC_FROM_SDK) $(APP_SRC_GEN), $(APP_SOURCE_FILES))
+APP_SOURCE_GEN = $(filter $(GEN_SRC_DIR)/%, $(APP_SOURCE_FILES))
+# Extract proto source files added by the App Makefile (explicitly listed ones, plus
+# those discovered under APP_SOURCE_PATH)
+APP_PROTOC_FOUND = $(shell find $(APP_SOURCE_PATH) -name '*.pb.c')
+APP_SOURCE_PROTOC = $(filter %.pb.c, $(APP_SOURCE_FILES) $(SOURCE_FILES)) $(APP_PROTOC_FOUND)
+# Remaining real App source files (SDK/gen extracted above, proto filtered globally hereafter)
+APP_SOURCE_OWN = $(filter-out $(SDK_SOURCE_FROM_APP) $(APP_SOURCE_GEN), $(APP_SOURCE_FILES))
 
 # Separate SDK and APP and GEN sources
-SOURCES_SDK += $(foreach libdir, src $(SDK_SOURCE_PATH), $(shell find $(BOLOS_SDK)/$(libdir) -name '*.[csS]')) $(APP_SRC_FROM_SDK) $(NBGL_SOURCES)
-SOURCES_APP += $(filter-out %.pb.c, $(abspath $(SOURCE_FILES) $(foreach libdir, $(SOURCE_PATH) $(APP_SOURCE_PATH), $(shell find $(libdir) -name '*.[csS]')) $(APP_SRC_FILTER)))
-SOURCES_GEN += $(GLYPH_DESTC) $(APP_SRC_GEN)
+SOURCES_SDK += \
+    $(foreach libdir, src $(SDK_SOURCE_PATH), $(shell find $(BOLOS_SDK)/$(libdir) -name '*.[csS]')) \
+    $(SDK_SOURCE_FROM_APP) \
+    $(SDK_SOURCE_FILES)
+
+SOURCES_APP += $(filter-out %.pb.c, $(abspath \
+    $(SOURCE_FILES) \
+    $(foreach libdir, $(SOURCE_PATH) $(APP_SOURCE_PATH), $(shell find $(libdir) -name '*.[csS]')) \
+    $(APP_SOURCE_OWN)))
+
+SOURCES_GEN += $(GLYPH_DESTC) $(APP_SOURCE_GEN)
 VPATH += $(call uniq, $(dir $(SOURCES_SDK) $(SOURCES_APP) $(GLYPH_DESTC)))
 
 # Retrieve APP header filenames
-INCLUDES_APP += $(shell find $(APP_SOURCE_PATH) -name '*.h')
+HEADERS_APP += $(shell find $(APP_SOURCE_PATH) -name '*.h')
 # Warn if a same header filename is found in both APP and SDK
-$(call check_duplicate, $(INCLUDES_APP), $(BOLOS_SDK))
+$(call check_duplicate, $(HEADERS_APP), $(BOLOS_SDK))
 
 # SDK header directories discovered from the SDK source paths (computed once).
-INCLUDES_PATH_SDK_BASE += $(dir $(foreach libdir, $(SDK_SOURCE_PATH) $(NBGL_INCLUDE_PATH), $(dir $(shell find $(BOLOS_SDK)/$(libdir) -name '*.h')))) $(BOLOS_SDK)/include $(BOLOS_SDK)/include/arm
+# For each SDK lib, $(dir ...) of the headers found gives the directories holding them.
+INCLUDES_PATH_SDK_BASE += \
+    $(foreach libdir, $(SDK_SOURCE_PATH) $(SDK_HEADER_PATH), $(dir $(shell find $(BOLOS_SDK)/$(libdir) -name '*.h'))) \
+    $(BOLOS_SDK)/include \
+    $(BOLOS_SDK)/include/arm
 
 # App header directories. RECURSIVELY expanded (=) on purpose: app Makefiles may add
 # include dirs (INCLUDES_PATH += ...) or extra sources (APP_SOURCE_PATH += ..., which
-# feeds INCLUDES_APP) AFTER this file is included; lazy expansion captures them at
+# feeds HEADERS_APP) AFTER this file is included; lazy expansion captures them at
 # build time. $(GLYPH_SRC_DIR) holds the generated glyphs.h.
-INCLUDES_PATH_APP_DIRS = $(INCLUDES_PATH) include $(dir $(INCLUDES_APP)) $(GLYPH_SRC_DIR)
+INCLUDES_PATH_APP_BASE = \
+    $(INCLUDES_PATH) \
+    include \
+    $(dir $(HEADERS_APP)) \
+    $(GLYPH_SRC_DIR)
 
 # Final include paths: same set of directories, but in opposite priority order, so
 # that the command-line search order is correct for each kind of source.
@@ -106,14 +129,16 @@ INCLUDES_PATH_APP_DIRS = $(INCLUDES_PATH) include $(dir $(INCLUDES_APP)) $(GLYPH
 #    dirs kept only as a fallback, needed e.g. for the generated glyphs.h included by
 #    SDK NBGL sources, or for headers force-included via 'CFLAGS += -include ...'.
 #  - APP sources: app headers FIRST, SDK headers as fallback.
-INCLUDES_PATH_SDK = $(call uniq, $(INCLUDES_PATH_SDK_BASE) $(INCLUDES_PATH_APP_DIRS))
-INCLUDES_PATH_APP = $(call uniq, $(INCLUDES_PATH_APP_DIRS) $(INCLUDES_PATH_SDK_BASE))
+INCLUDES_PATH_SDK = $(call uniq, $(INCLUDES_PATH_SDK_BASE) $(INCLUDES_PATH_APP_BASE))
+INCLUDES_PATH_APP = $(call uniq, $(INCLUDES_PATH_APP_BASE) $(INCLUDES_PATH_SDK_BASE))
 
 # Separate object files from SDK and APP to avoid name conflicts
 OBJECTS_SDK += $(sort $(subst $(BOLOS_SDK), $(OBJ_DIR)/sdk, $(addsuffix .o, $(basename $(SOURCES_SDK)))))
-OBJECTS_APP += $(sort $(addprefix $(OBJ_DIR)/app, $(addsuffix .o, $(basename $(foreach f, $(SOURCES_APP), $(shell echo $(f) | sed "s|$(APP_DIR)||" 2>/dev/null))))))
+# App object path = $(OBJ_DIR)/app/<source path relative to APP_DIR>.o
+OBJECTS_APP += $(sort $(addprefix $(OBJ_DIR)/app, $(addsuffix .o, $(basename \
+    $(foreach f, $(SOURCES_APP), $(shell echo $(f) | sed "s|$(APP_DIR)||" 2>/dev/null))))))
 OBJECTS_GEN += $(sort $(SOURCES_GEN:%c=%o))
-OBJECTS_PROTOC += $(sort $(addprefix $(OBJ_DIR)/, $(addsuffix .o, $(basename $(APP_SRC_PROTOC)))))
+OBJECTS_PROTOC += $(sort $(addprefix $(OBJ_DIR)/, $(addsuffix .o, $(basename $(APP_SOURCE_PROTOC)))))
 OBJECT_FILES = $(OBJECTS_GEN) $(OBJECTS_PROTOC) $(OBJECTS_APP) $(OBJECTS_SDK)
 OBJECTS_DIR += $(sort $(dir $(OBJECT_FILES)))
 
@@ -125,13 +150,13 @@ DEPEND_DIR += $(sort $(dir $(DEPEND_FILES)))
 APP_MANIFEST_FILE := $(APP_DIR)/ledger_app.toml
 # If the TOML file exists, retrieve the use-cases
 ifneq ($(wildcard $(APP_MANIFEST_FILE)),)
-  # Retrieve the use-cases from the TOML file
-  APP_USE_CASES := $(shell ledger-manifest "$(APP_MANIFEST_FILE)" -ouc -j | jq -r 'keys | join(" ")')
+    # Retrieve the use-cases from the TOML file
+    APP_USE_CASES := $(shell ledger-manifest "$(APP_MANIFEST_FILE)" -ouc -j | jq -r 'keys | join(" ")')
 
-  # Function to extract flags for a specific use case
-  define get_flags_for_use_case
-    $(shell ledger-manifest "$(APP_MANIFEST_FILE)" -ouc $1)
-  endef
+    # Function to extract flags for a specific use case
+    define get_flags_for_use_case
+        $(shell ledger-manifest "$(APP_MANIFEST_FILE)" -ouc $1)
+    endef
 endif
 
 include $(BOLOS_SDK)/Makefile.rules_generic

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -45,11 +45,6 @@ define uniq =
     ${seen}
 endef
 
-define check_duplicate =
-  $(eval LIST := $(sort $(foreach file_h, $(notdir $1), $(notdir $(shell find $2 -name $(file_h))))))
-  $(if $(LIST), $(info [WARNING] Found duplicate files in SDK and APP: ${LIST}))
-endef
-
 SDK_SOURCE_PATH += io io_legacy protocol lib_u2f_legacy
 
 # adding the correct target header to sources
@@ -103,8 +98,6 @@ VPATH += $(call uniq, $(dir $(SOURCES_SDK) $(SOURCES_APP) $(GLYPH_DESTC)))
 
 # Retrieve APP header filenames
 HEADERS_APP += $(shell find $(APP_SOURCE_PATH) -name '*.h')
-# Warn if a same header filename is found in both APP and SDK
-$(call check_duplicate, $(HEADERS_APP), $(BOLOS_SDK))
 
 # SDK header directories discovered from the SDK source paths (computed once).
 # For each SDK lib, $(dir ...) of the headers found gives the directories holding them.
@@ -158,6 +151,30 @@ ifneq ($(wildcard $(APP_MANIFEST_FILE)),)
         $(shell ledger-manifest "$(APP_MANIFEST_FILE)" -ouc $1)
     endef
 endif
+
+# Build-time check: warn when a header basename is reachable via -I from BOTH an APP
+# and an SDK include directory but from DIFFERENT directories (a real shadow risk).
+# Run in a recipe so that include dirs added by the app AFTER this file is included
+# (INCLUDES_PATH += ..., APP_SOURCE_PATH += ...) are covered.
+# Notes:
+#  - Directories present on BOTH sides are subtracted from the SDK side first: a header
+#    found in a shared dir is the same file, not a shadow (e.g. the generated glyphs.h
+#    in $(GLYPH_SRC_DIR), reachable by both SDK and APP). This keeps the warning
+#    signal to genuine cross-directory collisions only.
+#  - The bare $(BOLOS_SDK) root is excluded: a header sitting directly at the SDK root
+#    is still reachable via -I$(BOLOS_SDK) for SDK builds, so a collision there is a
+#    deliberate blind spot.
+#  - hdr() relies on word-splitting, so include paths containing spaces are not handled.
+.PHONY: check-duplicate-headers
+check-duplicate-headers:
+	$(L)hdr() { for d in $$1; do ls "$$d"/*.h 2>/dev/null; done | sed 's#.*/##' | sort -u; }; \
+	dup=$$(comm -12 \
+	    <(hdr "$(filter-out $(INCLUDES_PATH_APP_BASE) $(BOLOS_SDK),$(INCLUDES_PATH_SDK_BASE))") \
+	    <(hdr "$(INCLUDES_PATH_APP_BASE)")); \
+	[ -z "$$dup" ] || echo "[WARNING] Header(s) present in both SDK and APP include dirs:" $$dup
+
+# Run the duplicate check once at the start of every build.
+prepare: check-duplicate-headers
 
 include $(BOLOS_SDK)/Makefile.rules_generic
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -51,12 +51,13 @@ SDK_SOURCE_PATH += io io_legacy protocol lib_u2f_legacy
 # adding the correct target header to sources
 SDK_SOURCE_PATH += target/$(TARGET)/include
 
+# --- SDK include directories base (computed once, app-independent) ---
 # Expose all SDK header files with their full relative path to the SDK root folder
-INCLUDES_PATH  += ${BOLOS_SDK}
+INCLUDES_PATH_SDK_BASE += ${BOLOS_SDK}
 
 #include the lib_cxng definition by default if not asked otherwise
 ifeq ($(NO_CXNG),)
-INCLUDES_PATH += $(BOLOS_SDK)/lib_cxng/include
+INCLUDES_PATH_SDK_BASE += $(BOLOS_SDK)/lib_cxng/include
 endif
 
 # Get absolute App root directory to ensure correct stem replacement
@@ -89,8 +90,24 @@ VPATH += $(call uniq, $(dir $(SOURCES_SDK) $(SOURCES_APP) $(GLYPH_DESTC)))
 INCLUDES_APP += $(shell find $(APP_SOURCE_PATH) -name '*.h')
 # Warn if a same header filename is found in both APP and SDK
 $(call check_duplicate, $(INCLUDES_APP), $(BOLOS_SDK))
-# Compute header directories list
-INCLUDES_PATH += $(call uniq, $(dir $(foreach libdir, $(SDK_SOURCE_PATH) $(NBGL_INCLUDE_PATH), $(dir $(shell find $(BOLOS_SDK)/$(libdir) -name '*.h')))) include $(BOLOS_SDK)/include $(BOLOS_SDK)/include/arm $(dir $(INCLUDES_APP)) $(GLYPH_SRC_DIR))
+
+# SDK header directories discovered from the SDK source paths (computed once).
+INCLUDES_PATH_SDK_BASE += $(dir $(foreach libdir, $(SDK_SOURCE_PATH) $(NBGL_INCLUDE_PATH), $(dir $(shell find $(BOLOS_SDK)/$(libdir) -name '*.h')))) $(BOLOS_SDK)/include $(BOLOS_SDK)/include/arm
+
+# App header directories. RECURSIVELY expanded (=) on purpose: app Makefiles may add
+# include dirs (INCLUDES_PATH += ...) or extra sources (APP_SOURCE_PATH += ..., which
+# feeds INCLUDES_APP) AFTER this file is included; lazy expansion captures them at
+# build time. $(GLYPH_SRC_DIR) holds the generated glyphs.h.
+INCLUDES_PATH_APP_DIRS = $(INCLUDES_PATH) include $(dir $(INCLUDES_APP)) $(GLYPH_SRC_DIR)
+
+# Final include paths: same set of directories, but in opposite priority order, so
+# that the command-line search order is correct for each kind of source.
+#  - SDK sources: SDK headers FIRST (an app header can never shadow an SDK one); app
+#    dirs kept only as a fallback, needed e.g. for the generated glyphs.h included by
+#    SDK NBGL sources, or for headers force-included via 'CFLAGS += -include ...'.
+#  - APP sources: app headers FIRST, SDK headers as fallback.
+INCLUDES_PATH_SDK = $(call uniq, $(INCLUDES_PATH_SDK_BASE) $(INCLUDES_PATH_APP_DIRS))
+INCLUDES_PATH_APP = $(call uniq, $(INCLUDES_PATH_APP_DIRS) $(INCLUDES_PATH_SDK_BASE))
 
 # Separate object files from SDK and APP to avoid name conflicts
 OBJECTS_SDK += $(sort $(subst $(BOLOS_SDK), $(OBJ_DIR)/sdk, $(addsuffix .o, $(basename $(SOURCES_SDK)))))

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -96,15 +96,24 @@ SOURCES_APP += $(filter-out %.pb.c, $(abspath \
 SOURCES_GEN += $(GLYPH_DESTC) $(APP_SOURCE_GEN)
 VPATH += $(call uniq, $(dir $(SOURCES_SDK) $(SOURCES_APP) $(GLYPH_DESTC)))
 
-# Retrieve APP header filenames
-HEADERS_APP += $(shell find $(APP_SOURCE_PATH) -name '*.h')
+# Retrieve APP header filenames. Memoized: on first use (build time, after parsing, so
+# late APP_SOURCE_PATH additions are captured) the find runs once and the result is
+# reused, instead of re-scanning the app source tree for every object compiled.
+# (HEADERS_APP is never expanded during parsing, so the memoization can't freeze early.)
+HEADERS_APP = $(eval HEADERS_APP := $(shell find $(APP_SOURCE_PATH) -name '*.h'))$(HEADERS_APP)
 
-# SDK header directories discovered from the SDK source paths (computed once).
-# For each SDK lib, $(dir ...) of the headers found gives the directories holding them.
-INCLUDES_PATH_SDK_BASE += \
+# SDK header directories discovered from the SDK source paths.
+# Frozen with := so the (expensive) find over the SDK tree runs ONCE: the SDK source
+# paths are fixed at this point, so the result is computed here and reused. The app
+# include list below stays lazy to still capture late APP_SOURCE_PATH/INCLUDES_PATH
+# additions. For each SDK lib, $(dir ...) of the headers found gives their directories.
+# $(GLYPH_SRC_DIR) holds the generated glyphs.h: a build artifact (not an app source
+# header) included by SDK NBGL/UX sources, so it belongs to the SDK set.
+INCLUDES_PATH_SDK_BASE := $(INCLUDES_PATH_SDK_BASE) \
     $(foreach libdir, $(SDK_SOURCE_PATH) $(SDK_HEADER_PATH), $(dir $(shell find $(BOLOS_SDK)/$(libdir) -name '*.h'))) \
     $(BOLOS_SDK)/include \
-    $(BOLOS_SDK)/include/arm
+    $(BOLOS_SDK)/include/arm \
+    $(GLYPH_SRC_DIR)
 
 # App header directories. RECURSIVELY expanded (=) on purpose: app Makefiles may add
 # include dirs (INCLUDES_PATH += ...) or extra sources (APP_SOURCE_PATH += ..., which
@@ -116,14 +125,16 @@ INCLUDES_PATH_APP_BASE = \
     $(dir $(HEADERS_APP)) \
     $(GLYPH_SRC_DIR)
 
-# Final include paths: same set of directories, but in opposite priority order, so
-# that the command-line search order is correct for each kind of source.
-#  - SDK sources: SDK headers FIRST (an app header can never shadow an SDK one); app
-#    dirs kept only as a fallback, needed e.g. for the generated glyphs.h included by
-#    SDK NBGL sources, or for headers force-included via 'CFLAGS += -include ...'.
+# Final include paths.
+#  - SDK sources: SDK headers ONLY (incl. the generated glyphs.h). App header
+#    directories are intentionally NOT exposed, so the SDK builds independently of the
+#    app. Apps must therefore not rely on app headers being visible to SDK sources
+#    (e.g. no 'CFLAGS += -include <app_header>' resolved through the include path).
 #  - APP sources: app headers FIRST, SDK headers as fallback.
-INCLUDES_PATH_SDK = $(call uniq, $(INCLUDES_PATH_SDK_BASE) $(INCLUDES_PATH_APP_BASE))
-INCLUDES_PATH_APP = $(call uniq, $(INCLUDES_PATH_APP_BASE) $(INCLUDES_PATH_SDK_BASE))
+# INCLUDES_PATH_SDK is frozen (:=) since INCLUDES_PATH_SDK_BASE is; INCLUDES_PATH_APP
+# stays lazy (=) to capture late app additions, while reusing the frozen SDK list.
+INCLUDES_PATH_SDK := $(call uniq, $(INCLUDES_PATH_SDK_BASE))
+INCLUDES_PATH_APP  = $(call uniq, $(INCLUDES_PATH_APP_BASE) $(INCLUDES_PATH_SDK_BASE))
 
 # Separate object files from SDK and APP to avoid name conflicts
 OBJECTS_SDK += $(sort $(subst $(BOLOS_SDK), $(OBJ_DIR)/sdk, $(addsuffix .o, $(basename $(SOURCES_SDK)))))

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -88,46 +88,46 @@ default: $(BIN_TARGETS) $(DBG_TARGETS)
 # Glyphs target
 $(GEN_SRC_DIR)/%.o: $(GEN_SRC_DIR)/%.c $(BUILD_DEPENDENCIES) prepare
 	@echo "[CC]   $@"
-	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
+	$(L)$(call cc_cmdline,$(INCLUDES_PATH_APP), $(DEFINES),$<,$@)
 
 # App files targets
 $(OBJ_DIR)/app/%.o: $(APP_DIR)/%.c $(BUILD_DEPENDENCIES) prepare
 	@echo "[CC]   $@"
-	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
+	$(L)$(call cc_cmdline,$(INCLUDES_PATH_APP), $(DEFINES),$<,$@)
 
 $(OBJ_DIR)/app/%.o: $(APP_DIR)/%.s $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
-	$(L)$(call as_cmdline,$(INCLUDES_PATH),$<,$@)
+	$(L)$(call as_cmdline,$(INCLUDES_PATH_APP),$<,$@)
 
 $(OBJ_DIR)/app/%.o: $(APP_DIR)/%.S $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
-	$(L)$(call as_cmdline,$(INCLUDES_PATH),$<,$@)
+	$(L)$(call as_cmdline,$(INCLUDES_PATH_APP),$<,$@)
 
 # SDK files targets
 $(OBJ_DIR)/sdk/%.o: $(BOLOS_SDK)/%.c $(BUILD_DEPENDENCIES) prepare
 	@echo "[CC]   $@"
-	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
+	$(L)$(call cc_cmdline,$(INCLUDES_PATH_SDK), $(DEFINES),$<,$@)
 
 $(OBJ_DIR)/sdk/%.o: $(BOLOS_SDK)/%.s $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
-	$(L)$(call as_cmdline,$(INCLUDES_PATH),$<,$@)
+	$(L)$(call as_cmdline,$(INCLUDES_PATH_SDK),$<,$@)
 
 $(OBJ_DIR)/sdk/%.o: $(BOLOS_SDK)/%.S $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
-	$(L)$(call as_cmdline,$(INCLUDES_PATH),$<,$@)
+	$(L)$(call as_cmdline,$(INCLUDES_PATH_SDK),$<,$@)
 
 # Generic targets
 $(OBJ_DIR)/%.o: %.c $(BUILD_DEPENDENCIES) prepare
 	@echo "[CC]   $@"
-	$(L)$(call cc_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@)
+	$(L)$(call cc_cmdline,$(INCLUDES_PATH_APP), $(DEFINES),$<,$@)
 
 $(OBJ_DIR)/%.o: %.s $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
-	$(L)$(call as_cmdline,$(INCLUDES_PATH),$<,$@)
+	$(L)$(call as_cmdline,$(INCLUDES_PATH_APP),$<,$@)
 
 $(OBJ_DIR)/%.o: %.S $(BUILD_DEPENDENCIES) prepare
 	@echo "[AS]   $@"
-	$(L)$(call as_cmdline,$(INCLUDES_PATH),$<,$@)
+	$(L)$(call as_cmdline,$(INCLUDES_PATH_APP),$<,$@)
 
 ifeq (,$(filter $(DEFINES),BOLOS_OS_UPGRADER_APP))
 ifneq ($(SCRIPT_LD),)


### PR DESCRIPTION
## Description

Prioritize the header path during build to ensure:
1. Build the SDK sources using only the SDK headers
2. Build the App sources using:
  a. The App headers
  b. The SDK headers

Tested with app-boilerplate, lookiging at the verbose output:

SDK file `lib_nbgl/src/nbgl_use_case.c`:
```
-I/flex_sdk
-I/flex_sdk/lib_cxng/include
-I/flex_sdk/lib_blewbxx/include/
-I/flex_sdk/lib_tlv/
-I/flex_sdk/lib_tlv/use_cases/
-I/flex_sdk/lib_pki/
-I/flex_sdk/qrcode/include/
-I/flex_sdk/io/include/
-I/flex_sdk/protocol/include/
-I/flex_sdk/lib_stusb/include/
-I/flex_sdk/lib_stusb_impl/include/
-I/flex_sdk/lib_u2f/include/
-I/flex_sdk/lib_standard_app/
-I/flex_sdk/lib_ux_nbgl/
-I/flex_sdk/io_legacy/include/
-I/flex_sdk/lib_u2f_legacy/include/
-I/flex_sdk/target/flex/include/
-I/flex_sdk/lib_nbgl/src/
-I/flex_sdk/lib_nbgl/include/
-I/flex_sdk/include
-I/flex_sdk/include/arm
-Ibuild/flex/gen_src
```

App file `src/address.c`:
```
-Iinclude
-Isrc/handler/
-Isrc/helper/
-Isrc/apdu/
-Isrc/
-Isrc/swap/
-Isrc/ui/
-Isrc/ui/action/
-Isrc/token/
-Isrc/transaction/
-Ibuild/flex/gen_src

-I/flex_sdk
-I/flex_sdk/lib_cxng/include
-I/flex_sdk/lib_blewbxx/include/
-I/flex_sdk/lib_tlv/
-I/flex_sdk/lib_tlv/use_cases/
-I/flex_sdk/lib_pki/
-I/flex_sdk/qrcode/include/
-I/flex_sdk/io/include/
-I/flex_sdk/protocol/include/
-I/flex_sdk/lib_stusb/include/
-I/flex_sdk/lib_stusb_impl/include/
-I/flex_sdk/lib_u2f/include/
-I/flex_sdk/lib_standard_app/
-I/flex_sdk/lib_ux_nbgl/
-I/flex_sdk/io_legacy/include/
-I/flex_sdk/lib_u2f_legacy/include/
-I/flex_sdk/target/flex/include/
-I/flex_sdk/lib_nbgl/src/
-I/flex_sdk/lib_nbgl/include/
-I/flex_sdk/include
-I/flex_sdk/include/arm
```

Validé avec `ledger-app-tester` sur cette PR de test: https://github.com/LedgerHQ/ledger-app-tester/pull/155


## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26