### PR TITLE
Remove dead ST31 code and refactor ST31/ST33 defines

### DIFF
--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -10,7 +10,7 @@ typedef unsigned short exception_t;
 
 typedef struct try_context_s try_context_t;
 
-#if (defined(ST31) || defined(ST33) || defined(ST33K1M5)) && defined(__arm__)
+#if defined(__arm__)
 // #include <setjmp.h>
 //  GCC/LLVM declare way too big jmp context, reduce them to what is used on CM0+
 
@@ -19,7 +19,6 @@ typedef struct try_context_s try_context_t;
 typedef unsigned int jmp_buf[10];
 
 // borrowed from setjmp.h
-
 #ifdef __GNUC__
 void longjmp(jmp_buf __jmpb, int __retval) __attribute__((__noreturn__));
 #else

--- a/lib_cxng/src/cx_selftests.c
+++ b/lib_cxng/src/cx_selftests.c
@@ -95,10 +95,6 @@ void cx_printa(char *prefix, const unsigned char *r, unsigned short len)
     cx_printf(("\n"));
 }
 
-#ifdef ST31
-#include "product.h"
-#endif
-
 int cx_st_onefail(void)
 {
     volatile int i = 1;  // avoid inline

--- a/lib_cxng/src/cx_utils.c
+++ b/lib_cxng/src/cx_utils.c
@@ -47,17 +47,7 @@ uint32_t cx_swap_uint32(uint32_t v)
 void cx_swap_buffer32(uint32_t *v, size_t len)
 {
     while (len--) {
-#ifdef ST31
-        unsigned int tmp;
-        tmp                                = ((unsigned char *) v)[len * 4 + 3];
-        ((unsigned char *) v)[len * 4 + 3] = ((unsigned char *) v)[len * 4];
-        ((unsigned char *) v)[len * 4]     = tmp;
-        tmp                                = ((unsigned char *) v)[len * 4 + 2];
-        ((unsigned char *) v)[len * 4 + 2] = ((unsigned char *) v)[len * 4 + 1];
-        ((unsigned char *) v)[len * 4 + 1] = tmp;
-#else
         v[len] = cx_swap_uint32(v[len]);
-#endif
     }
 }
 

--- a/src/pic.c
+++ b/src/pic.c
@@ -24,20 +24,6 @@ extern void _nvram;
 extern void _envram;
 #endif  // !defined(HAVE_BOLOS) || defined(BOLOS_OS_UPGRADER_APP)
 
-#if defined(ST31)
-
-void *pic(void *link_address)
-{
-    // check if in the LINKED TEXT zone
-    if (link_address >= &_nvram && link_address < &_envram) {
-        link_address = pic_internal(link_address);
-    }
-
-    return link_address;
-}
-
-#elif defined(ST33) || defined(ST33K1M5)
-
 #if !defined(HAVE_BOLOS) || defined(BOLOS_OS_UPGRADER_APP)
 extern void _bss;
 extern void _estack;
@@ -124,9 +110,3 @@ void pic_init(void *real_flash_start, void *real_ram_start)
 }
 
 #endif  // !defined(HAVE_BOLOS) || defined(BOLOS_OS_UPGRADER_APP)
-
-#else
-
-#error "invalid architecture"
-
-#endif


### PR DESCRIPTION
## Description

Cleanup ST arch `#ifdefs` and remove dead ST31-specific code

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[ ] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
