### PR TITLE
Introduce `os_identity.h`

### DIFF
--- a/include/os_identity.h
+++ b/include/os_identity.h
@@ -1,0 +1,37 @@
+/**
+ * @file os_endorsement.h
+ * @brief Header file containing all prototypes related to endorsement feature
+ */
+
+#pragma once
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include <stdint.h>
+#include <stddef.h>
+#include "decorators.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * @brief Log out the device from the current identity.
+ *
+ * Once this function is called, the seed cannot be accessed anymore, until the the device is logged
+ * in with `os_global_pin_check`.
+ */
+SYSCALL PERMISSION(APPLICATION_FLAG_GLOBAL_PIN) void sys_identity_log_out(void);
+
+/**********************
+ *      MACROS
+ **********************/

--- a/include/os_pin.h
+++ b/include/os_pin.h
@@ -4,6 +4,7 @@
 #include "bolos_target.h"
 #include "decorators.h"
 #include "os_types.h"
+#include "os_identity.h"
 
 /* ----------------------------------------------------------------------- */
 /* -                             PIN FEATURE                             - */
@@ -16,6 +17,7 @@
  * @return BOLOS_UX_OK if pin validated
  */
 SYSCALL bolos_bool_t os_global_pin_is_validated(void);
+
 /**
  * Validating the pin also setup the identity linked with this pin (normal or alternate)
  * @return BOLOS_UX_OK if pin validated
@@ -23,14 +25,19 @@ SYSCALL bolos_bool_t os_global_pin_is_validated(void);
 SYSCALL      PERMISSION(APPLICATION_FLAG_GLOBAL_PIN)
 bolos_bool_t os_global_pin_check(unsigned char *pin_buffer PLENGTH(pin_length),
                                  unsigned char             pin_length);
-SYSCALL      PERMISSION(APPLICATION_FLAG_GLOBAL_PIN) void os_global_pin_invalidate(void);
+
+/**
+ * @brief Return the number of pin retries for the current identity.
+ */
 SYSCALL      PERMISSION(APPLICATION_FLAG_GLOBAL_PIN)
 unsigned int os_global_pin_retries(void);
 
 /**
- * This function checks whether a PIN is present
- * @return BOLOS_TRUE if the CRC of N_secure_element_nvram_user_sensitive_data
- * is correct and if a PIN value has been written
+ * @brief Check if main identity pin has been set.
+ *
+ * @return bolos_bool_t
+ * @retval BOLOS_TRUE Main identity pin is set
+ * @retval BOLOS_FALSE Main identity pin is not set
  */
 SYSCALL
 bolos_bool_t os_perso_is_pin_set(void);

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -161,7 +161,6 @@
 #define SYSCALL_RESERVED_16_ID                             0x0200004d
 #define SYSCALL_os_global_pin_is_validated_ID              0x000000a0
 #define SYSCALL_os_global_pin_check_ID                     0x020000a1
-#define SYSCALL_os_global_pin_invalidate_ID                0x0000005d
 #define SYSCALL_os_global_pin_retries_ID                   0x0000005e
 #define SYSCALL_RESERVED_3_ID                              0x0000005f
 #define SYSCALL_RESERVED_4_ID                              0x02000122
@@ -224,6 +223,11 @@
 #define SYSCALL_RESERVED_2_ID               0x010001ED
 #define SYSCALL_RESERVED_1_ID               0x010001EE
 #define SYSCALL_ENDORSEMENT_GET_METADATA_ID 0x02000138
+
+#define SYSCALL_RESERVED_38_ID   0x02000300
+#define SYSCALL_RESERVED_39_ID   0x02000301
+#define SYSCALL_RESERVED_40_ID   0x04000302
+#define SYSCALL_IDENTITY_LOG_OUT 0x00000303
 
 #if defined(HAVE_VAULT_RECOVERY_ALGO)
 #define SYSCALL_RESERVED_17_ID 0x02000137

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1363,6 +1363,12 @@ bolos_err_t sys_endorsement_get_metadata(ENDORSEMENT_slot_t slot,
     return (bolos_err_t) SVC_Call(SYSCALL_ENDORSEMENT_GET_METADATA_ID, parameters);
 }
 
+void sys_identity_log_out(void)
+{
+    uint32_t parameters = 0;
+    SVC_Call(SYSCALL_IDENTITY_LOG_OUT, &parameters);
+}
+
 bolos_bool_t os_perso_is_pin_set(void)
 {
     unsigned int parameters[2];
@@ -1383,14 +1389,6 @@ bolos_bool_t os_global_pin_check(unsigned char *pin_buffer, unsigned char pin_le
     parameters[0] = (unsigned int) pin_buffer;
     parameters[1] = (unsigned int) pin_length;
     return (bolos_bool_t) SVC_Call(SYSCALL_os_global_pin_check_ID, parameters);
-}
-
-void os_global_pin_invalidate(void)
-{
-    unsigned int parameters[2];
-    parameters[1] = 0;
-    SVC_Call(SYSCALL_os_global_pin_invalidate_ID, parameters);
-    return;
 }
 
 unsigned int os_global_pin_retries(void)


### PR DESCRIPTION
`os_identity.h` will contains the function accessible from the apps,
to interact with the user pin.

- Introduce `sys_identity_log_out`
- Deprecate `os_global_pin_invalidate`

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

New syscall, replacing `os_global_pin_invalidate`
