### PR TITLE
Ensure __stack_chk_guard remains the very first symbol in .bss

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -155,6 +155,15 @@ LINK_DEPENDENCIES += $(APP_CUSTOM_LINK_DEPENDENCIES)
 $(BIN_DIR)/app.elf: $(LINK_DEPENDENCIES)
 	@echo "[LINK] $(BIN_DIR)/app.elf"
 	$(L)$(call link_cmdline,$(OBJECT_FILES) $(LDLIBS),$(BIN_DIR)/app.elf)
+ifneq ($(ENABLE_STACK_PROTECTOR),0)
+	@# Ensure __stack_chk_guard remains the very first symbol in .bss.
+	@BSS=$$(llvm-nm $(BIN_DIR)/app.elf | grep ' _bss$$' | cut -d' ' -f1); \
+	GUARD=$$(llvm-nm $(BIN_DIR)/app.elf | grep ' __stack_chk_guard$$' | cut -d' ' -f1); \
+	if [ -z "$$GUARD" ] || [ "$$GUARD" != "$$BSS" ]; then \
+		echo "[ERROR] __stack_chk_guard ($$GUARD) must be the first symbol in .bss ($$BSS)"; \
+		exit 1; \
+	fi
+endif
 	$(L)llvm-objcopy -O ihex -S $(BIN_DIR)/app.elf $(BIN_DIR)/app.hex
 	$(L)llvm-objdump -S -d $(BIN_DIR)/app.elf > $(DBG_DIR)/app.asm
 


### PR DESCRIPTION
## Description

Alternative implementation for https://github.com/LedgerHQ/ledger-secure-sdk/pull/1600.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category) - just an additional assurance 

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
