### PR TITLE
Security audit and bug fixes for lib_nbgl

### DIFF
--- a/lib_nbgl/doc/nbgl_layout.dox
+++ b/lib_nbgl/doc/nbgl_layout.dox
@@ -156,6 +156,58 @@ A thin vertical separation is drawn between both text areas.
 
 \warning This object is incompatible with navigation bar or bottom button, for example
 
+@subsection extended_footer Extended footer
+
+This object is a richly-configurable footer placed at the very bottom of the screen, outside the main container.
+It is a superset of @ref nbgl_layoutAddFooter() and @ref nbgl_layoutAddSplitFooter() and covers all @ref nbgl_layoutFooterType_t variants:
+
+- @ref FOOTER_EMPTY: empty space (for better vertical centering of the main content)
+- @ref FOOTER_SIMPLE_TEXT: a single touchable bold text, optionally grayed-out
+- @ref FOOTER_DOUBLE_TEXT: two horizontally-adjacent touchable texts separated by a vertical line
+- @ref FOOTER_TEXT_AND_NAV: a touchable text on the left with a navigation bar on the right
+- @ref FOOTER_NAV: a full navigation bar (see also @ref nbgl_layoutAddNavigationBar())
+- @ref FOOTER_SIMPLE_BUTTON: a single rounded button (black or white, see @ref nbgl_layoutButtonStyle_t)
+- @ref FOOTER_CHOICE_BUTTONS: a pair of stacked choice buttons (same as @ref nbgl_layoutAddChoiceButtons())
+
+The API to insert such an object is @ref nbgl_layoutAddExtendedFooter(), using @ref nbgl_layoutFooter_t structure.
+
+A thin horizontal separation line can optionally be added on top by setting the \b separationLine field to true.
+
+\warning This object is incompatible with navigation bar or bottom button.
+
+@subsection up_footer Up-footer area
+
+This object places a control area immediately above the footer (or above the bottom of the main container when no footer is present).
+It is not part of the main container. It covers all @ref nbgl_layoutUpFooterType_t variants:
+
+- @ref UP_FOOTER_LONG_PRESS: a long-press button (equivalent to @ref nbgl_layoutAddLongPressButton())
+- @ref UP_FOOTER_BUTTON: a single rounded button
+- @ref UP_FOOTER_HORIZONTAL_BUTTONS: a pair of horizontal buttons (equivalent to @ref nbgl_layoutAddHorizontalButtons())
+- @ref UP_FOOTER_TIP_BOX: a tip-box information area
+- @ref UP_FOOTER_TEXT: a grayed-out touchable text (e.g. "Tap to continue")
+
+The API to insert such an object is @ref nbgl_layoutAddUpFooter(), using @ref nbgl_layoutUpFooter_t structure.
+
+@subsection navigation_bar Navigation bar
+
+This object places a classic bottom navigation bar at the very bottom of the screen, outside the main container.
+It provides optional back and forward arrow buttons as well as an optional exit key. It is a convenience wrapper
+around @ref nbgl_layoutAddExtendedFooter() with type @ref FOOTER_NAV, and is the lower-level alternative to the navigation embedded in @ref nbgl_layoutAddExtendedFooter().
+
+The parameters of @ref nbgl_layoutNavigationBar_t include:
+
+- \b nbPages: total number of pages (if 0, no page indicator)
+- \b activePage: index of the currently active page (from 0 to nbPages-1)
+- \b withExitKey: if true, an exit (X) button is drawn on the left
+- \b withBackKey: if true, a back arrow button is drawn
+- \b withSeparationLine: if true, a horizontal line is drawn on top of the bar
+- \b token: token passed to the action callback when a navigation key is pressed; for the exit key, \b index is @ref EXIT_PAGE
+- \b tuneId: optional tune to play on key press
+
+The API to insert such an object is @ref nbgl_layoutAddNavigationBar(), using @ref nbgl_layoutNavigationBar_t structure.
+
+\warning This object is incompatible with footer or bottom button.
+
 @subsection centered_info Centered info area
 
 \image{inline} html stax_layout1.png "caption" height=300
@@ -176,6 +228,37 @@ The colors and fonts for the texts depends of the \b style field used in @ref nb
 
 - if @ref LARGE_CASE_INFO, main text is in @ref BLACK and large case (INTER 32px), subText in @ref BLACK in INTER 24px
 - if @ref NORMAL_INFO, icon in black and main text in INTER 24px in @ref BLACK under it, subText in INTER 24px in @ref DARK_GRAY under it
+
+@subsection content_center Centered content area
+
+This object is a richer alternative to the @ref centered_info area. It uses the @ref nbgl_contentCenter_t structure and supports
+more illustration types (icon, image, Lottie animation) as well as an optional small title, a description text, and a sub-text.
+
+The fields of @ref nbgl_contentCenter_t include:
+
+- \b illustrType: the type of illustration (icon, image…)
+- \b icon or \b image pointer, depending on \b illustrType
+- \b title: main text in large bold font (optional)
+- \b smallTitle: secondary title text in smaller bold font (optional)
+- \b description: description text in regular font (optional)
+- \b subText: sub-description in gray (optional)
+
+The whole object is centered horizontally in the page.
+
+The API to insert such an object is @ref nbgl_layoutAddContentCenter(), using @ref nbgl_contentCenter_t structure.
+
+@subsection left_content Left-aligned content area
+
+This object displays a bold title followed by a list of rows, each row made of an icon and a text, all left-aligned.
+
+The fields of @ref nbgl_layoutLeftContent_t include:
+
+- \b title: bold title drawn above the rows
+- \b nbRows: number of rows
+- \b rowTexts: array of \b nbRows text strings (displayed in regular font)
+- \b rowIcons: array of \b nbRows icon pointers
+
+The API to insert such an object is @ref nbgl_layoutAddLeftContent(), using @ref nbgl_layoutLeftContent_t structure.
 
 @subsection choice_buttons Choice buttons
 
@@ -201,7 +284,8 @@ The API to insert such an object is @ref nbgl_layoutAddChoiceButtons(), with @re
 
 This object is made of a single button, in @ref BLACK. The text and optional icon are in @ref WHITE
 
-This button occupies the full width of the screen, except if \b fittingContent field of @ref nbgl_layoutButton_t is true, and is put at the bottom of the main container, on top of a potential navigation bar or bottom button.
+This button occupies the full width of the screen, except if \b fittingContent field of @ref nbgl_layoutButton_t is true,
+and is put at the bottom of the main container, on top of a potential navigation bar or bottom button.
 
 The API to insert such an object is @ref nbgl_layoutAddButton(), with @ref nbgl_layoutButton_t structure.
 
@@ -217,6 +301,21 @@ and the action callback is called with the given \b token.
 This button occupies the full width of the screen and is put at the bottom of the main container, on top of a potential navigation bar or bottom button.
 
 The API to insert such an object is @ref nbgl_layoutAddLongPressButton(), with the button text and token as parameters.
+
+@subsection horizontal_buttons Horizontal buttons pair
+
+This object places a small round icon-only button on the left and a full text button on the right, both on the same horizontal line.
+It is implemented internally via @ref nbgl_layoutAddUpFooter() with type @ref UP_FOOTER_HORIZONTAL_BUTTONS.
+
+The fields of @ref nbgl_layoutHorizontalButtons_t include:
+
+- \b leftIcon: 1BPP icon for the left round button
+- \b leftToken: token reported when the left button is pressed
+- \b rightText: text of the right button
+- \b rightToken: token reported when the right button is pressed
+- \b tuneId: optional tune to play on press
+
+The API to insert such an object is @ref nbgl_layoutAddHorizontalButtons(), using @ref nbgl_layoutHorizontalButtons_t structure.
 
 @subsection item_values Tag/value list
 
@@ -242,6 +341,49 @@ fitting length)
 This area is displayed in the main container, under the previously inserted complex object.
 
 The API to insert such an object is @ref nbgl_layoutAddTagValueList(), with @ref nbgl_layoutTagValueList_t structure
+
+@subsection text_block Text block
+
+This object adds a text area with an optional sub-text below it. Both texts are left-aligned and auto-wrap.
+The main text uses a small bold font; the sub-text uses a small regular font.
+
+The API to insert such an object is @ref nbgl_layoutAddText(), which takes the main \b text and an optional \b subText as parameters.
+
+@subsection text_with_alias Touchable text block with alias
+
+This object is similar to the @ref text_block but adds a small chevron icon (>) on the right of the main text, making the entire row touchable.
+When touched, the provided \b token is reported to the action callback together with the given \b index.
+
+The API to insert such an object is @ref nbgl_layoutAddTextWithAlias().
+
+@subsection large_case_text Large-case text
+
+This object adds a single multi-line text displayed in a large (32 px) font, left-aligned and auto-wrapping.
+The text is rendered in @ref BLACK by default; if the \b grayedOut parameter is true, it is rendered in light gray instead.
+
+The API to insert such an object is @ref nbgl_layoutAddLargeCaseText().
+
+@subsection text_content Composite text content
+
+This object adds a composite block that can contain up to three layers of text, all left-aligned:
+
+- A bold title in a large font (optional)
+- Up to @ref NB_MAX_DESCRIPTIONS description paragraphs in a small regular font (optional)
+- An info text in gray anchored to the bottom of the container (optional)
+
+The fields of @ref nbgl_layoutTextContent_t include:
+
+- \b title: main bold large-font text
+- \b nbDescriptions / \b descriptions: array of regular-font description paragraphs
+- \b info: gray informational text placed at the bottom
+
+The API to insert such an object is @ref nbgl_layoutAddTextContent(), using @ref nbgl_layoutTextContent_t structure.
+
+@subsection separation_line Horizontal separation line
+
+This object adds a thin horizontal line directly below the previously inserted object in the main container. It can be used to visually separate groups of items.
+
+The API to insert such an object is @ref nbgl_layoutAddSeparationLine().
 
 @subsection touchable_bar Touchable bar
 
@@ -278,7 +420,8 @@ This object is made of:
 
 This area is displayed in the main container, under the previously inserted complex object.
 
-When touched, if not inactivated, the \b token provided in @ref nbgl_layoutSwitch_t is used with the action callback. \b index parameter meaning is 0 for inactive, 1 for active.
+When touched, if not inactivated, the \b token provided in @ref nbgl_layoutSwitch_t is used with the action callback.
+\b index parameter meaning is 0 for inactive, 1 for active.
 
 The API to insert such an object is @ref nbgl_layoutAddSwitch(), with @ref nbgl_layoutSwitch_t structure
 
@@ -314,6 +457,10 @@ The API to insert such an object is @ref nbgl_layoutAddSpinner().
 
 \warning No other object shall be inserted beside this one.
 
+@note Once a spinner layout has been drawn, the spinner position and texts can be updated in-place (without a full redraw)
+using @ref nbgl_layoutUpdateSpinner(). Pass the new \b position, \b text and optional \b subText.
+The function returns 0 if nothing changed, 1 if a partial black-and-white refresh is needed, or 2 if a partial color refresh is needed.
+
 @subsection progress_indicator Progress indicator
 
 \image{inline} html layout5.png "caption" height=300
@@ -336,6 +483,19 @@ The API to insert such an object is @ref nbgl_layoutAddProgressIndicator().
 \warning This object is incompatible with top-right button and page selector.
 \warning This object is deprecated.
 
+@subsection progress_bar Progress bar
+
+This object adds a centered progress bar with a percentage completion, a title text above it, and an optional sub-text below it.
+It is distinct from the deprecated @ref progress_indicator.
+
+The parameters of @ref nbgl_layoutAddProgressBar() are:
+
+- \b percentage: completion level from 0 to 100
+- \b text: title text displayed in large bold font, centered above the bar
+- \b subText: optional description in small regular font, centered below the bar (can be NULL)
+
+The API to insert such an object is @ref nbgl_layoutAddProgressBar().
+
 @subsection qr_code QR Code
 
 \image{inline} html stax_layout13.png "caption" height=300
@@ -351,6 +511,28 @@ The parameters to build this object are:
 The API to insert such an object is @ref nbgl_layoutAddQRCode(), with @ref nbgl_layoutQRCode_t structure as parameter.
 
 \warning This object is incompatible with top-right button and progress indicator.
+
+@subsection swipe Swipe gesture handler
+
+This object registers a swipe gesture on the main container. When the user swipes in one of the enabled directions
+(described by the \b swipesMask bitmask), the action callback is called with the given \b token.
+
+An optional gray label text can be displayed at the bottom of the container (e.g. "Swipe to continue") by providing a non-NULL \b text parameter.
+
+The parameters of @ref nbgl_layoutAddSwipe() are:
+
+- \b swipesMask: bitmask of swipe directions to handle
+- \b text: optional gray text drawn at the bottom of the container (can be NULL)
+- \b token: token passed to the action callback when a swipe is detected
+- \b tuneId: optional tune to play when a swipe is detected
+
+The API to register such a gesture is @ref nbgl_layoutAddSwipe().
+
+@subsection invert_background Background color inversion
+
+This utility inverts the page background from white to black (dark mode). Any "Tap to continue" text in the up-footer area is also adjusted for contrast.
+
+The API to apply this inversion is @ref nbgl_layoutInvertBackground().
 
 @subsection keyboard_section Keyboard-related objects
 
@@ -388,6 +570,9 @@ used to modify the mask of an existing keyboard.
 - If mask[1] bit is 1, the 'w' key is invalid
 - And so on in "qwertyuiopasdfghjklzxcvbnm" string.
 - "space" key has index 29.
+
+@note After calling @ref nbgl_layoutUpdateKeyboard() with a new key mask, use @ref nbgl_layoutKeyboardNeedsRefresh()
+to query whether the keyboard widget has actually been redrawn and therefore requires a screen refresh. It returns true if a refresh is needed (and clears the internal flag).
 
 @subsubsection keyboard_sub_section_2 Adding/Updating Keyboard Content
 
@@ -480,7 +665,7 @@ static void keyboardCallback(char touchedKey) {
     textToEnter[textLen-1] = '\0';
   }
   // be sure to redraw the text
-  nbgl_layoutUpdateKeyboardContent(layout,textIndex,false,0,textToEnter,false);
+  nbgl_layoutUpdateKeyboardContent(layout, &kbdContent);
 }
 
 void app_keyboard(void) {
@@ -557,7 +742,7 @@ static void layoutTouchCallback(int token, uint8_t index) {
   else if (token == KBD_TEXT_TOKEN) {
     // Delete entered text
     textToEnter[0] = '\0';
-    nbgl_layoutKbdContent_t kbdContent = {
+    nbgl_layoutKeyboardContent_t kbdContent = {
       .title                              = headerText,
       .type                               = KEYBOARD_WITH_SUGGESTIONS,
       .numbered                           = true,
@@ -571,7 +756,7 @@ static void layoutTouchCallback(int token, uint8_t index) {
       .suggestionButtons.nbUsedButtons    = 0
     };
     // update keyboard content
-    nbgl_layoutUpdateKeyboardContent(&kbdContent);
+    nbgl_layoutUpdateKeyboardContent(layout, &kbdContent);
 
     // and refresh screen
     nbgl_refresh();
@@ -588,7 +773,7 @@ static void layoutTouchCallback(int token, uint8_t index) {
 
 // function called when a key of keyboard is touched
 static void keyboardCallback(char touchedKey) {
-  nbgl_layoutKbdContent_t kbdContent = {
+  nbgl_layoutKeyboardContent_t kbdContent = {
     .title                              = headerText,
     .type                               = KEYBOARD_WITH_SUGGESTIONS,
     .numbered                           = true,
@@ -617,7 +802,7 @@ static void keyboardCallback(char touchedKey) {
     // remove any suggestion buttons because empty string
     bdContent.suggestionButtons.nbUsedButtons    = 0;
     // clear keyboard mask
-    nbgl_layoutUpdateKeyboard(layout,keyboardIndex, 0x0, LOWER_CASE);
+    nbgl_layoutUpdateKeyboard(layout, keyboardIndex, 0x0, false, LOWER_CASE);
   }
   else {
     // find up to NB_MAX_SUGGESTION_BUTTONS words beginning with textToEnter
@@ -627,7 +812,7 @@ static void keyboardCallback(char touchedKey) {
     // get keys to mask on keyboard for possible next letters
     uint32_t mask = getKeyboardMask(textToEnter);
     // use it for keyboard
-    nbgl_layoutUpdateKeyboard(layout,keyboardIndex, mask, LOWER_CASE);
+    nbgl_layoutUpdateKeyboard(layout, keyboardIndex, mask, false, LOWER_CASE);
   }
   // update keyboard content
   nbgl_layoutUpdateKeyboardContent(&kbdContent);
@@ -648,7 +833,7 @@ void app_keyboard(void) {
       .mode = MODE_LETTERS, // start in letters mode
       .upperCase = false    // start with lower case letters
     };
-    nbgl_layoutKbdContent_t kbdContent = {
+    nbgl_layoutKeyboardContent_t kbdContent = {
       .title                              = headerText,
       .type                               = KEYBOARD_WITH_SUGGESTIONS,
       .numbered                           = true,
@@ -708,6 +893,9 @@ The API to insert such an object is @ref nbgl_layoutAddKeypad().
 
 This function returns a positive integer (if successful) to be used as an index in @ref nbgl_layoutUpdateKeypad() function,
 used to modify the mask (active keys) of an existing keypad.
+
+@note To switch the keypad between a hard validation key (check icon) and a soft validation key (arrow icon),
+call @ref nbgl_layoutUpdateKeypadValidation() with \b softValidation set to true or false. This function updates the keypad widget without triggering a redraw.
 
 @subsubsection keypad_sub_section_2 Adding/Updating keypad content
 

--- a/lib_nbgl/doc/nbgl_page.dox
+++ b/lib_nbgl/doc/nbgl_page.dox
@@ -52,10 +52,11 @@ A few APIs are available to draw typical pages, like:
 - @ref nbgl_pageDrawInfo() to draw a centered info with potential footer (or bottom button), "tapable" container and top-right button
 - @ref nbgl_pageDrawConfirmation() to draw a typical confirmation screen, for example when rejecting a transaction (with 1 button for confirmation)
 
-In addition, in order to factorize some code, a generic function is available to draw generic content, either for a single page
+In addition, in order to factorize some code, generic functions are available to draw generic content, either for a single page
 or for a multi-pages configuration.
 
 - @ref nbgl_pageDrawGenericContent()
+- @ref nbgl_pageDrawGenericContentExt() when a modal display is needed
 
 @subsection page_typical_types Typical page types
 
@@ -177,6 +178,11 @@ The API to create such a page is @ref nbgl_pageDrawGenericContent().
 - The first parameter provides the action callback (for all controls)
 - The second one, if not NULL, provides the navigation parameters (see next chapter)
 - The last one provides the content of the page itself
+
+When the page must be displayed as a modal (on top of an existing page), use @ref nbgl_pageDrawGenericContentExt() instead.
+It accepts the same parameters as @ref nbgl_pageDrawGenericContent(), plus an additional \b modal boolean as the last argument.
+Setting \b modal to true causes the page to be rendered on top of the current screen rather than replacing it.
+Passing \b modal as false makes it behave identically to @ref nbgl_pageDrawGenericContent().
 
 @subsubsection page_generic_navigation Generic content page navigation
 

--- a/lib_nbgl/doc/nbgl_screens_objs.dox
+++ b/lib_nbgl/doc/nbgl_screens_objs.dox
@@ -5,7 +5,8 @@ This chapter describes briefly how \b NBGL manages the screens stack and the dyn
 
 @section nbgl_screens_mngt Screens stack management
 
-All windows are full screens, some of them are considered as modals when they are displayed on top of existing ones, catching all user events (on Touchscreen), and giving back the display (and the focus) once they are dismissed.
+All windows are full screens, some of them are considered as modals when they are displayed on top of existing ones,
+catching all user events (on Touchscreen), and giving back the display (and the focus) once they are dismissed.
 
 Let's take the simple example of pin-validation window, which is displayed automatically after a period of inactivity, when the wallet is locked:
 
@@ -17,7 +18,8 @@ That's why it is created in a separate layer, called *screen*.
 
 *Screens* are organized in a stack. The top of the stack is recovering the previous screen, which is recovering the previous one, and so on.
 
-Even if its size is static, the screens stack is considered as empty at start-up. Then most of windows (and even all of them for applications) are simply created in the background layer of the stack (index 0), by using @ref nbgl_screenSet() function.
+Even if its size is static, the screens stack is considered as empty at start-up. Then most of windows (and even all of them for applications)
+are simply created in the background layer of the stack (index 0), by using @ref nbgl_screenSet() function.
 
 When a modal window needs to be displayed, a new screen is pushed on the stack and graphical objects are attached to this new screen as its children (@ref nbgl_screenPush() function)
 

--- a/lib_nbgl/doc/nbgl_step.dox
+++ b/lib_nbgl/doc/nbgl_step.dox
@@ -38,6 +38,7 @@ A few APIs are available to draw typical pages, like:
 - @ref nbgl_stepDrawText() to draw a text and a sub-text on one or several lines/pages, with navigation
 - @ref nbgl_stepDrawCenteredInfo() to draw an icon, a text and a sub-text in a single page, with navigation
 - @ref nbgl_stepDrawMenuList() to draw a menu list, with navigation
+- @ref nbgl_stepDrawSwitch() to draw a toggle switch with its name and description, with navigation
 
 @subsection step_typical_types Typical step types
 
@@ -98,6 +99,26 @@ The API to insert such an object is @ref nbgl_stepDrawMenuList() with:
 - A potential ticker configuration.
 - The menu list description structure
 - The position of the step in a flow (see @subpage step_positioning)
+- A boolean to indicate whether this step is modal or not
+
+To retrieve the index of the item currently selected in a menu list step, use @ref nbgl_stepGetMenuListCurrent() with:
+
+- The step context returned by @ref nbgl_stepDrawMenuList()
+
+It returns the zero-based index of the currently highlighted menu entry.
+
+@subsubsection step_switch_type Switch Step
+
+This type is intended to draw a single toggle switch with its name and an optional description, in a single page, with navigation arrows.
+
+@note The switch name must fit on one line; the description may span at most two lines.
+
+The API to insert such an object is @ref nbgl_stepDrawSwitch() with:
+
+- The position of the step in a flow (see @subpage step_positioning)
+- A callback to handle the actions on buttons (left, right or both)
+- A potential ticker configuration.
+- A pointer to the switch description structure (@ref nbgl_layoutSwitch_t), containing the switch name, description and initial state
 - A boolean to indicate whether this step is modal or not
 
 @subsection step_release Releasing a step

--- a/lib_nbgl/doc/nbgl_use_case.dox
+++ b/lib_nbgl/doc/nbgl_use_case.dox
@@ -4,7 +4,8 @@
 @section nbgl_use_case_intro Introduction
 This chapter describes the Application Use-cases API of Advanced BOLOS Graphic Library.
 
-This layer offers a simplified view of some typical use-cases of display in an Application running on Stax.
+This layer offers a simplified view of some typical use-cases of display in an Application
+running on Stax.
 For example, a use-case can be:
 
 - Reviewing a transaction/message
@@ -15,51 +16,89 @@ A full description of each predefined use-case can be found in this document
 
 @section nbgl_use_case_concepts Concepts
 
-This layer uses the high-level API described in @ref nbgl_page, but offers to developer more than a single page.
+This layer uses the high-level API described in @ref nbgl_page, but offers to developer more than
+a single page.
 
-The goal is to simplify the usage of NBGL, but also to offer a better homogeneity across applications, by pushing
-developers to use common API for common use-cases.
+The goal is to simplify the usage of NBGL, but also to offer a better homogeneity across
+applications, by pushing developers to use common API for common use-cases.
 
-So that not only the look of the pages but also their transitions look the same. Which should be a real help
-for end-users, getting more and more familiar with the user experience of applications.
+So that not only the look of the pages but also their transitions look the same. Which should be a
+real help for end-users, getting more and more familiar with the user experience of applications.
 
 @subsection nbgl_use_case_example_1 Example 1: transaction review
 
 \image{inline} html UseCase-Review.png "caption" height=300
 
-In this example, a transaction review consists in 3 successive pages, and can be seen as a use-case
+In this example, a transaction review consists in 3 successive pages, and can be seen as a
+use-case
 
 @subsection nbgl_use_case_example_2 Example 2: home & settings pages
 
 \image{inline} html UseCase-HomeSettings.png "caption" height=300
 
-In this other example, displaying home page, then the settings and info consists in 3 pages, and can be seen as another use-case.
+In this other example, displaying home page, then the settings and info consists in 3 pages, and
+can be seen as another use-case.
 
 @section nbgl_use_cases Use Cases
 
 A few APIs are available to draw typical Use-Cases, such as:
 
 - for Home Screen & Settings:
- - @ref nbgl_useCaseHomeAndSettings() to draw the home page and settings/info pages (see @subpage use_case_home_settings)
+ - @ref nbgl_useCaseHomeAndSettings() to draw the home page and settings/info pages
+   (see @subpage use_case_home_settings)
+ - @ref nbgl_useCaseGenericSettings() to draw only settings and info pages, without a home page
+   (see @subpage use_case_generic_settings)
+ - @ref nbgl_useCaseGenericConfiguration() to draw a generic set of configuration pages with a
+   title and a quit callback (see @subpage use_case_generic_configuration)
 - for Individual pages:
- - @ref nbgl_useCaseConfirm() to draw a typical confirmation page, for example when rejecting a transaction (see @subpage use_case_confirm)
+ - @ref nbgl_useCaseConfirm() to draw a typical confirmation page, for example when rejecting a
+   transaction (see @subpage use_case_confirm)
  - @ref nbgl_useCaseChoice() to draw a typical dual choice page (see @subpage use_case_choice)
- - @ref nbgl_useCaseAdvancedChoiceWithDetails() to draw a choice page with three content lines, a configurable top-right icon and an optional details modal (see @subpage use_case_advanced_choice_with_details)
- - @ref nbgl_useCaseStatus() to draw a transient status page, without control, for example when a transaction is successfully signed (see @subpage use_case_status)
+ - @ref nbgl_useCaseChoiceWithDetails() to draw a choice page with a top-right button that opens
+   a details modal (see @subpage use_case_choice_with_details)
+ - @ref nbgl_useCaseAdvancedChoiceWithDetails() to draw a choice page with three content lines, a
+   configurable top-right icon and an optional details modal
+   (see @subpage use_case_advanced_choice_with_details)
+ - @ref nbgl_useCaseAction() to draw a single action page with a centered icon, a message and an
+   action button (see @subpage use_case_action)
+ - @ref nbgl_useCaseStatus() to draw a transient status page, without control, for example when a
+   transaction is successfully signed (see @subpage use_case_status)
  - @ref nbgl_useCaseSpinner() to draw an infinite spinner page (see @subpage use_case_spinner)
 - for most used reviews:
- - @ref nbgl_useCaseReview() to draw the pages of a regular coin transaction review, when all info are available from the beginning (see @subpage use_case_review)
- - @ref nbgl_useCaseReviewLight() to draw the pages of a transaction review with a simple button confirmation, when all info are available from the beginning (see @subpage use_case_review_light)
- - @ref nbgl_useCaseReviewStreamingStart() to draw the pages of a regular coin transaction review, when all info are not available from the beginning (see @subpage use_case_review_streaming)
+ - @ref nbgl_useCaseReview() to draw the pages of a regular coin transaction review, when all
+   info are available from the beginning (see @subpage use_case_review)
+ - @ref nbgl_useCaseReviewBlindSigning() to draw the pages of a blind-signing review with a
+   warning prolog and an optional tip-box (see @subpage use_case_review_blind_signing)
+ - @ref nbgl_useCaseReviewLight() to draw the pages of a transaction review with a simple button
+   confirmation, when all info are available from the beginning
+   (see @subpage use_case_review_light)
+ - @ref nbgl_useCaseGenericReview() to draw a review from a generic contents list, with a
+   configurable reject footer (see @subpage use_case_generic_review)
+ - @ref nbgl_useCaseReviewStreamingStart() to draw the pages of a regular coin transaction
+   review, when all info are not available from the beginning
+   (see @subpage use_case_review_streaming)
+ - @ref nbgl_useCaseReviewStreamingBlindSigningStart() to start a blind-signing streaming review
+   preceded by a warning page (see @subpage use_case_review_streaming)
+ - @ref nbgl_useCaseAdvancedReviewStreamingStart() to start a streaming review with a warning
+   prolog, when all info are not available from the beginning
+   (see @subpage use_case_review_streaming)
 - for reviews with a warning prolog:
- - @ref nbgl_useCaseAdvancedReview() to draw the pages of a regular coin transaction review, when all info are available from the beginning, but with an identified risk requiring a warning prolog (see @subpage use_case_review_with_warning)
- - @ref nbgl_useCaseAdvancedReviewStreamingStart() to draw the pages of a regular coin transaction review, when all info are not available from the beginning, but with an identified risk requiring a warning prolog (see @subpage use_case_review_with_warning and @subpage use_case_review_streaming)
+ - @ref nbgl_useCaseAdvancedReview() to draw the pages of a regular coin transaction review, when
+   all info are available from the beginning, but with an identified risk requiring a warning
+   prolog (see @subpage use_case_review_with_warning)
+ - @ref nbgl_useCaseAdvancedReviewStreamingStart() to draw the pages of a regular coin
+   transaction review, when all info are not available from the beginning, but with an identified
+   risk requiring a warning prolog
+   (see @subpage use_case_review_with_warning and @subpage use_case_review_streaming)
 - for address verification:
- - @ref nbgl_useCaseAddressReview() to draw an address confirmation page, with a possibility to see it as QR Code and some extra tag/value pairs (see @subpage use_case_addr_review)
+ - @ref nbgl_useCaseAddressReview() to draw an address confirmation page, with a possibility to
+   see it as QR Code and some extra tag/value pairs (see @subpage use_case_addr_review)
 - for keypad:
- - @ref nbgl_useCaseKeypad() to draw a default keypad implementation (see @subpage use_case_keypad)
+ - @ref nbgl_useCaseKeypad() to draw a default keypad implementation
+   (see @subpage use_case_keypad)
 - for keyboard:
- - @ref nbgl_useCaseKeyboard() to draw a keyboard for text input (see @subpage use_case_keyboard)
+ - @ref nbgl_useCaseKeyboard() to draw a keyboard for text input
+   (see @subpage use_case_keyboard)
 - for generic navigable content:
  - @ref nbgl_useCaseNavigableContent() to draw a level of generic content navigable pages
 
@@ -67,18 +106,23 @@ Some APIs have also been kept for backward compatibility, and for some rare case
 
 - for most used reviews:
  - @ref nbgl_useCaseReviewStart() to draw the cover page of a review (initial page, without data)
- - @ref nbgl_useCaseStaticReview() to draw the data pages of a regular review, when all info are available from the beginning (all pages but the cover one)
+ - @ref nbgl_useCaseStaticReview() to draw the data pages of a regular review, when all info are
+   available from the beginning (all pages but the cover one)
+ - @ref nbgl_useCaseStaticReviewLight() to draw the data pages of a regular review with a simple
+   button/footer pair instead of a long press button (all pages but the cover one)
 
 @subsection use_case_home_settings Home & Settings screen Use Case
 
 \image{inline} html UseCase-HomeSettingsAPI.png "caption" height=300
 
-Ledger would like all application to have the same layout for home screen and settings/info, so the @ref nbgl_useCaseHomeAndSettings() function enables to
-create such a set of page, the configurable parameters being:
+Ledger would like all application to have the same layout for home screen and settings/info, so
+the @ref nbgl_useCaseHomeAndSettings() function enables to create such a set of page, the
+configurable parameters being:
 
 - the application name (appName)
 - the application icon (appIcon)
-- the tagline, a text under app name (if NULL, it will be "This app enables signing transactions on the <appName> network.")
+- the tagline, a text under app name (if NULL, it will be "This app enables signing transactions
+  on the <appName> network.")
 - the callback when touching *quit application* button
 
 @code
@@ -160,23 +204,26 @@ For some rare applications, one may need an action button in the Home screen, to
 - The main action of the Application
 - Or an side-action, as to display an address
 
-The \b action argument of @ref nbgl_useCaseHomeAndSettings() can be used for that. This structure (@ref nbgl_homeAction_t)
-enables to specify:
+The \b action argument of @ref nbgl_useCaseHomeAndSettings() can be used for that. This structure
+(@ref nbgl_homeAction_t) enables to specify:
 
 - A text & an icon for the button
 - A function to be called when the button is touched
-- The type of button (either @ref STRONG_HOME_ACTION for main action, in black, or @ref SOFT_HOME_ACTION for side action, in white)
+- The type of button (either @ref STRONG_HOME_ACTION for main action, in black, or
+  @ref SOFT_HOME_ACTION for side action, in white)
 
 @subsection use_case_confirm Confirmation Use Case
 
 \image{inline} html UseCase-Confirm.png "caption" height=300
 
-A confirmation use-case consists in a single modal page containing a fixed icon, a configurable message, a black button and a footer to make
-the choice, with configuration texts. The @ref nbgl_useCaseConfirm() function enables to create such a page.
+A confirmation use-case consists in a single modal page containing a fixed icon, a configurable
+message, a black button and a footer to make the choice, with configuration texts.
+The @ref nbgl_useCaseConfirm() function enables to create such a page.
 
 The *callback* argument is called when the button is touched.
 
-When the footer is touched, this modal screen is simply dismissed, revealing the previous page on background.
+When the footer is touched, this modal screen is simply dismissed, revealing the previous page on
+background.
 
 Here is the code to display the example picture (and a status page for confirmation)
 
@@ -188,6 +235,7 @@ static void confirmationCallback(void) {
 
 void onRejectTransaction(void) {
   nbgl_useCaseConfirm("Reject transaction?",
+                      NULL,
                       "Yes, Reject",
                       "Go back to transaction",
                       confirmationCallback);
@@ -198,11 +246,12 @@ void onRejectTransaction(void) {
 
 \image{inline} html UseCase-Choice.png "caption" height=300
 
-A choice use-case consists in a single page containing a fixed icon, a configurable icon, a configurable message, a black button and a footer to make
-the choice, with configuration texts. The @ref nbgl_useCaseChoice() function enables to create such a page.
+A choice use-case consists in a single page containing a fixed icon, a configurable icon, a
+configurable message, a black button and a footer to make the choice, with configuration texts.
+The @ref nbgl_useCaseChoice() function enables to create such a page.
 
-The *callback* argument is called when the button or the footer is touched. Its argument is a boolean which is *true* when button is
-touched, *false* when footer is touched.
+The *callback* argument is called when the button or the footer is touched. Its argument is a
+boolean which is *true* when button is touched, *false* when footer is touched.
 
 Here is the code to display the example picture
 
@@ -230,19 +279,22 @@ void onRejectTransaction(void) {
 
 \image{inline} html UseCase-AdvancedChoiceWithDetails.png "caption" height=300
 
-A variant of the Choice use-case that displays three content lines and an optional top-right icon button
-that opens a details modal. The @ref nbgl_useCaseAdvancedChoiceWithDetails() function enables to create such a page.
+A variant of the Choice use-case that displays three content lines and an optional top-right icon
+button that opens a details modal.
+The @ref nbgl_useCaseAdvancedChoiceWithDetails() function enables to create such a page.
 
 The page layout is:
 - a centered icon (*center_icon*, can be NULL)
 - a bold title (*title*)
 - a regular black message (*message*, can be NULL)
 - a gray sub-message (*subMessage*, can be NULL)
-- a top-right icon button (*header_icon*) that opens the *details* modal — shown only when both *details* and *header_icon* are non-NULL
+- a top-right icon button (*header_icon*) that opens the *details* modal — shown only when both
+  *details* and *header_icon* are non-NULL
 - Confirm / Cancel buttons at the bottom
 
-The *callback* argument is called when the button or the footer is touched. Its argument is a boolean which is *true* when the
-Confirm button is touched, *false* when the Cancel footer is touched.
+The *callback* argument is called when the button or the footer is touched. Its argument is a
+boolean which is *true* when the Confirm button is touched, *false* when the Cancel footer is
+touched.
 
 Here is the code to display the example picture
 
@@ -283,11 +335,14 @@ void displayAccountConfirm(void) {
 
 \image{inline} html UseCase-Status.png "caption" height=300
 
-A status is a transient page, without control, to display during a short time, for example when a transaction is successfully signed.
-The @ref nbgl_useCaseStatus() function enables to create such a page, with the following arguments:
+A status is a transient page, without control, to display during a short time, for example when a
+transaction is successfully signed.
+The @ref nbgl_useCaseStatus() function enables to create such a page, with the following
+arguments:
 
 - a message string to set in middle of page
-- a boolean to indicate if true, that the message is drawn in a Ledger style (with corners) and select the icon
+- a boolean to indicate if true, that the message is drawn in a Ledger style (with corners) and
+  select the icon
 - a quit callback, called when timer times out (or the page is "tapped")
 
 If it's a success status, a *success* tune will be automatically played.
@@ -296,8 +351,10 @@ If it's a success status, a *success* tune will be automatically played.
 
 \image{inline} html UseCase-Review-Status.png "caption" height=300
 
-Similar as @subpage use_case_status, this is used to display transient page, without control, during a short time, for example when a transaction is successfully signed.
-The @ref nbgl_useCaseReviewStatus() function enables to create such a page, with the following arguments:
+Similar as @ref use_case_status, this is used to display transient page, without control, during a
+short time, for example when a transaction is successfully signed.
+The @ref nbgl_useCaseReviewStatus() function enables to create such a page, with the following
+arguments:
 
 - a type of status (with predefined message)
 - a quit callback, called when timer times out (or the page is "tapped")
@@ -310,21 +367,24 @@ If it's a success status, a *success* tune will be automatically played.
 
 In most cases, the developer may know all tag/value pairs of a transaction when it is submitted.
 
-Thus, the number of pages is computed automatically and pages can be navigated forward and backward.
+Thus, the number of pages is computed automatically and pages can be navigated forward and
+backward.
 
-In case of a tag/value pair too long to be fully displayed, the *more* button will be automatically drawn and its handling
-automatically performed by NBGL by building a detailed modal view.
+In case of a tag/value pair too long to be fully displayed, the *more* button will be
+automatically drawn and its handling automatically performed by NBGL by building a detailed modal
+view.
 
-When the user taps on *Reject* in any page, a confirmation page is automatically drawned to let user confirm that he rejects
-the transaction. In this case, the given callback is called and it's up to app's developer to call @ref nbgl_useCaseReviewStatus(), as in
-case of long-press.
+When the user taps on *Reject* in any page, a confirmation page is automatically drawned to let
+user confirm that he rejects the transaction. In this case, the given callback is called and it's
+up to app's developer to call @ref nbgl_useCaseReviewStatus(), as in case of long-press.
 
 The API to initiate the display of the series of pages is @ref nbgl_useCaseReview(), providing:
 
 - the type of operation to review (transaction, message or generic operation)
 - the list of tag/value pairs (or a callback to get them one by one)
 - the texts/icon to use in presentation page and in last page
-- a callback called when the long press button on last page or reject confirmation is used. The callback's param is *true* for confirmation, *false* for rejection.
+- a callback called when the long press button on last page or reject confirmation is used.
+  The callback's param is *true* for confirmation, *false* for rejection.
 
 Here is the code to display something similar to example picture:
 
@@ -425,51 +485,62 @@ void startReview(void) {
 
 @subsection use_case_review_light Light review Use Case
 
-In some cases, the developer may want to display a review but with a less intense confirmation than a long-press button. A simple button is used in this
-case.
+In some cases, the developer may want to display a review but with a less intense confirmation
+than a long-press button. A simple button is used in this case.
 
-The API to initiate the display of the series of pages is @ref nbgl_useCaseReviewLight(), providing:
+The API to initiate the display of the series of pages is @ref nbgl_useCaseReviewLight(),
+providing:
 
 - the list of tag/value pairs (or a callback to get them one by one)
 - the texts/icon to use in presentation page and in last page
-- a callback called when the long press button on last page or reject confirmation is used. The callback's param is *true* for confirmation, *false* for rejection.
+- a callback called when the long press button on last page or reject confirmation is used.
+  The callback's param is *true* for confirmation, *false* for rejection.
 
 @subsection use_case_review_streaming Streaming review Use Case
 
 \image{inline} html UseCase-Streaming.png "caption" height=300
 
-In some cases, the application cannot know all tag/value pairs of a transaction when the review is started.
+In some cases, the application cannot know all tag/value pairs of a transaction when the review
+is started.
 
-In this case, what we call a *streaming* review can be used. The pages to display for each *stream* are computed automatically and pages can be navigated forward
-and backward (only within a *stream* for backward).
+In this case, what we call a *streaming* review can be used. The pages to display for each
+*stream* are computed automatically and pages can be navigated forward and backward (only within
+a *stream* for backward).
 
-In case of a tag/value pair too long to be fully displayed, the *more* button will be automatically drawn and its handling
-automatically performed by NBGL by building a detailed modal view.
+In case of a tag/value pair too long to be fully displayed, the *more* button will be
+automatically drawn and its handling automatically performed by NBGL by building a detailed modal
+view.
 
-When the user taps on *Reject* in any page, a confirmation page is automatically drawned to let user confirm that he rejects
-the transaction. In this case, the given callback is called and it's up to app's developer to call @ref nbgl_useCaseReviewStatus(), as in
-case of long-press.
+When the user taps on *Reject* in any page, a confirmation page is automatically drawned to let
+user confirm that he rejects the transaction. In this case, the given callback is called and it's
+up to app's developer to call @ref nbgl_useCaseReviewStatus(), as in case of long-press.
 
-The API to initiate the display of the series of pages is @ref nbgl_useCaseReviewStreamingStart(), providing:
+The API to initiate the display of the series of pages is
+@ref nbgl_useCaseReviewStreamingStart(), providing:
 
 - the type of operation to review (transaction, message or generic operation)
 - the texts/icon to use in presentation page
 - a callback with one boolean parameter:
   - If this parameter is *false*, it means that the transaction is rejected.
-  - If this parameter is *true*, it means that NBGL is waiting for new data, sent with @ref nbgl_useCaseReviewStreamingContinue() or @ref nbgl_useCaseReviewStreamingContinueExt()
+  - If this parameter is *true*, it means that NBGL is waiting for new data, sent with
+    @ref nbgl_useCaseReviewStreamingContinue() or @ref nbgl_useCaseReviewStreamingContinueExt()
 
-As long as there are new tag/value pairs to send, the API to call is either @ref nbgl_useCaseReviewStreamingContinueExt() (if skip is possible) or
+As long as there are new tag/value pairs to send, the API to call is either
+@ref nbgl_useCaseReviewStreamingContinueExt() (if skip is possible) or
 @ref nbgl_useCaseReviewStreamingContinue(), providing:
 
 - the list of tag/value pairs (or a callback to get them one by one)
 - a callback with one boolean parameter:
   - If this parameter is *false*, it means that the transaction is rejected.
-  - If this parameter is *true*, it means that NBGL is waiting for new data, to be sent with @ref nbgl_useCaseReviewStreamingContinue() or @ref nbgl_useCaseReviewStreamingContinueExt()
+  - If this parameter is *true*, it means that NBGL is waiting for new data, to be sent with
+    @ref nbgl_useCaseReviewStreamingContinue() or @ref nbgl_useCaseReviewStreamingContinueExt()
 
-When there is no more data to send, the API to call is @ref nbgl_useCaseReviewStreamingFinish(), providing:
+When there is no more data to send, the API to call is
+@ref nbgl_useCaseReviewStreamingFinish(), providing:
 
 - the title to use for last page (with long-press button)
-- a callback called when the long press button on last page or reject confirmation is used. The callback's param is *true* for confirmation, *false* for rejection.
+- a callback called when the long press button on last page or reject confirmation is used.
+  The callback's param is *true* for confirmation, *false* for rejection.
 
 Here is the code to display something similar to example picture:
 
@@ -521,19 +592,25 @@ void startReview(void) {
 
 The review itself behaves like in @subpage use_case_review. The main differences are:
 
-- The review itself is preceded by a warning page offering the possibility to cancel the review ("Back to safety") or to start it ("Continue anyway")
-- In the first and last pages of the actual review, a top-right button offers the possibility to get more information about the warning
+- The review itself is preceded by a warning page offering the possibility to cancel the review
+  ("Back to safety") or to start it ("Continue anyway")
+- In the first and last pages of the actual review, a top-right button offers the possibility to
+  get more information about the warning
 
-The API to initiate the display of the series of pages is @ref nbgl_useCaseAdvancedReview(), providing:
+The API to initiate the display of the series of pages is @ref nbgl_useCaseAdvancedReview(),
+providing:
 
 - the type of operation to review (transaction, message or generic operation)
 - the list of tag/value pairs (or a callback to get them one by one)
 - the texts/icon to use in presentation page and in last page
 - the configuration to use for the warning (see @ref nbgl_warning_t structure)
-- a callback called when the long press button on last page or reject confirmation is used. The callback's param is *true* for confirmation, *false* for rejection.
+- a callback called when the long press button on last page or reject confirmation is used.
+  The callback's param is *true* for confirmation, *false* for rejection.
 
-@note the recommended configuration for warning is the predefined one. In this case, one just has to fill the *predefinedSet* field of @ref nbgl_warning_t with the appropriate warning
-causes (bitfield) and the *reportProvider* field with the name of the 3rd party providing the Web3Checks report, if necessary.
+@note the recommended configuration for warning is the predefined one. In this case, one just has
+to fill the *predefinedSet* field of @ref nbgl_warning_t with the appropriate warning causes
+(bitfield) and the *reportProvider* field with the name of the 3rd party providing the Web3Checks
+report, if necessary.
 
 Here is the code to display something similar to example picture:
 
@@ -612,7 +689,7 @@ static const struct nbgl_warningDetails_s barListIntroDetails[]  = {
 static const struct nbgl_warningDetails_s barListIntroDetails[]  = {
     {.title  = "Back",
      .type   = CENTERED_INFO_WARNING,
-     .centeredInfo = {.icon = &C_Warning_64px, .title = "Blind signing", .description = "This transaction’s details are not fully verifiable. If you sign it, you could lose all your assets.\n\nLearn about blind signing:
+     .centeredInfo = {.icon = &C_Warning_64px, .title = "Blind signing", .description = "This transaction's details are not fully verifiable. If you sign it, you could lose all your assets.\n\nLearn about blind signing:
 ledger.com/e8"}},
     {.title        = "Back",
      .type         = CENTERED_INFO_WARNING,
@@ -623,7 +700,7 @@ ledger.com/e8"}},
 static const nbgl_contentCenter_t warningInfo = {
   .icon          = &C_Warning_64px,
   .title         = "Dangerous transaction",
-  .description   = "This transaction cannot be fully decoded, and was marked risky by Web3 Checks."
+  .description   = "This transaction cannot be fully decoded, and was marked risky by Web3 Checks."
 };
 
 // first level warning details in prolog
@@ -687,11 +764,14 @@ void staticReview(void) {
 \image{inline} html UseCase-AddressReview.png "caption" height=500
 
 When an address needs to be confirmed, it can be displayed in a Address Review Use Case.
-After a title page, a second page is displayed with the raw address (as text). An extra button under the raw address enables to open a modal page to see the address as a QR code.
-Moreover, if extra information need to be displayed, for example a derivation path, it is provided in a second page, also containing
-a black button/Footer pair to choose to confirm or reject the address.
+After a title page, a second page is displayed with the raw address (as text). An extra button
+under the raw address enables to open a modal page to see the address as a QR code.
+Moreover, if extra information need to be displayed, for example a derivation path, it is provided
+in a second page, also containing a black button/Footer pair to choose to confirm or reject the
+address.
 
-The @ref nbgl_useCaseAddressReview() function enables to create such a set of pages, with the following parameters:
+The @ref nbgl_useCaseAddressReview() function enables to create such a set of pages, with the
+following parameters:
 
 - the address to confirm (NULL terminated string)
 - a callback called when button or footer is touched (if true, confirm, if false reject)
@@ -721,12 +801,11 @@ static void displayAddressCallback(bool confirm) {
 
 void app_ethereumVerifyAddress(void) {
   nbgl_useCaseAddressReview("bc1pkdcufjh6dxjaaa05hudvxqg5fhspfmwmp8g92gq8cv4gwwnmgrfqfd4jlg",
-                            &pairList
+                            &pairList,
                             myAppIcon,
                             "Verify MyCoin\naddress",
                             NULL,
-                            "Cancel",
-                            appMain);
+                            displayAddressCallback);
 }
 @endcode
 
@@ -788,8 +867,8 @@ void ui_menu_pinentry_display(unsigned int value) {
 @subsection use_case_keyboard Keyboard Use Case
 
 When text input is required (not just digits), a full keyboard can be displayed.
-The keyboard supports different modes (lowercase, uppercase, digits, special characters) and can be configured
-with either a confirmation button or dynamic suggestion buttons.
+The keyboard supports different modes (lowercase, uppercase, digits, special characters) and can
+be configured with either a confirmation button or dynamic suggestion buttons.
 
 As shown in the examples below, the keyboard page consists of:
 
@@ -799,7 +878,8 @@ As shown in the examples below, the keyboard page consists of:
 - the keyboard at the bottom (navigable with touch or buttons depending on device)
 - either a confirmation button or suggestion buttons above the keyboard
 
-The @ref nbgl_useCaseKeyboard() function enables to create such page, with the following parameters:
+The @ref nbgl_useCaseKeyboard() function enables to create such page, with the following
+parameters:
 
 - a pointer to @ref nbgl_keyboardParams_t structure containing:
   - \b type: either @ref KEYBOARD_WITH_BUTTON or @ref KEYBOARD_WITH_SUGGESTIONS
@@ -939,10 +1019,288 @@ void display_keyboard_page(void) {
 }
 @endcode
 
+@subsection use_case_review_blind_signing Blind Signing Review Use Case
+
+A blind-signing review behaves exactly like @ref use_case_review, but the review is automatically
+preceded by a mandatory blind-signing warning page. The first page of the review may also display
+an optional tip-box (e.g. to point the user to a companion app that can decode the transaction).
+
+The API to initiate the display is @ref nbgl_useCaseReviewBlindSigning(), providing:
+
+- the type of operation to review (transaction, message or generic operation)
+- the list of tag/value pairs (or a callback to get them one by one)
+- the icon to use on the first and last pages
+- the title and optional sub-title of the first page
+- the title of the last page (with long-press button)
+- an optional tip-box (@ref nbgl_tipBox_t) shown in the first page of the review (can be NULL)
+- a callback called when the long-press button or the reject confirmation is used. The callback's
+  param is *true* for confirmation, *false* for rejection.
+
+Here is a minimal example:
+
+@code
+// 4 pairs of tag/value to display
+static nbgl_layoutTagValue_t pairs[4];
+
+static const nbgl_contentTagValueList_t pairList = {
+  .nbMaxLinesForValue = 0,
+  .nbPairs = 4,
+  .pairs = (nbgl_layoutTagValue_t*)pairs
+};
+
+// called when long press button is long-touched or when reject footer is touched
+static void onReviewResult(bool confirm) {
+  if (confirm) {
+    nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_SIGNED, appMain);
+  }
+  else {
+    nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_REJECTED, appMain);
+  }
+}
+
+void startBlindSigningReview(void) {
+  nbgl_useCaseReviewBlindSigning(TYPE_TRANSACTION, // type of operation
+                                 &pairList,         // list of tag/value pairs
+                                 coinIcon,           // icon on first and last pages
+                                 "Review transaction\nto send coin", // title of first page
+                                 NULL,               // no sub-title
+                                 "Sign transaction to\nsend coin?",  // title of last page
+                                 NULL,               // no tip-box
+                                 onReviewResult);    // callback on result
+}
+@endcode
+
+@subsection use_case_generic_review Generic Review Use Case
+
+A generic review displays a flow of pages built from a @ref nbgl_genericContents_t list. Unlike
+@ref use_case_review, the developer is responsible for building every page explicitly; NBGL handles
+pagination and navigation automatically.
+
+The API is @ref nbgl_useCaseGenericReview(), providing:
+
+- the generic contents list to display
+- the text to use in the reject footer
+- a callback called when the footer is touched
+
+Here is a minimal example:
+
+@code
+static const nbgl_content_t contentsList[1] = {
+  {.type = TAG_VALUE_LIST,
+   .content.tagValueList = { .nbPairs = 2,
+                              .pairs   = myPairs }}
+};
+
+static const nbgl_genericContents_t reviewContents = {
+  .contentsList = contentsList,
+  .nbContents   = 1
+};
+
+static void onReject(void) {
+  nbgl_useCaseReviewStatus(STATUS_TYPE_OPERATION_REJECTED, appMain);
+}
+
+void startGenericReview(void) {
+  nbgl_useCaseGenericReview(&reviewContents,
+                             "Reject",
+                             onReject);
+}
+@endcode
+
+@subsection use_case_generic_configuration Generic Configuration Use Case
+
+Displays a set of configuration pages with automatic pagination. A touchable title bar at the
+top acts as a quit/back button.
+
+The API is @ref nbgl_useCaseGenericConfiguration(), providing:
+
+- the title string displayed in the touchable header
+- the page index to start on (0-based)
+- the generic contents list to display
+- a callback called when the title is pressed
+
+Here is a minimal example:
+
+@code
+static const nbgl_content_t confContentsList[1] = {
+  {.type = SWITCHES_LIST,
+   .content.switchesList = { .nbSwitches = 2,
+                              .switches   = mySwitches },
+   .contentActionCallback = onSwitchToggle}
+};
+
+static const nbgl_genericContents_t confContents = {
+  .contentsList = confContentsList,
+  .nbContents   = 1
+};
+
+static void onQuit(void) {
+  appMain();
+}
+
+void startConfiguration(void) {
+  nbgl_useCaseGenericConfiguration("My Configuration",
+                                   0,               // start on first page
+                                   &confContents,
+                                   onQuit);
+}
+@endcode
+
+@subsection use_case_generic_settings Generic Settings Use Case
+
+Like @ref use_case_home_settings but without the home page: only the settings contents and the
+app-info pages are displayed. This is useful for sub-setting screens that must be reachable
+without going through the home page.
+
+The API is @ref nbgl_useCaseGenericSettings(), providing:
+
+- the app name (used as page title)
+- the page index to start on (0-based)
+- the settings contents (can be NULL if only info pages are needed)
+- the info list (version, developer, …)
+- a callback called when the quit button or title is pressed
+
+Here is a minimal example:
+
+@code
+static const char *infoTypes[]    = {"Version", "Developer"};
+static const char *infoContents[] = {"1.0.0", "Ledger"};
+
+static const nbgl_contentInfoList_t eth_infosList = {
+  .nbInfos       = 2,
+  .infoTypes     = infoTypes,
+  .infoContents  = infoContents
+};
+
+static void onQuit(void) {
+  appMain();
+}
+
+void displaySettings(uint8_t settingPage) {
+  nbgl_useCaseGenericSettings("Ethereum",
+                              settingPage,
+                              &eth_settingContents, // defined elsewhere
+                              &eth_infosList,
+                              onQuit);
+}
+@endcode
+
+@subsection use_case_choice_with_details Choice with Details Use Case
+
+A variant of @ref use_case_choice that adds a top-right icon button. When that button is
+touched, the modal page described by the @p details argument is displayed.
+
+The page layout is identical to @ref use_case_choice (centered icon, message, optional
+sub-message, confirm button, cancel footer) with the addition of the top-right button, which is
+shown only when the @p details argument is non-NULL.
+
+The @ref nbgl_useCaseChoiceWithDetails() function accepts the same parameters as
+@ref nbgl_useCaseChoice() plus:
+
+- *details* (@ref nbgl_warningDetails_t): description of the modal page to display when the
+  top-right button is touched. If NULL, no top-right button is shown.
+
+The *callback* argument works the same way as in @ref use_case_choice.
+
+@note For a richer layout supporting three content lines and a fully configurable top-right icon,
+see @ref use_case_advanced_choice_with_details.
+
+Here is an example:
+
+@code
+static void onChoice(bool confirm) {
+  if (confirm) {
+    // confirmed
+  } else {
+    // cancelled
+  }
+}
+
+static const char *detailTexts[]    = {"Risk"};
+static const char *detailSubTexts[] = {"This action is irreversible."};
+
+static nbgl_warningDetails_t choiceDetails = {
+  .title              = "More information",
+  .type               = BAR_LIST_WARNING,
+  .barList.nbBars     = 1,
+  .barList.texts      = detailTexts,
+  .barList.subTexts   = detailSubTexts,
+};
+
+void displayConfirmWithDetails(void) {
+  nbgl_useCaseChoiceWithDetails(&C_warning_64px,
+                                "Delete all credentials?",
+                                "This cannot be undone.",
+                                "Yes, delete",
+                                "No, keep",
+                                &choiceDetails,
+                                onChoice);
+}
+@endcode
+
+@subsection use_case_action Action Use Case
+
+An action page consists of a centered info (icon + message) and a single action button at the
+bottom. No footer is displayed. The given callback is called when the button is touched.
+
+The @ref nbgl_useCaseAction() function accepts the following parameters:
+
+- *icon*: icon to display in the centered info
+- *message*: text to display in the centered info
+- *actionText*: label of the action button
+- *callback*: function called when the action button is touched
+
+Here is an example:
+
+@code
+static void onAction(void) {
+  // perform the action
+}
+
+void displayActionPage(void) {
+  nbgl_useCaseAction(&C_app_64px,
+                     "Connect to companion\napp to get started",
+                     "Open app",
+                     onAction);
+}
+@endcode
+
+@section use_case_utils Utility functions
+
+The following functions compute how many items of a given type fit in a single review or settings
+page. They are useful when building custom paginated content with @ref nbgl_useCaseGenericReview()
+or similar APIs.
+
+- @ref nbgl_useCaseGetNbTagValuesInPage() — returns the number of tag/value pairs that fit in one
+  page starting at a given index. Sets the *requireSpecificDisplay* output flag when the pair needs
+  special rendering (centeredInfo flag or value too long).
+
+- @ref nbgl_useCaseGetNbTagValuesInPageExt() — same as above but also accounts for a potential
+  *skip* header when *isSkippable* is true.
+
+- @ref nbgl_useCaseGetNbInfosInPage() — returns the number of info items (type/content string
+  pairs) that fit in one page starting at a given index.
+
+- @ref nbgl_useCaseGetNbSwitchesInPage() — returns the number of switch items that fit in one
+  page starting at a given index.
+
+- @ref nbgl_useCaseGetNbBarsInPage() — returns the number of touchable bar items that fit in one
+  page starting at a given index.
+
+- @ref nbgl_useCaseGetNbChoicesInPage() — returns the number of radio-choice items that fit in
+  one page starting at a given index.
+
+- @ref nbgl_useCaseGetNbPagesForTagValueList() — returns the total number of pages required to
+  display a complete @ref nbgl_contentTagValueList_t. Useful to pre-compute navigation structures
+  before starting a review.
+
+All functions take the navigation bar into account: when a navigation footer is present the
+available area is reduced accordingly.
+
 @section use_case_refresh_page Refreshing screen
 
-After having drawn graphic objects in **framebuffer**, all functions of this API automatically refresh the screen.
-So no need to call @ref nbgl_refresh().
+After having drawn graphic objects in **framebuffer**, all functions of this API automatically
+refresh the screen. So no need to call @ref nbgl_refresh().
 
 */
 #endif // HAVE_SE_TOUCH

--- a/lib_nbgl/doc/nbgl_use_case_nanos.dox
+++ b/lib_nbgl/doc/nbgl_use_case_nanos.dox
@@ -4,7 +4,8 @@
 @section nbgl_use_case_intro Introduction
 This chapter describes the Application Use-cases API of Advanced BOLOS Graphic Library.
 
-This layer offers a simplified view of some typical use-cases of display in an Application running on Stax.
+This layer offers a simplified view of some typical use-cases of display in an Application
+running on Nano devices.
 For example, a use-case can be:
 
 - Reviewing a transaction/message
@@ -15,50 +16,83 @@ A full description of each predefined use-case can be found in this document
 
 @section nbgl_use_case_concepts Concepts
 
-This layer uses the high-level API described in @ref nbgl_step, but offers to developer more than a single step.
+This layer uses the high-level API described in @ref nbgl_step, but offers to developer more than
+a single step.
 
-The goal is to simplify the usage of NBGL, but also to offer a better homogeneity across applications, by pushing
-developers to use common API for common use-cases.
+The goal is to simplify the usage of NBGL, but also to offer a better homogeneity across
+applications, by pushing developers to use common API for common use-cases.
 
-So that not only the look of the pages but also their transitions look the same. Which should be a real help
-for end-users, getting more and more familiar with the user experience of applications.
+So that not only the look of the pages but also their transitions look the same. Which should be a
+real help for end-users, getting more and more familiar with the user experience of applications.
 
 @subsection nbgl_use_case_example_1 Example 1: transaction review
 
 \image{inline} html UseCase-Nano-Review-ex.png "caption" width=1000
 
-In this example, a transaction review consists in 5 successive pages, and can be seen as a use-case
+In this example, a transaction review consists in 5 successive pages, and can be seen as a
+use-case
 
 @subsection nbgl_use_case_example_2 Example 2: Settings pages
 
 \image{inline} html UseCase-Nano-Settings-ex.png "caption" width=750
 
-In this example, the settings (accessed from *Settings* in Home, single level) consists in 3 pages, and can be seen as another use-case.
+In this example, the settings (accessed from *Settings* in Home, single level) consists in 3
+pages, and can be seen as another use-case.
 
 @section nbgl_use_cases Use Cases
 
 A few APIs are available to draw typical Use-Cases, such as:
 
 - For Home Screen & Settings:
- - @ref nbgl_useCaseHomeAndSettings() to draw the home page and settings/info pages (see @subpage use_case_home_settings)
+ - @ref nbgl_useCaseHomeAndSettings() to draw the home page and settings/info pages
+   (see @subpage use_case_home_settings)
+ - @ref nbgl_useCaseGenericSettings() to draw only settings and info pages, without a home page
+   (see @subpage use_case_generic_settings)
+ - @ref nbgl_useCaseGenericConfiguration() to draw a generic set of configuration pages with a
+   title and a quit callback (see @subpage use_case_generic_configuration)
 - For Individual pages:
- - @ref nbgl_useCaseConfirm() to draw a typical confirmation page, for example when rejecting a transaction (see @subpage use_case_confirm)
+ - @ref nbgl_useCaseConfirm() to draw a typical confirmation page, for example when rejecting a
+   transaction (see @subpage use_case_confirm)
  - @ref nbgl_useCaseChoice() to draw a typical dual choice page (see @subpage use_case_choice)
- - @ref nbgl_useCaseAdvancedChoiceWithDetails() to draw a choice page with an optional details modal (see @subpage use_case_advanced_choice_with_details)
- - @ref nbgl_useCaseStatus() to draw a transient status page, without control, for example when a transaction is successfully signed (see @subpage use_case_status)
+ - @ref nbgl_useCaseChoiceWithDetails() to draw a choice page with an optional details sequence
+   (see @subpage use_case_choice_with_details)
+ - @ref nbgl_useCaseAdvancedChoiceWithDetails() to draw a choice page with an optional details
+   modal (see @subpage use_case_advanced_choice_with_details)
+ - @ref nbgl_useCaseAction() to draw a single action page with a centered icon, a message and an
+   action button (see @subpage use_case_action)
+ - @ref nbgl_useCaseStatus() to draw a transient status page, without control, for example when a
+   transaction is successfully signed (see @subpage use_case_status)
  - @ref nbgl_useCaseSpinner() to draw an infinite spinner page (see @subpage use_case_spinner)
 - For most used reviews:
- - @ref nbgl_useCaseReview() to draw the pages of a regular coin transaction review, when all info are available from the beginning (see @subpage use_case_review)
- - @ref nbgl_useCaseReviewLight() to draw the pages of a transaction review with a simple button confirmation, when all info are available from the beginning (see @subpage use_case_review_light)
- - @ref nbgl_useCaseReviewStreamingStart() to draw the pages of a regular coin transaction review, when all info are not available from the beginning (see @subpage use_case_review_streaming)
+ - @ref nbgl_useCaseReview() to draw the pages of a regular coin transaction review, when all info
+   are available from the beginning (see @subpage use_case_review)
+ - @ref nbgl_useCaseReviewBlindSigning() to draw the pages of a blind-signing review with a
+   warning prolog (see @subpage use_case_review_blind_signing)
+ - @ref nbgl_useCaseReviewLight() to draw the pages of a transaction review with a simple button
+   confirmation, when all info are available from the beginning
+   (see @subpage use_case_review_light)
+ - @ref nbgl_useCaseGenericReview() to draw a review from a generic contents list, with a
+   configurable reject footer (see @subpage use_case_generic_review)
+ - @ref nbgl_useCaseReviewStreamingStart() to draw the pages of a regular coin transaction review,
+   when all info are not available from the beginning (see @subpage use_case_review_streaming)
+ - @ref nbgl_useCaseReviewStreamingBlindSigningStart() to start a blind-signing streaming review
+   preceded by a warning page (see @subpage use_case_review_streaming)
+ - @ref nbgl_useCaseAdvancedReviewStreamingStart() to start a streaming review with a warning
+   prolog, when all info are not available from the beginning
+   (see @subpage use_case_review_streaming)
 - for reviews with a warning prolog:
- - @ref nbgl_useCaseAdvancedReview() to draw the pages of a regular coin transaction review, when all info are available from the beginning, but with an identified risk requiring a warning prolog (see @subpage use_case_review_with_warning)
+ - @ref nbgl_useCaseAdvancedReview() to draw the pages of a regular coin transaction review, when
+   all info are available from the beginning, but with an identified risk requiring a warning
+   prolog (see @subpage use_case_review_with_warning)
 - For address verification:
- - @ref nbgl_useCaseAddressReview() to draw an address confirmation page, with a possibility to see some extra tag/value pairs (see @subpage use_case_addr_review)
+ - @ref nbgl_useCaseAddressReview() to draw an address confirmation page, with a possibility to
+   see some extra tag/value pairs (see @subpage use_case_addr_review)
 - For keypad:
- - @ref nbgl_useCaseKeypad() to draw a default keypad implementation (see @subpage use_case_keypad)
+ - @ref nbgl_useCaseKeypad() to draw a default keypad implementation
+   (see @subpage use_case_keypad)
 - For keyboard:
- - @ref nbgl_useCaseKeyboard() to draw a keyboard for text input (see @subpage use_case_keyboard)
+ - @ref nbgl_useCaseKeyboard() to draw a keyboard for text input
+   (see @subpage use_case_keyboard)
 - For generic navigable content:
  - @ref nbgl_useCaseNavigableContent() to draw a level of generic content navigable pages
 
@@ -66,8 +100,9 @@ A few APIs are available to draw typical Use-Cases, such as:
 
 \image{inline} html UseCase-Nano-Home.png "caption" width=1000
 
-Ledger would like all application to have the same layout for home screen and settings/info, so the @ref nbgl_useCaseHomeAndSettings() function enables to
-create such a set of page, the configurable parameters being:
+Ledger would like all application to have the same layout for home screen and settings/info, so
+the @ref nbgl_useCaseHomeAndSettings() function enables to create such a set of page, the
+configurable parameters being:
 
 - The application name (appName)
 - The application icon (appIcon)
@@ -158,8 +193,8 @@ For some rare applications, one may need an action button in the Home screen, to
 - The main action of the Application
 - Or an side-action, as to display an address
 
-The \b action argument of @ref nbgl_useCaseHomeAndSettings() can be used for that. This structure (@ref nbgl_homeAction_t)
-enables to specify:
+The \b action argument of @ref nbgl_useCaseHomeAndSettings() can be used for that. This structure
+(@ref nbgl_homeAction_t) enables to specify:
 
 - A text
 - An optional icon
@@ -209,7 +244,8 @@ A choice use-case consists in a 4-page sequence:
 
 The @ref nbgl_useCaseChoice() function enables to create such a page.
 
-The *callback* argument is called when a choice is done. Its argument is a boolean which is *true* upon confirmation, else *false*.
+The *callback* argument is called when a choice is done. Its argument is a boolean which is *true*
+upon confirmation, else *false*.
 
 Here is the code to display the example picture
 
@@ -233,17 +269,71 @@ void onRejectTransaction(void) {
 }
 @endcode
 
+@subsection use_case_choice_with_details Choice with Details Use Case
+
+A variant of @ref use_case_choice that adds an optional details page. When *details* is non-NULL,
+an extra navigation step is inserted in the sequence to display the details content.
+
+@note On Nano devices there is no top-right icon button. Instead, when *details* is non-NULL, an
+additional page is appended to the navigation flow so the user can reach the details by pressing
+the right button.
+
+The @ref nbgl_useCaseChoiceWithDetails() function accepts the same parameters as
+@ref nbgl_useCaseChoice() plus:
+
+- *details* (@ref nbgl_warningDetails_t): description of the details page. If NULL, the sequence
+  behaves exactly like @ref nbgl_useCaseChoice().
+
+The *callback* argument works the same way as in @ref use_case_choice.
+
+@note For a richer layout supporting a sub-message and a configurable header icon,
+see @ref use_case_advanced_choice_with_details.
+
+Here is an example:
+
+@code
+static void onChoice(bool confirm) {
+  if (confirm) {
+    // confirmed
+  } else {
+    // cancelled
+  }
+}
+
+static const char *detailTexts[]    = {"Risk"};
+static const char *detailSubTexts[] = {"This action is irreversible."};
+
+static nbgl_warningDetails_t choiceDetails = {
+  .title              = "More information",
+  .type               = BAR_LIST_WARNING,
+  .barList.nbBars     = 1,
+  .barList.texts      = detailTexts,
+  .barList.subTexts   = detailSubTexts,
+};
+
+void displayConfirmWithDetails(void) {
+  nbgl_useCaseChoiceWithDetails(&C_warning_64px,
+                                "Delete all credentials?",
+                                "This cannot be undone.",
+                                "Yes, delete",
+                                "No, keep",
+                                &choiceDetails,
+                                onChoice);
+}
+@endcode
+
 @subsection use_case_advanced_choice_with_details Advanced Choice with Details Use Case
 
-A variant of the @ref use_case_choice with an optional *details* modal page, accessible by an extra navigation step.
+A variant of the @ref use_case_choice with an optional *details* modal page, accessible by an
+extra navigation step.
 The @ref nbgl_useCaseAdvancedChoiceWithDetails() function enables to create such a sequence.
 
-On Nano, the *header_icon* and *subMessage* arguments are ignored (no top-right icon button, and only one text line
-below the title is displayed). When *details* is non-NULL, an additional page is inserted in the navigation to display
-the details content.
+On Nano, the *header_icon* and *subMessage* arguments are ignored (no top-right icon button, and
+only one text line below the title is displayed). When *details* is non-NULL, an additional page
+is inserted in the navigation to display the details content.
 
-The *callback* argument is called when a choice is done. Its argument is a boolean which is *true* upon confirmation,
-else *false*.
+The *callback* argument is called when a choice is done. Its argument is a boolean which is *true*
+upon confirmation, else *false*.
 
 Here is an example of usage:
 
@@ -281,12 +371,41 @@ void displayAccountConfirm(void) {
 }
 @endcode
 
+@subsection use_case_action Action Use Case
+
+An action page consists of a centered info (icon + message) and a single action button at the
+bottom. The given callback is called when both buttons are pressed on the action page.
+
+The @ref nbgl_useCaseAction() function accepts the following parameters:
+
+- *icon*: icon to display in the centered info
+- *message*: text to display in the centered info
+- *actionText*: label of the action button
+- *callback*: function called when the action button is pressed
+
+Here is an example:
+
+@code
+static void onAction(void) {
+  // perform the action
+}
+
+void displayActionPage(void) {
+  nbgl_useCaseAction(&C_app_64px,
+                     "Connect to companion\napp to get started",
+                     "Open app",
+                     onAction);
+}
+@endcode
+
 @subsection use_case_status Status Use Case
 
 \image{inline} html UseCase-Nano-Status.png "caption" width=600
 
-A status is a transient page, without control, to display during a short time, for example when a transaction is successfully signed.
-The @ref nbgl_useCaseStatus() function enables to create such a page, with the following arguments:
+A status is a transient page, without control, to display during a short time, for example when a
+transaction is successfully signed.
+The @ref nbgl_useCaseStatus() function enables to create such a page, with the following
+arguments:
 
 - A message string to set in middle of page
 - A boolean to indicate if true (to determine the icon)
@@ -296,8 +415,10 @@ The @ref nbgl_useCaseStatus() function enables to create such a page, with the f
 
 \image{inline} html UseCase-Nano-Review-Status.png "caption" width=600
 
-Similar as @subpage use_case_status, this is used to display transient page, without control, during a short time, for example when a transaction is successfully signed.
-The @ref nbgl_useCaseReviewStatus() function enables to create such a page, with the following arguments:
+Similar as @ref use_case_status, this is used to display transient page, without control, during a
+short time, for example when a transaction is successfully signed.
+The @ref nbgl_useCaseReviewStatus() function enables to create such a page, with the following
+arguments:
 
 - A type of status (with predefined message and icon)
 - A quit callback, called when timer times out (or both buttons are pressed)
@@ -308,19 +429,23 @@ The @ref nbgl_useCaseReviewStatus() function enables to create such a page, with
 
 In most cases, the developer may know all tag/value pairs of a transaction when it is submitted.
 
-Thus, the number of pages is computed automatically and pages can be navigated forward and backward.
+Thus, the number of pages is computed automatically and pages can be navigated forward and
+backward.
 
-@note In case of a tag/value pair too long to be fully displayed, the value is automatically split on successive pages, adding an indication `(n/m)` in the name.
+@note In case of a tag/value pair too long to be fully displayed, the value is automatically split
+on successive pages, adding an indication `(n/m)` in the name.
 
 At the end of the review flow, the user has 2 pages to *Approve* or *Reject* the transaction.
-Finally, the given callback is called and it's up to app's developer to call @ref nbgl_useCaseReviewStatus().
+Finally, the given callback is called and it's up to app's developer to call
+@ref nbgl_useCaseReviewStatus().
 
 The API to initiate the display of the series of pages is @ref nbgl_useCaseReview(), providing:
 
 - The type of operation to review (*transaction*, *message* or generic *operation*)
 - The title and icon for the presentation page
 - The list of tag/value pairs (or a callback to get them one by one)
-- A callback called when the review is *Approved* or *Rejected*. The callback's param is *true* for approval, *false* for rejection.
+- A callback called when the review is *Approved* or *Rejected*. The callback's param is *true*
+  for approval, *false* for rejection.
 
 Here is the code to display something similar to example picture:
 
@@ -422,41 +547,223 @@ void startReview(void) {
 
 Not really useful on Nano devices, and thus, directly mapped to @subpage use_case_review.
 
+@subsection use_case_review_blind_signing Blind Signing Review Use Case
+
+A blind-signing review behaves exactly like @ref use_case_review, but the review is automatically
+preceded by a mandatory blind-signing warning page.
+
+@note On Nano devices, the optional tip-box parameter is ignored.
+
+The API to initiate the display is @ref nbgl_useCaseReviewBlindSigning(), providing:
+
+- the type of operation to review (transaction, message or generic operation)
+- the list of tag/value pairs (or a callback to get them one by one)
+- the icon to use on the first and last pages
+- the title and optional sub-title of the first page
+- the title of the last page (with the approve/reject pages)
+- an optional tip-box (@ref nbgl_tipBox_t) — ignored on Nano
+- a callback called when the review is *Approved* or *Rejected*. The callback's param is *true*
+  for confirmation, *false* for rejection.
+
+Here is a minimal example:
+
+@code
+// 4 pairs of tag/value to display
+static nbgl_layoutTagValue_t pairs[4];
+
+static const nbgl_contentTagValueList_t pairList = {
+  .nbMaxLinesForValue = 0,
+  .nbPairs = 4,
+  .pairs = (nbgl_layoutTagValue_t*)pairs
+};
+
+// called when review is approved or rejected
+static void onReviewResult(bool confirm) {
+  if (confirm) {
+    nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_SIGNED, appMain);
+  }
+  else {
+    nbgl_useCaseReviewStatus(STATUS_TYPE_TRANSACTION_REJECTED, appMain);
+  }
+}
+
+void startBlindSigningReview(void) {
+  nbgl_useCaseReviewBlindSigning(TYPE_TRANSACTION, // type of operation
+                                 &pairList,         // list of tag/value pairs
+                                 coinIcon,           // icon on first and last pages
+                                 "Review transaction\nto send coin", // title of first page
+                                 NULL,               // no sub-title
+                                 "Sign transaction to\nsend coin?",  // title of last page
+                                 NULL,               // no tip-box (ignored on Nano)
+                                 onReviewResult);    // callback on result
+}
+@endcode
+
+@subsection use_case_generic_review Generic Review Use Case
+
+A generic review displays a flow of pages built from a @ref nbgl_genericContents_t list. Unlike
+@ref use_case_review, the developer is responsible for building every page explicitly; NBGL handles
+pagination and navigation automatically.
+
+The API is @ref nbgl_useCaseGenericReview(), providing:
+
+- the generic contents list to display
+- the text to use in the reject page
+- a callback called when the reject page is confirmed
+
+Here is a minimal example:
+
+@code
+static const nbgl_content_t contentsList[1] = {
+  {.type = TAG_VALUE_LIST,
+   .content.tagValueList = { .nbPairs = 2,
+                              .pairs   = myPairs }}
+};
+
+static const nbgl_genericContents_t reviewContents = {
+  .contentsList = contentsList,
+  .nbContents   = 1
+};
+
+static void onReject(void) {
+  nbgl_useCaseReviewStatus(STATUS_TYPE_OPERATION_REJECTED, appMain);
+}
+
+void startGenericReview(void) {
+  nbgl_useCaseGenericReview(&reviewContents,
+                             "Reject",
+                             onReject);
+}
+@endcode
+
+@subsection use_case_generic_configuration Generic Configuration Use Case
+
+Displays a set of configuration pages with automatic pagination. The user can navigate with the
+physical buttons and quit by pressing both buttons on the last page.
+
+The API is @ref nbgl_useCaseGenericConfiguration(), providing:
+
+- the title string displayed in the header
+- the page index to start on (0-based)
+- the generic contents list to display
+- a callback called when the quit action is triggered
+
+Here is a minimal example:
+
+@code
+static const nbgl_content_t confContentsList[1] = {
+  {.type = SWITCHES_LIST,
+   .content.switchesList = { .nbSwitches = 2,
+                              .switches   = mySwitches },
+   .contentActionCallback = onSwitchToggle}
+};
+
+static const nbgl_genericContents_t confContents = {
+  .contentsList = confContentsList,
+  .nbContents   = 1
+};
+
+static void onQuit(void) {
+  appMain();
+}
+
+void startConfiguration(void) {
+  nbgl_useCaseGenericConfiguration("My Configuration",
+                                   0,               // start on first page
+                                   &confContents,
+                                   onQuit);
+}
+@endcode
+
+@subsection use_case_generic_settings Generic Settings Use Case
+
+Like @ref use_case_home_settings but without the home page: only the settings contents and the
+app-info pages are displayed. This is useful for sub-setting screens that must be reachable
+without going through the home page.
+
+The API is @ref nbgl_useCaseGenericSettings(), providing:
+
+- the app name (used as page title)
+- the page index to start on (0-based)
+- the settings contents (can be NULL if only info pages are needed)
+- the info list (version, developer, …)
+- a callback called when the quit action is triggered
+
+Here is a minimal example:
+
+@code
+static const char *infoTypes[]    = {"Version", "Developer"};
+static const char *infoContents[] = {"1.0.0", "Ledger"};
+
+static const nbgl_contentInfoList_t eth_infosList = {
+  .nbInfos       = 2,
+  .infoTypes     = infoTypes,
+  .infoContents  = infoContents
+};
+
+static void onQuit(void) {
+  appMain();
+}
+
+void displaySettings(uint8_t settingPage) {
+  nbgl_useCaseGenericSettings("Ethereum",
+                              settingPage,
+                              &eth_settingContents, // defined elsewhere
+                              &eth_infosList,
+                              onQuit);
+}
+@endcode
+
 @subsection use_case_review_streaming Streaming review Use Case
 
 \image{inline} html UseCase-Nano-Streaming.png "caption" width=1000
 
-In some cases, the application cannot know all tag/value pairs of a transaction when the review is started.
+In some cases, the application cannot know all tag/value pairs of a transaction when the review is
+started.
 
-In this case, what we call a *streaming* review can be used. The pages to display for each *stream* are computed automatically
-and pages can be navigated forward and backward.
+In this case, what we call a *streaming* review can be used. The pages to display for each
+*stream* are computed automatically and pages can be navigated forward and backward.
 
 In case of a tag/value pair too long to be fully displayed, the value is automatically split on
 successive pages, adding an indication `(n/m)` in the name.
 
 At the end of the review flow, the user has 2 pages to *Approve* or *Reject* the transaction.
-Finally, the given callback is called and it's up to app's developer to call @ref nbgl_useCaseReviewStatus().
+Finally, the given callback is called and it's up to app's developer to call
+@ref nbgl_useCaseReviewStatus().
 
-The API to initiate the display of the series of pages is @ref nbgl_useCaseReviewStreamingStart(), providing:
+The API to initiate the display of the series of pages is @ref nbgl_useCaseReviewStreamingStart(),
+providing:
 
 - The type of operation to review (transaction, message or generic operation)
 - The title and icon for the presentation page
 - A callback with one boolean parameter:
   - If this parameter is *false*, it means that the transaction is rejected.
-  - If this parameter is *true*, it means that NBGL is waiting for new data, sent with @ref nbgl_useCaseReviewStreamingContinue()
+  - If this parameter is *true*, it means that NBGL is waiting for new data, sent with
+    @ref nbgl_useCaseReviewStreamingContinue()
 
-As long as there are new tag/value pairs to send, the API to call is @ref nbgl_useCaseReviewStreamingContinue(), providing:
+As long as there are new tag/value pairs to send, the API to call is
+@ref nbgl_useCaseReviewStreamingContinue(), providing:
 
 - The list of tag/value pairs (or a callback to get them one by one)
 - A callback with one boolean parameter:
   - If this parameter is *false*, it means that the transaction is rejected.
-  - If this parameter is *true*, it means that NBGL is waiting for new data, to be sent with @ref nbgl_useCaseReviewStreamingContinue()
+  - If this parameter is *true*, it means that NBGL is waiting for new data, to be sent with
+    @ref nbgl_useCaseReviewStreamingContinue()
 
-@note Considering *skip* is not available on Nano device, @ref nbgl_useCaseReviewStreamingContinueExt() is useless and directly mapped to @ref nbgl_useCaseReviewStreamingContinue()
+@note Considering *skip* is not available on Nano device,
+@ref nbgl_useCaseReviewStreamingContinueExt() is useless and directly mapped to
+@ref nbgl_useCaseReviewStreamingContinue()
 
-When there is no more data to send, the API to call is @ref nbgl_useCaseReviewStreamingFinish(), providing:
+When there is no more data to send, the API to call is
+@ref nbgl_useCaseReviewStreamingFinish(), providing:
 
-- A callback called when the review is *Approved* or *Rejected*. The callback's param is *true* for approval, *false* for rejection.
+- A callback called when the review is *Approved* or *Rejected*. The callback's param is *true*
+  for approval, *false* for rejection.
+
+@ref nbgl_useCaseReviewStreamingBlindSigningStart() and
+@ref nbgl_useCaseAdvancedReviewStreamingStart() behave like
+@ref nbgl_useCaseReviewStreamingStart() but automatically prepend a warning page before the first
+stream. The continuation and finish APIs are the same.
 
 Here is the code to display something similar to example picture:
 
@@ -509,16 +816,20 @@ The review itself behaves like in @subpage use_case_review. The main differences
 
 - The review itself is preceded by a warning page
 
-The API to initiate the display of the series of pages is @ref nbgl_useCaseAdvancedReview(), providing:
+The API to initiate the display of the series of pages is @ref nbgl_useCaseAdvancedReview(),
+providing:
 
 - the type of operation to review (transaction, message or generic operation)
 - the list of tag/value pairs (or a callback to get them one by one)
 - the texts/icon to use in presentation page and in last page
 - the configuration to use for the warning (see @ref nbgl_warning_t structure)
-- a callback called when the long press button on last page or reject confirmation is used. The callback's param is *true* for confirmation, *false* for rejection.
+- a callback called when the long press button on last page or reject confirmation is used.
+  The callback's param is *true* for confirmation, *false* for rejection.
 
-@note the recommended configuration for warning is the predefined one. In this case, one just has to fill the *predefinedSet* field of @ref nbgl_warning_t with the appropriate warning
-causes (bitfield) and the *reportProvider* field with the name of the 3rd party providing the Web3Checks report, if necessary.
+@note the recommended configuration for warning is the predefined one. In this case, one just has
+to fill the *predefinedSet* field of @ref nbgl_warning_t with the appropriate warning causes
+(bitfield) and the *reportProvider* field with the name of the 3rd party providing the Web3Checks
+report, if necessary.
 
 Here is a code sample:
 
@@ -570,15 +881,19 @@ When an address needs to be confirmed, it can be displayed in a Address Review U
 
 After a title page, a second page is displayed with the raw address (as text).
 
-Moreover, if extra information need to be displayed, in the form of tags/values, they are show in successive pages.
+Moreover, if extra information need to be displayed, in the form of tags/values, they are show in
+successive pages.
 
-@note In case of a tag/value pair too long to be fully displayed, the value is automatically split on successive pages, adding an indication `(n/m)` in the name.
+@note In case of a tag/value pair too long to be fully displayed, the value is automatically split
+on successive pages, adding an indication `(n/m)` in the name.
 
 
 At the end of the review flow, the user has 2 pages to *Approve* or *Reject* the review.
-Finally, the given callback is called and it's up to app's developer to call @ref nbgl_useCaseReviewStatus().
+Finally, the given callback is called and it's up to app's developer to call
+@ref nbgl_useCaseReviewStatus().
 
-The @ref nbgl_useCaseAddressReview() function enables to create such a set of pages, with the following parameters:
+The @ref nbgl_useCaseAddressReview() function enables to create such a set of pages, with the
+following parameters:
 
 - The address to confirm (NULL terminated string)
 - A callback called when the review is *Approved* or *Rejected*
@@ -681,18 +996,21 @@ void ui_menu_pinentry_display(unsigned int value) {
 @subsection use_case_keyboard Keyboard Use Case
 
 When text input is required (not just digits), a full keyboard can be displayed on Nano devices.
-The keyboard is navigable using the physical buttons, and supports different modes (lowercase, uppercase, digits, special characters).
+The keyboard is navigable using the physical buttons, and supports different modes (lowercase,
+uppercase, digits, special characters).
 
 The keyboard can be configured with either a confirmation button or dynamic suggestion buttons.
 
-The @ref nbgl_useCaseKeyboard() function enables to create such page, with the following parameters:
+The @ref nbgl_useCaseKeyboard() function enables to create such page, with the following
+parameters:
 
 - A pointer to @ref nbgl_keyboardParams_t structure containing:
   - \b type: either @ref KEYBOARD_WITH_BUTTON or @ref KEYBOARD_WITH_SUGGESTIONS
   - \b title: the page title
   - \b entryBuffer: buffer to store the entered text
   - \b entryMaxLen: maximum length of text
-  - \b mode: initial keyboard mode (@ref MODE_LOWER_LETTERS, @ref MODE_UPPER_LETTERS, @ref MODE_DIGITS_AND_SPECIALS, @ref MODE_NONE)
+  - \b mode: initial keyboard mode (@ref MODE_LOWER_LETTERS, @ref MODE_UPPER_LETTERS,
+    @ref MODE_DIGITS_AND_SPECIALS, @ref MODE_NONE)
   - \b lettersOnly: if true, only letter keys and Backspace are shown
   - \b confirmationParams or \b suggestionParams: depending on the type
 - A callback for the back action
@@ -820,10 +1138,42 @@ void display_keyboard_page(void) {
 }
 @endcode
 
+@section use_case_utils Utility functions
+
+The following functions compute how many items of a given type fit in a single review or settings
+page. They are useful when building custom paginated content with @ref nbgl_useCaseGenericReview()
+or similar APIs.
+
+- @ref nbgl_useCaseGetNbTagValuesInPage() — returns the number of tag/value pairs that fit in one
+  page starting at a given index. Sets the *requireSpecificDisplay* output flag when the pair needs
+  special rendering (centeredInfo flag or value too long).
+
+- @ref nbgl_useCaseGetNbTagValuesInPageExt() — same as above but also accounts for a potential
+  *skip* header when *isSkippable* is true.
+
+- @ref nbgl_useCaseGetNbInfosInPage() — returns the number of info items (type/content string
+  pairs) that fit in one page starting at a given index.
+
+- @ref nbgl_useCaseGetNbSwitchesInPage() — returns the number of switch items that fit in one
+  page starting at a given index.
+
+- @ref nbgl_useCaseGetNbBarsInPage() — returns the number of touchable bar items that fit in one
+  page starting at a given index.
+
+- @ref nbgl_useCaseGetNbChoicesInPage() — returns the number of radio-choice items that fit in
+  one page starting at a given index.
+
+- @ref nbgl_useCaseGetNbPagesForTagValueList() — returns the total number of pages required to
+  display a complete @ref nbgl_contentTagValueList_t. Useful to pre-compute navigation structures
+  before starting a review.
+
+All functions take the navigation bar into account: when a navigation footer is present the
+available area is reduced accordingly.
+
 @section use_case_refresh_page Refreshing screen
 
-After having drawn graphic objects in **framebuffer**, all functions of this API automatically refresh the screen.
-So no need to call @ref nbgl_refresh().
+After having drawn graphic objects in **framebuffer**, all functions of this API automatically
+refresh the screen. So no need to call @ref nbgl_refresh().
 
 */
 #endif // HAVE_SE_TOUCH

--- a/lib_nbgl/src/nbgl_flow.c
+++ b/lib_nbgl/src/nbgl_flow.c
@@ -136,6 +136,7 @@ static void actionCallback(nbgl_step_t stepCtx, nbgl_buttonEvent_t event)
     FlowContext_t      *ctx = getContextFromStepCtx(stepCtx);
 
     if (!ctx) {
+        LOG_WARN(FLOW_LOGGER, "actionCallback(): ctx not found\n");
         return;
     }
     LOG_DEBUG(FLOW_LOGGER, "actionCallback: event = 0x%X, step = %d\n", event, ctx->curStep);
@@ -208,6 +209,7 @@ nbgl_flow_t nbgl_flowDraw(const nbgl_stepDesc_t *steps,
     FlowContext_t      *ctx = getFreeContext(modal);
 
     if (!ctx) {
+        LOG_WARN(FLOW_LOGGER, "nbgl_flowDraw(): no free context\n");
         return NULL;
     }
 

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -2651,37 +2651,35 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
                                               ? headerDesc->extendedBack.backToken
                                               : headerDesc->backAndText.token;
             nbgl_button_t *actionButton = NULL;
-            // add back button
-            button = (nbgl_button_t *) nbgl_objPoolGet(BUTTON, layoutInt->layer);
-            // only make it active if valid token
+            // add back button only if token is valid
             if (backToken != NBGL_INVALID_TOKEN) {
-                obj = layoutAddCallbackObj(layoutInt,
+                button = (nbgl_button_t *) nbgl_objPoolGet(BUTTON, layoutInt->layer);
+                obj    = layoutAddCallbackObj(layoutInt,
                                            (nbgl_obj_t *) button,
                                            backToken,
                                            (headerDesc->type == HEADER_EXTENDED_BACK)
-                                               ? headerDesc->extendedBack.tuneId
-                                               : headerDesc->backAndText.tuneId);
+                                                  ? headerDesc->extendedBack.tuneId
+                                                  : headerDesc->backAndText.tuneId);
                 if (obj == NULL) {
                     LOG_WARN(LAYOUT_LOGGER,
                              "nbgl_layoutAddHeader(): no more callback obj for type %d\n",
                              headerDesc->type);
                     return -1;
                 }
+                button->obj.alignment   = MID_LEFT;
+                button->innerColor      = WHITE;
+                button->foregroundColor = BLACK;
+                button->borderColor     = WHITE;
+                button->obj.area.width  = BACK_KEY_WIDTH;
+                button->obj.area.height = TOUCHABLE_HEADER_BAR_HEIGHT;
+                button->text            = NULL;
+                button->icon            = PIC(&LEFT_ARROW_ICON);
+                button->obj.touchMask   = (1 << TOUCHED);
+                button->obj.touchId     = BACK_BUTTON_ID;
+                layoutInt->headerContainer->children[layoutInt->headerContainer->nbChildren]
+                    = (nbgl_obj_t *) button;
+                layoutInt->headerContainer->nbChildren++;
             }
-
-            button->obj.alignment   = MID_LEFT;
-            button->innerColor      = WHITE;
-            button->foregroundColor = (backToken != NBGL_INVALID_TOKEN) ? BLACK : WHITE;
-            button->borderColor     = WHITE;
-            button->obj.area.width  = BACK_KEY_WIDTH;
-            button->obj.area.height = TOUCHABLE_HEADER_BAR_HEIGHT;
-            button->text            = NULL;
-            button->icon            = PIC(&LEFT_ARROW_ICON);
-            button->obj.touchMask   = (backToken != NBGL_INVALID_TOKEN) ? (1 << TOUCHED) : 0;
-            button->obj.touchId     = BACK_BUTTON_ID;
-            layoutInt->headerContainer->children[layoutInt->headerContainer->nbChildren]
-                = (nbgl_obj_t *) button;
-            layoutInt->headerContainer->nbChildren++;
 
             // add optional text if needed
             if (text != NULL) {

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -2115,6 +2115,10 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
     if (layout == NULL) {
         return -1;
     }
+    if ((list->pairs == NULL) && (list->callback == NULL)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddTagValueList(): pairs and callback are both NULL\n");
+        return -1;
+    }
 
     for (i = 0; i < list->nbPairs; i++) {
         const nbgl_layoutTagValue_t *pair;
@@ -2130,6 +2134,12 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
         }
         else {
             pair = list->callback(list->startIndex + i);
+            if (pair == NULL) {
+                LOG_WARN(LAYOUT_LOGGER,
+                         "nbgl_layoutAddTagValueList(): callback returned NULL for index %d\n",
+                         i);
+                return -1;
+            }
         }
 
         container = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
@@ -2139,7 +2149,8 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
         if ((pair->valueIcon != NULL) || pair->aliasValue) {
             nbChildren++;
             // if it's a alias with a subName, add a child
-            if ((pair->aliasValue) && (pair->extension->aliasSubName)) {
+            if ((pair->aliasValue) && (pair->extension != NULL)
+                && (pair->extension->aliasSubName)) {
                 nbChildren++;
             }
         }
@@ -2237,7 +2248,8 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
             container->nbChildren++;
 
             // if an aliasSubName is provided, display it under value
-            if ((pair->aliasValue) && (pair->extension->aliasSubName)) {
+            if ((pair->aliasValue) && (pair->extension != NULL)
+                && (pair->extension->aliasSubName)) {
                 nbgl_text_area_t *textArea
                     = (nbgl_text_area_t *) nbgl_objPoolGet(TEXT_AREA, layoutInt->layer);
                 textArea->textColor            = BLACK;
@@ -2621,7 +2633,7 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
     layoutInt->headerContainer->obj.area.width = SCREEN_WIDTH;
     layoutInt->headerContainer->layout         = VERTICAL;
     layoutInt->headerContainer->children
-        = (nbgl_obj_t **) nbgl_containerPoolGet(5, layoutInt->layer);
+        = (nbgl_obj_t **) nbgl_containerPoolGet(6, layoutInt->layer);
     layoutInt->headerContainer->obj.alignment = TOP_MIDDLE;
 
     switch (headerDesc->type) {
@@ -2759,7 +2771,7 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
 
                 actionButton->obj.alignment = MID_RIGHT;
                 actionButton->innerColor    = WHITE;
-                button->foregroundColor
+                actionButton->foregroundColor
                     = (headerDesc->extendedBack.actionToken != NBGL_INVALID_TOKEN) ? BLACK
                                                                                    : LIGHT_GRAY;
                 actionButton->borderColor     = WHITE;

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -270,6 +270,7 @@ static void touchCallback(nbgl_obj_t *obj, nbgl_touchType_t eventType)
     bool                   needRefresh = false;
 
     if (obj == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "touchCallback(): obj not found\n");
         return;
     }
     LOG_DEBUG(LAYOUT_LOGGER, "touchCallback(): eventType = %d, obj = %p\n", eventType, obj);
@@ -652,10 +653,12 @@ layoutObj_t *layoutAddCallbackObj(nbgl_layoutInternal_t *layout,
 void layoutUpdateCallbackObjToken(nbgl_layoutInternal_t *layout, nbgl_obj_t *obj, uint8_t token)
 {
     if (layout == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "layoutUpdateCallbackObjToken(): layout is NULL\n");
         return;
     }
 
     if (obj == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "layoutUpdateCallbackObjToken(): obj is NULL\n");
         return;
     }
 
@@ -702,11 +705,13 @@ static int addSwipeInternal(nbgl_layoutInternal_t *layoutInt,
     layoutObj_t *obj;
 
     if ((swipesMask & SWIPE_MASK) == 0) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddSwipe(): invalid swipesMask 0x%x\n", swipesMask);
         return -1;
     }
 
     obj = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) layoutInt->container, token, tuneId);
     if (obj == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddSwipe(): no more callback obj\n");
         return -1;
     }
     layoutInt->container->obj.touchMask = swipesMask;
@@ -750,6 +755,7 @@ static nbgl_container_t *addListItem(nbgl_layoutInternal_t *layoutInt, const lis
     obj       = layoutAddCallbackObj(
         layoutInt, (nbgl_obj_t *) container, itemDesc->token, itemDesc->tuneId);
     if (obj == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "addListItem(): no more callback obj\n");
         return NULL;
     }
     obj->index = itemDesc->index;
@@ -1299,6 +1305,7 @@ int nbgl_layoutAddTopRightButton(nbgl_layout_t             *layout,
     button = (nbgl_button_t *) nbgl_objPoolGet(BUTTON, layoutInt->layer);
     obj    = layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) button, token, tuneId);
     if (obj == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddTopRightButton(): no more callback obj\n");
         return -1;
     }
 
@@ -1404,6 +1411,7 @@ int nbgl_layoutAddTouchableBar(nbgl_layout_t *layout, const nbgl_layoutBar_t *ba
     container          = addListItem(layoutInt, &itemDesc);
 
     if (container == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddTouchableBar(): addListItem failed\n");
         return -1;
     }
     return container->obj.area.height;
@@ -1440,6 +1448,7 @@ int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switc
     container        = addListItem(layoutInt, &itemDesc);
 
     if (container == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddSwitch(): addListItem failed\n");
         return -1;
     }
     return container->obj.area.height;
@@ -1472,6 +1481,7 @@ int nbgl_layoutAddText(nbgl_layout_t *layout, const char *text, const char *subT
     container        = addListItem(layoutInt, &itemDesc);
 
     if (container == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddText(): addListItem failed\n");
         return -1;
     }
     return container->obj.area.height;
@@ -1513,6 +1523,7 @@ int nbgl_layoutAddTextWithAlias(nbgl_layout_t *layout,
     container          = addListItem(layoutInt, &itemDesc);
 
     if (container == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddTextWithAlias(): addListItem failed\n");
         return -1;
     }
     return container->obj.area.height;
@@ -1674,6 +1685,7 @@ int nbgl_layoutAddRadioChoice(nbgl_layout_t *layout, const nbgl_layoutRadioChoic
         obj = layoutAddCallbackObj(
             layoutInt, (nbgl_obj_t *) container, choices->token, choices->tuneId);
         if (obj == NULL) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddRadioChoice(): no more callback obj\n");
             return -1;
         }
 
@@ -2446,6 +2458,7 @@ int nbgl_layoutAddButton(nbgl_layout_t *layout, const nbgl_layoutButton_t *butto
     obj    = layoutAddCallbackObj(
         layoutInt, (nbgl_obj_t *) button, buttonInfo->token, buttonInfo->tuneId);
     if (obj == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddButton(): no more callback obj\n");
         return -1;
     }
 
@@ -2637,6 +2650,9 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
                                                ? headerDesc->extendedBack.tuneId
                                                : headerDesc->backAndText.tuneId);
                 if (obj == NULL) {
+                    LOG_WARN(LAYOUT_LOGGER,
+                             "nbgl_layoutAddHeader(): no more callback obj for type %d\n",
+                             headerDesc->type);
                     return -1;
                 }
             }
@@ -2675,6 +2691,9 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
                                                headerDesc->extendedBack.textToken,
                                                headerDesc->extendedBack.tuneId);
                     if (obj == NULL) {
+                        LOG_WARN(LAYOUT_LOGGER,
+                                 "nbgl_layoutAddHeader(): no more callback obj for type %d\n",
+                                 headerDesc->type);
                         return -1;
                     }
                     textArea->obj.touchMask = (1 << TOUCHED);
@@ -2730,6 +2749,9 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
                                                headerDesc->extendedBack.actionToken,
                                                headerDesc->extendedBack.tuneId);
                     if (obj == NULL) {
+                        LOG_WARN(LAYOUT_LOGGER,
+                                 "nbgl_layoutAddHeader(): no more callback obj for type %d\n",
+                                 headerDesc->type);
                         return -1;
                     }
                     actionButton->obj.touchMask = (1 << TOUCHED);
@@ -2809,6 +2831,9 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
                                            headerDesc->progressAndBack.token,
                                            headerDesc->progressAndBack.tuneId);
                 if (obj == NULL) {
+                    LOG_WARN(LAYOUT_LOGGER,
+                             "nbgl_layoutAddHeader(): no more callback obj for type %d\n",
+                             headerDesc->type);
                     return -1;
                 }
 
@@ -2872,6 +2897,9 @@ int nbgl_layoutAddHeader(nbgl_layout_t *layout, const nbgl_layoutHeader_t *heade
                                        headerDesc->rightText.token,
                                        headerDesc->rightText.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER,
+                         "nbgl_layoutAddHeader(): no more callback obj for type %d\n",
+                         headerDesc->type);
                 return -1;
             }
             textArea->obj.alignment        = MID_RIGHT;
@@ -2958,6 +2986,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->simpleText.token,
                                        footerDesc->simpleText.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
 
@@ -2985,6 +3014,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->doubleText.leftToken,
                                        footerDesc->doubleText.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
             textArea->obj.alignment   = BOTTOM_LEFT;
@@ -3008,6 +3038,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->doubleText.rightToken,
                                        footerDesc->doubleText.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
 
@@ -3047,6 +3078,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->textAndNav.token,
                                        footerDesc->textAndNav.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
             textArea->obj.alignment   = BOTTOM_LEFT;
@@ -3080,6 +3112,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->textAndNav.navigation.token,
                                        footerDesc->textAndNav.navigation.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
 
@@ -3112,6 +3145,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->navigation.token,
                                        footerDesc->navigation.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
 
@@ -3126,6 +3160,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->button.token,
                                        footerDesc->button.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
 
@@ -3175,6 +3210,8 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
             // texts cannot be NULL
             if ((footerDesc->choiceButtons.bottomText == NULL)
                 || (footerDesc->choiceButtons.topText == NULL)) {
+                LOG_WARN(LAYOUT_LOGGER,
+                         "nbgl_layoutAddFooter(): FOOTER_CHOICE_BUTTONS texts cannot be NULL\n");
                 return -1;
             }
 
@@ -3185,6 +3222,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->choiceButtons.token,
                                        footerDesc->choiceButtons.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
             // associate with with index 1
@@ -3234,6 +3272,7 @@ int nbgl_layoutAddExtendedFooter(nbgl_layout_t *layout, const nbgl_layoutFooter_
                                        footerDesc->choiceButtons.token,
                                        footerDesc->choiceButtons.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddFooter(): no more callback obj\n");
                 return -1;
             }
             // associate with with index 0
@@ -3369,6 +3408,7 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
                                        upFooterDesc->longPress.token,
                                        upFooterDesc->longPress.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddUpFooter(): no more callback obj\n");
                 return -1;
             }
             layoutInt->upFooterContainer->nbChildren      = 4;
@@ -3425,6 +3465,7 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
                                        upFooterDesc->button.token,
                                        upFooterDesc->button.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddUpFooter(): no more callback obj\n");
                 return -1;
             }
 
@@ -3468,6 +3509,9 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
             // icon & text cannot be NULL
             if ((upFooterDesc->horizontalButtons.leftIcon == NULL)
                 || (upFooterDesc->horizontalButtons.rightText == NULL)) {
+                LOG_WARN(LAYOUT_LOGGER,
+                         "nbgl_layoutAddUpFooter(): UP_FOOTER_HORIZONTAL_BUTTONS fields cannot be "
+                         "NULL\n");
                 return -1;
             }
 
@@ -3481,6 +3525,7 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
                                        upFooterDesc->horizontalButtons.leftToken,
                                        upFooterDesc->horizontalButtons.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddUpFooter(): no more callback obj\n");
                 return -1;
             }
             // associate with with index 1
@@ -3506,6 +3551,7 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
                                        upFooterDesc->horizontalButtons.rightToken,
                                        upFooterDesc->horizontalButtons.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddUpFooter(): no more callback obj\n");
                 return -1;
             }
             // associate with with index 0
@@ -3528,6 +3574,8 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
         case UP_FOOTER_TIP_BOX: {
             // text cannot be NULL
             if (upFooterDesc->tipBox.text == NULL) {
+                LOG_WARN(LAYOUT_LOGGER,
+                         "nbgl_layoutAddUpFooter(): UP_FOOTER_TIP_BOX text cannot be NULL\n");
                 return -1;
             }
             obj = layoutAddCallbackObj(layoutInt,
@@ -3535,6 +3583,7 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
                                        upFooterDesc->tipBox.token,
                                        upFooterDesc->tipBox.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddUpFooter(): no more callback obj\n");
                 return -1;
             }
             layoutInt->upFooterContainer->nbChildren    = 3;
@@ -3585,6 +3634,7 @@ int nbgl_layoutAddUpFooter(nbgl_layout_t *layout, const nbgl_layoutUpFooter_t *u
                                        upFooterDesc->text.token,
                                        upFooterDesc->text.tuneId);
             if (obj == NULL) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddUpFooter(): no more callback obj\n");
                 return -1;
             }
             layoutInt->upFooterContainer->nbChildren      = 1;
@@ -3791,11 +3841,15 @@ int nbgl_layoutUpdateSpinner(nbgl_layout_t *layout,
 
     container = (nbgl_container_t *) layoutInt->container->children[0];
     if ((container->obj.type != CONTAINER) || (container->nbChildren < 2)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateSpinner(): unexpected container state\n");
         return -1;
     }
 
     spinner = (nbgl_spinner_t *) container->children[0];
     if (spinner->obj.type != SPINNER) {
+        LOG_WARN(LAYOUT_LOGGER,
+                 "nbgl_layoutUpdateSpinner(): expected SPINNER, got type %d\n",
+                 spinner->obj.type);
         return -1;
     }
     // if position is different, redraw
@@ -3808,6 +3862,9 @@ int nbgl_layoutUpdateSpinner(nbgl_layout_t *layout,
     // update text area if necessary
     textArea = (nbgl_text_area_t *) container->children[1];
     if (textArea->obj.type != TEXT_AREA) {
+        LOG_WARN(LAYOUT_LOGGER,
+                 "nbgl_layoutUpdateSpinner(): expected TEXT_AREA, got type %d\n",
+                 textArea->obj.type);
         return -1;
     }
     const char *newText    = PIC(text);
@@ -3823,10 +3880,16 @@ int nbgl_layoutUpdateSpinner(nbgl_layout_t *layout,
         nbgl_text_area_t *subTextArea;
 
         if (container->nbChildren != 3) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutUpdateSpinner(): expected 3 children for subText, got %d\n",
+                     container->nbChildren);
             return -1;
         }
         subTextArea = (nbgl_text_area_t *) container->children[2];
         if (subTextArea->obj.type != TEXT_AREA) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutUpdateSpinner(): expected TEXT_AREA for subText, got type %d\n",
+                     subTextArea->obj.type);
             return -1;
         }
         const char *newSubText    = PIC(subText);
@@ -3854,6 +3917,7 @@ int nbgl_layoutDraw(nbgl_layout_t *layoutParam)
     nbgl_layoutInternal_t *layout = (nbgl_layoutInternal_t *) layoutParam;
 
     if (layout == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutDraw(): layout is NULL\n");
         return -1;
     }
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutDraw(): layout->isUsed = %d\n", layout->isUsed);

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -1344,7 +1344,7 @@ int nbgl_layoutAddNavigationBar(nbgl_layout_t *layout, const nbgl_layoutNavigati
 
 /**
  * @brief Creates a centered button at bottom of main container
- * @brief incompatible with navigation bar
+ * @note incompatible with navigation bar
  *
  * @param layout the current layout
  * @param icon icon inside the round button

--- a/lib_nbgl/src/nbgl_layout.c
+++ b/lib_nbgl/src/nbgl_layout.c
@@ -2123,7 +2123,8 @@ int nbgl_layoutAddTagValueList(nbgl_layout_t *layout, const nbgl_layoutTagValueL
         container = (nbgl_container_t *) nbgl_objPoolGet(CONTAINER, layoutInt->layer);
 
         // tune container number of children (max 4 if a valueIcon and aliasSubName)
-        if (pair->valueIcon != NULL) {
+        // aliasValue also adds an icon (MINI_PUSH_ICON), so count it the same way
+        if ((pair->valueIcon != NULL) || pair->aliasValue) {
             nbChildren++;
             // if it's a alias with a subName, add a child
             if ((pair->aliasValue) && (pair->extension->aliasSubName)) {

--- a/lib_nbgl/src/nbgl_layout_keyboard.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard.c
@@ -584,6 +584,7 @@ int nbgl_layoutAddKeyboard(nbgl_layout_t *layout, const nbgl_layoutKbd_t *kbdInf
     }
     // footer must be empty
     if (layoutInt->footerContainer != NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddKeyboard(): footer already set\n");
         return -1;
     }
 
@@ -660,6 +661,8 @@ int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout,
     // get existing keyboard (in the footer container)
     keyboard = (nbgl_keyboard_t *) layoutInt->footerContainer->children[0];
     if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
+        LOG_WARN(
+            LAYOUT_LOGGER, "nbgl_layoutUpdateKeyboard(): keyboard not found at index %d\n", index);
         return -1;
     }
     keyboard->keyMask = keyMask;
@@ -693,6 +696,9 @@ bool nbgl_layoutKeyboardNeedsRefresh(nbgl_layout_t *layout, uint8_t index)
     // get existing keyboard (in the footer container)
     keyboard = (nbgl_keyboard_t *) layoutInt->footerContainer->children[0];
     if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
+        LOG_WARN(LAYOUT_LOGGER,
+                 "nbgl_layoutKeyboardNeedsRefresh(): keyboard not found at index %d\n",
+                 index);
         return -1;
     }
     if (keyboard->needsRefresh) {
@@ -809,10 +815,12 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
     // update text entry area
     container = (nbgl_container_t *) layoutInt->container->children[enteredTextIndex];
     if ((container == NULL) || (container->obj.type != CONTAINER)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): container not found\n");
         return -1;
     }
     textArea = (nbgl_text_area_t *) container->children[2];
     if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): text area not found\n");
         return -1;
     }
     textArea->text          = text;
@@ -906,6 +914,7 @@ int nbgl_layoutUpdateConfirmationButton(nbgl_layout_t *layout,
     // update main text area
     button = (nbgl_button_t *) layoutInt->container->children[enteredTextIndex + 1];
     if ((button == NULL) || (button->obj.type != BUTTON)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateConfirmationButton(): button not found\n");
         return -1;
     }
     button->text = text;
@@ -969,6 +978,8 @@ int nbgl_layoutAddKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardCont
         // the main container is swipable on Flex
         if (layoutAddCallbackObj(layoutInt, (nbgl_obj_t *) layoutInt->container, 0, NBGL_NO_TUNE)
             == NULL) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutAddKeyboardContent(): cannot add callback object\n");
             return -1;
         }
         layoutInt->container->obj.touchMask = (1 << SWIPED_LEFT) | (1 << SWIPED_RIGHT);
@@ -1095,6 +1106,7 @@ int nbgl_layoutUpdateKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardC
         // update main text area
         nbgl_button_t *button = (nbgl_button_t *) layoutInt->container->children[1];
         if ((button == NULL) || (button->obj.type != BUTTON)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeyboardContent(): button not found\n");
             return -1;
         }
         button->text = content->confirmationButton.text;

--- a/lib_nbgl/src/nbgl_layout_keyboard.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard.c
@@ -163,9 +163,8 @@ static bool updateSuggestionButtons(nbgl_layoutInternal_t *layoutInt,
     uint32_t       i           = 0;
     nbgl_button_t *button      = NULL;
 
-    if ((eventType == SWIPED_LEFT)
-        && (currentLeftButtonIndex
-            < (uint32_t) (nbActiveButtons - NB_MAX_VISIBLE_SUGGESTION_BUTTONS))) {
+    if ((eventType == SWIPED_LEFT) && (nbActiveButtons > NB_MAX_VISIBLE_SUGGESTION_BUTTONS)
+        && (currentLeftButtonIndex < (nbActiveButtons - NB_MAX_VISIBLE_SUGGESTION_BUTTONS))) {
         // shift all buttons on the left if there are still at least
         // NB_MAX_VISIBLE_SUGGESTION_BUTTONS buttons to display
         currentLeftButtonIndex += NB_MAX_VISIBLE_SUGGESTION_BUTTONS;
@@ -182,7 +181,7 @@ static bool updateSuggestionButtons(nbgl_layoutInternal_t *layoutInt,
             // Button to be updated
             button = (nbgl_button_t *) container->children[FIRST_BUTTON_INDEX + i];
 
-            if (currentLeftButtonIndex < (uint32_t) (nbActiveButtons - i)) {
+            if ((uint32_t) currentLeftButtonIndex + i < (uint32_t) nbActiveButtons) {
                 button->text = choiceTexts[currentLeftButtonIndex + i];
                 layoutUpdateCallbackObjToken(layoutInt,
                                              (nbgl_obj_t *) button,
@@ -262,7 +261,8 @@ static bool updateSuggestionButtons(nbgl_layoutInternal_t *layoutInt,
         container->children[LEFT_HALF_INDEX] = NULL;
     }
     // if not on the last button, display beginning of next button
-    if (currentLeftButtonIndex < (nbActiveButtons - NB_MAX_VISIBLE_SUGGESTION_BUTTONS)) {
+    if ((nbActiveButtons > NB_MAX_VISIBLE_SUGGESTION_BUTTONS)
+        && (currentLeftButtonIndex < (nbActiveButtons - NB_MAX_VISIBLE_SUGGESTION_BUTTONS))) {
         container->children[RIGHT_HALF_INDEX] = (nbgl_obj_t *) partialButtonImages[1];
     }
     else {

--- a/lib_nbgl/src/nbgl_layout_keyboard.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard.c
@@ -1067,7 +1067,16 @@ int nbgl_layoutUpdateKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardC
 
     // get top container from main container (it shall be the 1st object)
     mainContainer = (nbgl_container_t *) layoutInt->container->children[0];
-    container     = (nbgl_container_t *) mainContainer->children[1];
+    if ((mainContainer == NULL) || (mainContainer->obj.type != CONTAINER)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeyboardContent(): main container not found\n");
+        return -1;
+    }
+    container = (nbgl_container_t *) mainContainer->children[1];
+    if ((container == NULL) || (container->obj.type != CONTAINER)) {
+        LOG_WARN(LAYOUT_LOGGER,
+                 "nbgl_layoutUpdateKeyboardContent(): text entry container not found\n");
+        return -1;
+    }
 
     if (content->numbered) {
         // get Word number typed text
@@ -1102,6 +1111,11 @@ int nbgl_layoutUpdateKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardC
         nbActiveButtons = content->suggestionButtons.nbUsedButtons;
         nbgl_container_t *suggestionsContainer
             = (nbgl_container_t *) layoutInt->container->children[1];
+        if ((suggestionsContainer == NULL) || (suggestionsContainer->obj.type != CONTAINER)) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutUpdateKeyboardContent(): suggestions container not found\n");
+            return -1;
+        }
 
         // update suggestion texts
         for (i = 0; i < NB_MAX_SUGGESTION_BUTTONS; i++) {

--- a/lib_nbgl/src/nbgl_layout_keyboard.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard.c
@@ -749,6 +749,10 @@ int nbgl_layoutAddEnteredText(nbgl_layout_t *layout,
     UNUSED(grayedOut);
 
     container = addTextEntry(layoutInt, NULL, text, numbered, number, token, compactMode, false);
+    if (container == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddEnteredText(): addTextEntry failed\n");
+        return -1;
+    }
 
     // set this container as first or 2nd child of the main layout container
     layoutInt->container->children[enteredTextIndex] = (nbgl_obj_t *) container;
@@ -813,12 +817,21 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
     UNUSED(index);
 
     // update text entry area
-    container = (nbgl_container_t *) layoutInt->container->children[enteredTextIndex];
-    if ((container == NULL) || (container->obj.type != CONTAINER)) {
-        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): container not found\n");
+    // container->children[enteredTextIndex] is the mainContainer built by addTextEntry(),
+    // which has 2 children: [0]=title (optional) and [1]=inner text-entry container.
+    // The inner container holds NUMBER_INDEX, TEXT_INDEX, DELETE_INDEX, LINE_INDEX children.
+    nbgl_container_t *mainContainer
+        = (nbgl_container_t *) layoutInt->container->children[enteredTextIndex];
+    if ((mainContainer == NULL) || (mainContainer->obj.type != CONTAINER)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): main container not found\n");
         return -1;
     }
-    textArea = (nbgl_text_area_t *) container->children[2];
+    container = (nbgl_container_t *) mainContainer->children[1];
+    if ((container == NULL) || (container->obj.type != CONTAINER)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): text entry container not found\n");
+        return -1;
+    }
+    textArea = (nbgl_text_area_t *) container->children[TEXT_INDEX];
     if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
         LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): text area not found\n");
         return -1;
@@ -830,8 +843,11 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout,
 
     // update number text area
     if (numbered) {
-        // it is the previously created object
-        textArea = (nbgl_text_area_t *) layoutInt->container->children[1];
+        textArea = (nbgl_text_area_t *) container->children[NUMBER_INDEX];
+        if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): number area not found\n");
+            return -1;
+        }
         snprintf(numText, sizeof(numText), "%d.", number);
         textArea->text = numText;
         nbgl_objDraw((nbgl_obj_t *) textArea);
@@ -871,6 +887,11 @@ int nbgl_layoutAddConfirmationButton(nbgl_layout_t *layout,
     }
 
     button = addConfirmationButton(layoutInt, active, text, token, tuneId, compactMode);
+    if (button == NULL) {
+        LOG_WARN(LAYOUT_LOGGER,
+                 "nbgl_layoutAddConfirmationButton(): addConfirmationButton failed\n");
+        return -1;
+    }
     // set this button as second child of the main layout container
     layoutInt->container->children[enteredTextIndex + 1] = (nbgl_obj_t *) button;
     if (layoutInt->container->children[enteredTextIndex] != NULL) {
@@ -960,6 +981,10 @@ int nbgl_layoutAddKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardCont
                                       content->textToken,
                                       compactMode,
                                       content->obfuscated);
+    if (textEntryContainer == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddKeyboardContent(): addTextEntry failed\n");
+        return -1;
+    }
 
     // set this container as first child of the main layout container
     layoutInt->container->children[0] = (nbgl_obj_t *) textEntryContainer;
@@ -972,6 +997,11 @@ int nbgl_layoutAddKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardCont
                                    content->suggestionButtons.firstButtonToken,
                                    content->tuneId,
                                    content->obfuscated);
+        if (suggestionsContainer == NULL) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutAddKeyboardContent(): addSuggestionButtons failed\n");
+            return -1;
+        }
 
         // set this container as second child of the main layout container
         layoutInt->container->children[1] = (nbgl_obj_t *) suggestionsContainer;
@@ -997,6 +1027,11 @@ int nbgl_layoutAddKeyboardContent(nbgl_layout_t *layout, nbgl_layoutKeyboardCont
                                                       content->confirmationButton.token,
                                                       content->tuneId,
                                                       (content->title != NULL));
+        if (button == NULL) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutAddKeyboardContent(): addConfirmationButton failed\n");
+            return -1;
+        }
         // set this button as second child of the main layout container
         layoutInt->container->children[1] = (nbgl_obj_t *) button;
         textEntryContainer->obj.alignmentMarginY

--- a/lib_nbgl/src/nbgl_layout_keyboard_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_keyboard_nanos.c
@@ -108,6 +108,8 @@ int nbgl_layoutUpdateKeyboard(nbgl_layout_t *layout, uint8_t index, uint32_t key
     // get keyboard at given index
     keyboard = (nbgl_keyboard_t *) layoutInt->children[index];
     if ((keyboard == NULL) || (keyboard->obj.type != KEYBOARD)) {
+        LOG_WARN(
+            LAYOUT_LOGGER, "nbgl_layoutUpdateKeyboard(): keyboard not found at index %d\n", index);
         return -1;
     }
     if (keyboard->lettersOnly) {
@@ -221,6 +223,7 @@ int nbgl_layoutUpdateEnteredText(nbgl_layout_t *layout, uint8_t index, const cha
     // update main text area
     textEntry = (nbgl_text_entry_t *) layoutInt->children[index];
     if ((textEntry == NULL) || (textEntry->obj.type != TEXT_ENTRY)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateEnteredText(): text entry not found\n");
         return -1;
     }
     textEntry->text = text;

--- a/lib_nbgl/src/nbgl_layout_keypad.c
+++ b/lib_nbgl/src/nbgl_layout_keypad.c
@@ -356,8 +356,11 @@ int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t 
             if (nbActive == container->nbChildren) {
                 return 0;
             }
-            // deactivate the next digit
-            image                  = (nbgl_image_t *) container->children[nbActive];
+            // deactivate the next digit — guard against the underline object at children[nbDigits]
+            image = (nbgl_image_t *) container->children[nbActive];
+            if ((image == NULL) || (image->obj.type != IMAGE)) {
+                return 0;
+            }
             image->foregroundColor = WHITE;
         }
         else {

--- a/lib_nbgl/src/nbgl_layout_keypad.c
+++ b/lib_nbgl/src/nbgl_layout_keypad.c
@@ -95,6 +95,7 @@ int nbgl_layoutAddKeypad(nbgl_layout_t *layout, keyboardCallback_t callback, boo
     }
     // footer must be empty
     if (layoutInt->footerContainer != NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutAddKeypad(): footer already set\n");
         return -1;
     }
 
@@ -167,6 +168,7 @@ int nbgl_layoutUpdateKeypad(nbgl_layout_t *layout,
     // get existing keypad (in the footer container)
     keypad = (nbgl_keypad_t *) layoutInt->footerContainer->children[0];
     if ((keypad == NULL) || (keypad->obj.type != KEYPAD)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypad(): keypad not found at index %d\n", index);
         return -1;
     }
     // partial redraw only if only validate and backspace have changed
@@ -203,6 +205,7 @@ int nbgl_layoutUpdateKeypadValidation(nbgl_layout_t *layout, bool softValidation
     // get existing keypad (in the footer container)
     keypad = (nbgl_keypad_t *) layoutInt->footerContainer->children[0];
     if ((keypad == NULL) || (keypad->obj.type != KEYPAD)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadValidation(): keypad not found\n");
         return -1;
     }
     keypad->softValidation = softValidation;
@@ -321,15 +324,21 @@ int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t 
     container = (nbgl_container_t *) layoutInt->container->children[index];
     // sanity check
     if ((container == NULL) || (container->obj.type != CONTAINER)) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateHiddenDigits(): container not found\n");
         return -1;
     }
     if (nbActive > container->nbChildren) {
+        LOG_WARN(LAYOUT_LOGGER,
+                 "nbgl_layoutUpdateHiddenDigits(): nbActive %d > nbChildren %d\n",
+                 nbActive,
+                 container->nbChildren);
         return -1;
     }
     if (nbActive == 0) {
         // deactivate the first digit
         image = (nbgl_image_t *) container->children[0];
         if ((image == NULL) || (image->obj.type != IMAGE)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateHiddenDigits(): image not found\n");
             return -1;
         }
         image->foregroundColor = WHITE;
@@ -337,6 +346,7 @@ int nbgl_layoutUpdateHiddenDigits(nbgl_layout_t *layout, uint8_t index, uint8_t 
     else {
         image = (nbgl_image_t *) container->children[nbActive - 1];
         if ((image == NULL) || (image->obj.type != IMAGE)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateHiddenDigits(): image not found\n");
             return -1;
         }
         // if the last "active" is already active, it means that we are decreasing the number of
@@ -423,6 +433,10 @@ int nbgl_layoutAddKeypadContent(nbgl_layout_t *layout,
         uint8_t           space;
 
         if (nbDigits > KEYPAD_MAX_DIGITS) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutAddKeypadContent(): nbDigits %d > KEYPAD_MAX_DIGITS %d\n",
+                     nbDigits,
+                     KEYPAD_MAX_DIGITS);
             return -1;
         }
         // space between "digits"
@@ -550,15 +564,21 @@ int nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
                         ->children[1];
         // sanity check
         if ((container == NULL) || (container->obj.type != CONTAINER)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): container not found\n");
             return -1;
         }
         if (nbActiveDigits > container->nbChildren) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutUpdateKeypadContent(): nbActive %d > nbChildren %d\n",
+                     nbActiveDigits,
+                     container->nbChildren);
             return -1;
         }
         if (nbActiveDigits == 0) {
             // deactivate the first digit
             image = (nbgl_image_t *) container->children[0];
             if ((image == NULL) || (image->obj.type != IMAGE)) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): image not found\n");
                 return -1;
             }
             image->foregroundColor = WHITE;
@@ -566,6 +586,7 @@ int nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
         else {
             image = (nbgl_image_t *) container->children[nbActiveDigits - 1];
             if ((image == NULL) || (image->obj.type != IMAGE)) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): image not found\n");
                 return -1;
             }
             // if the last "active" is already active, it means that we are decreasing the number of
@@ -593,6 +614,7 @@ int nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
             = (nbgl_text_area_t *) ((nbgl_container_t *) layoutInt->container->children[0])
                   ->children[1];
         if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): text area not found\n");
             return -1;
         }
         textArea->text          = text;

--- a/lib_nbgl/src/nbgl_layout_keypad_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_keypad_nanos.c
@@ -293,15 +293,21 @@ int nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
         container = (nbgl_container_t *) layoutInt->children[2];
         // sanity check
         if ((container == NULL) || (container->obj.type != CONTAINER)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): container not found\n");
             return -1;
         }
         if (nbActiveDigits > container->nbChildren) {
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutUpdateKeypadContent(): nbActive %d > nbChildren %d\n",
+                     nbActiveDigits,
+                     container->nbChildren);
             return -1;
         }
         if (nbActiveDigits == 0) {
             // deactivate the first digit
             image = (nbgl_image_t *) container->children[0];
             if ((image == NULL) || (image->obj.type != IMAGE)) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): image not found\n");
                 return -1;
             }
             image->buffer = &C_pin_bullet_empty;
@@ -309,6 +315,7 @@ int nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
         else {
             image = (nbgl_image_t *) container->children[nbActiveDigits - 1];
             if ((image == NULL) || (image->obj.type != IMAGE)) {
+                LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): image not found\n");
                 return -1;
             }
             // if the last "active" is already active, it means that we are decreasing the number of
@@ -333,6 +340,7 @@ int nbgl_layoutUpdateKeypadContent(nbgl_layout_t *layout,
         // update main text area (second child of the main container)
         nbgl_text_area_t *textArea = (nbgl_text_area_t *) layoutInt->children[2];
         if ((textArea == NULL) || (textArea->obj.type != TEXT_AREA)) {
+            LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutUpdateKeypadContent(): text area not found\n");
             return -1;
         }
         textArea->text = text;

--- a/lib_nbgl/src/nbgl_layout_nanos.c
+++ b/lib_nbgl/src/nbgl_layout_nanos.c
@@ -735,7 +735,8 @@ int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switc
         = nbgl_getTextNbLinesInWidth(textArea->fontId, textArea->text, AVAILABLE_WIDTH, true);
     // if more than 1 line on screen
     if (nbLines > 1) {
-        // TODO: warning for screenshots
+        LOG_WARN(
+            LAYOUT_LOGGER, "nbgl_layoutAddSwitch(): item text too long (%d lines > 1)\n", nbLines);
         return -1;
     }
     textArea->obj.area.height      = nbgl_getFontLineHeight(textArea->fontId);
@@ -757,7 +758,9 @@ int nbgl_layoutAddSwitch(nbgl_layout_t *layout, const nbgl_layoutSwitch_t *switc
             = nbgl_getTextNbLinesInWidth(textArea->fontId, textArea->text, AVAILABLE_WIDTH, true);
         // if more than 2 lines on screen
         if (nbLines > 2) {
-            // TODO: warning for screenshots
+            LOG_WARN(LAYOUT_LOGGER,
+                     "nbgl_layoutAddSwitch(): sub text too long (%d lines > 2)\n",
+                     nbLines);
             return -1;
         }
         textArea->obj.alignment        = CENTER;
@@ -795,6 +798,7 @@ int nbgl_layoutDraw(nbgl_layout_t *layoutParam)
     nbgl_layoutInternal_t *layout = (nbgl_layoutInternal_t *) layoutParam;
 
     if (layout == NULL) {
+        LOG_WARN(LAYOUT_LOGGER, "nbgl_layoutDraw(): layout is NULL\n");
         return -1;
     }
     LOG_DEBUG(LAYOUT_LOGGER, "nbgl_layoutDraw(): layout->nbChildren = %d\n", layout->nbChildren);

--- a/lib_nbgl/src/nbgl_page.c
+++ b/lib_nbgl/src/nbgl_page.c
@@ -375,6 +375,9 @@ nbgl_page_t *nbgl_pageDrawInfo(nbgl_layoutTouchCallback_t              onActionC
             icon = &CLOSE_ICON;
         }
         else {
+            LOG_WARN(PAGE_LOGGER,
+                     "nbgl_pageDrawInfo(): unknown topRightStyle %d\n",
+                     info->topRightStyle);
             return NULL;
         }
         nbgl_layoutAddTopRightButton(layout, PIC(icon), info->topRightToken, info->tuneId);
@@ -408,6 +411,9 @@ nbgl_page_t *nbgl_pageDrawInfo(nbgl_layoutTouchCallback_t              onActionC
             icon = &CLOSE_ICON;
         }
         else {
+            LOG_WARN(PAGE_LOGGER,
+                     "nbgl_pageDrawInfo(): unknown bottomButtonStyle %d\n",
+                     info->bottomButtonStyle);
             return NULL;
         }
         nbgl_layoutAddBottomButton(

--- a/lib_nbgl/src/nbgl_step.c
+++ b/lib_nbgl/src/nbgl_step.c
@@ -345,6 +345,7 @@ static void actionCallback(nbgl_layout_t *layout, nbgl_buttonEvent_t event)
     StepContext_t *ctx = getContextFromLayout(layout);
 
     if (!ctx) {
+        LOG_WARN(STEP_LOGGER, "actionCallback(): ctx not found\n");
         return;
     }
     if (event == BUTTON_LEFT_PRESSED) {
@@ -415,6 +416,7 @@ static void menuListActionCallback(nbgl_layout_t *layout, nbgl_buttonEvent_t eve
 {
     StepContext_t *ctx = getContextFromLayout(layout);
     if (!ctx) {
+        LOG_WARN(STEP_LOGGER, "menuListActionCallback(): ctx not found\n");
         return;
     }
 
@@ -470,6 +472,7 @@ nbgl_step_t nbgl_stepDrawText(nbgl_stepPosition_t               pos,
 #endif  // BUILD_SCREENSHOTS
     StepContext_t *ctx = getFreeContext(TEXT_STEP, modal);
     if (!ctx) {
+        LOG_WARN(STEP_LOGGER, "nbgl_stepDrawText(): no free context\n");
         return NULL;
     }
     // initialize context (already set to 0 by getFreeContext())
@@ -574,6 +577,7 @@ nbgl_step_t nbgl_stepDrawCenteredInfo(nbgl_stepPosition_t               pos,
     };
     StepContext_t *ctx = getFreeContext(CENTERED_INFO_STEP, modal);
     if (!ctx) {
+        LOG_WARN(STEP_LOGGER, "nbgl_stepDrawCenteredInfo(): no free context\n");
         return NULL;
     }
 
@@ -623,6 +627,7 @@ nbgl_step_t nbgl_stepDrawMenuList(nbgl_stepMenuListCallback_t       onActionCall
 {
     StepContext_t *ctx = getFreeContext(MENU_LIST_STEP, modal);
     if (!ctx) {
+        LOG_WARN(STEP_LOGGER, "nbgl_stepDrawMenuList(): no free context\n");
         return NULL;
     }
 
@@ -685,6 +690,7 @@ nbgl_step_t nbgl_stepDrawSwitch(nbgl_stepPosition_t               pos,
     };
     StepContext_t *ctx = getFreeContext(CENTERED_INFO_STEP, modal);
     if (!ctx) {
+        LOG_WARN(STEP_LOGGER, "nbgl_stepDrawSwitch(): no free context\n");
         return NULL;
     }
 

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -3186,6 +3186,12 @@ static void displayTagValueListModal(const nbgl_contentTagValueList_t *tagValues
     nbElements = tagValues->nbPairs;
 
     while (nbElements > 0) {
+        if (detailsContext.nbPages >= MAX_MODAL_PAGE_NB) {
+            LOG_WARN(USE_CASE_LOGGER,
+                     "displayTagValueListModal(): too many pages, truncating at %d\n",
+                     MAX_MODAL_PAGE_NB);
+            break;
+        }
         nbElementsInPage = getNbTagValuesInDetailsPage(nbElements, tagValues, elemIdx);
 
         elemIdx += nbElementsInPage;
@@ -3259,11 +3265,11 @@ uint8_t nbgl_useCaseGetNbInfosInPage(uint8_t                       nbInfos,
                                      uint8_t                       startIndex,
                                      bool                          withNav)
 {
-    uint8_t            nbInfosInPage = 0;
-    uint16_t           currentHeight = 0;
-    uint16_t           previousHeight;
-    uint16_t           navHeight    = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
-    const char *const *infoContents = PIC(infosList->infoContents);
+    uint8_t            nbInfosInPage  = 0;
+    uint16_t           currentHeight  = 0;
+    uint16_t           previousHeight = 0;
+    uint16_t           navHeight      = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
+    const char *const *infoContents   = PIC(infosList->infoContents);
 
     while (nbInfosInPage < nbInfos) {
         // The type string must be a 1 liner and its height is LIST_ITEM_MIN_TEXT_HEIGHT
@@ -3355,10 +3361,10 @@ uint8_t nbgl_useCaseGetNbBarsInPage(uint8_t                       nbBars,
                                     uint8_t                       startIndex,
                                     bool                          withNav)
 {
-    uint8_t  nbBarsInPage  = 0;
-    uint16_t currentHeight = 0;
-    uint16_t previousHeight;
-    uint16_t navHeight = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
+    uint8_t  nbBarsInPage   = 0;
+    uint16_t currentHeight  = 0;
+    uint16_t previousHeight = 0;
+    uint16_t navHeight      = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
 
     UNUSED(barsList);
     UNUSED(startIndex);
@@ -3396,8 +3402,8 @@ uint8_t nbgl_useCaseGetNbChoicesInPage(uint8_t                          nbChoice
 {
     uint8_t  nbChoicesInPage = 0;
     uint16_t currentHeight   = 0;
-    uint16_t previousHeight;
-    uint16_t navHeight = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
+    uint16_t previousHeight  = 0;
+    uint16_t navHeight       = withNav ? SIMPLE_FOOTER_HEIGHT : 0;
 
     UNUSED(choicesList);
     UNUSED(startIndex);

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -3858,6 +3858,8 @@ void nbgl_useCaseAdvancedChoiceWithDetails(const nbgl_icon_details_t *centerIcon
     // clang-format on
 
     if ((confirmText == NULL) || (cancelText == NULL)) {
+        LOG_WARN(USE_CASE_LOGGER,
+                 "nbgl_useCaseAdvancedChoiceWithDetails(): confirmText or cancelText is NULL\n");
         return;
     }
 

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -1964,8 +1964,14 @@ static void keyboardCallback(char touchedKey)
         keyboardContext.entryBuffer[--textLen] = '\0';
     }
     else {
-        keyboardContext.entryBuffer[textLen]   = touchedKey;
-        keyboardContext.entryBuffer[++textLen] = '\0';
+        if (textLen >= keyboardContext.entryMaxLen) {
+            // entry length can't be greater, so we mask every characters
+            mask = -1;
+        }
+        else {
+            keyboardContext.entryBuffer[textLen]   = touchedKey;
+            keyboardContext.entryBuffer[++textLen] = '\0';
+        }
     }
     if (keyboardContext.keyboardContent.type == KEYBOARD_WITH_SUGGESTIONS) {
         // if suggestions are displayed, we update them at each key press
@@ -2310,7 +2316,8 @@ static void prepareAddressConfirmationPages(const char                       *ad
     // all but the first chunk ensures each chunk starts a fresh page.
     nbAddressChunks = nbgl_getTextNbPagesInWidth(
         LARGE_MEDIUM_FONT, address, NB_MAX_LINES_IN_REVIEW, AVAILABLE_WIDTH);
-    if (nbAddressChunks > ADDR_VERIF_NB_PAIRS) {
+    bool addressTruncated = (nbAddressChunks > ADDR_VERIF_NB_PAIRS);
+    if (addressTruncated) {
         nbAddressChunks = ADDR_VERIF_NB_PAIRS;
     }
     {
@@ -2379,7 +2386,7 @@ static void prepareAddressConfirmationPages(const char                       *ad
     // at NB_MAX_LINES_IN_REVIEW lines so each chunk-pair occupies exactly one page
     tagValueConfirm->tagValueList.nbMaxLinesForValue
         = (nbAddressChunks > 1) ? NB_MAX_LINES_IN_REVIEW : 0;
-    tagValueConfirm->tagValueList.hideEndOfLastLine = false;
+    tagValueConfirm->tagValueList.hideEndOfLastLine = addressTruncated;
     tagValueConfirm->tagValueList.wrapping          = false;
 
     // Number of extras left to place on a second page

--- a/lib_nbgl/src/nbgl_use_case.c
+++ b/lib_nbgl/src/nbgl_use_case.c
@@ -840,7 +840,11 @@ static void displaySettingsPage(uint8_t page, bool forceFullRefresh)
 {
     nbgl_pageContent_t content = {0};
 
-    if ((onNav == NULL) || (onNav(page, &content) == false)) {
+    if (onNav == NULL) {
+        LOG_WARN(USE_CASE_LOGGER, "displaySettingsPage(): onNav callback is NULL\n");
+        return;
+    }
+    if (onNav(page, &content) == false) {
         return;
     }
 
@@ -871,7 +875,11 @@ static void displayReviewPage(uint8_t page, bool forceFullRefresh)
         return;
     }
     navInfo.activePage = page;
-    if ((onNav == NULL) || (onNav(navInfo.activePage, &content) == false)) {
+    if (onNav == NULL) {
+        LOG_WARN(USE_CASE_LOGGER, "displayReviewPage(): onNav callback is NULL\n");
+        return;
+    }
+    if (onNav(navInfo.activePage, &content) == false) {
         return;
     }
 
@@ -3747,6 +3755,7 @@ void nbgl_useCaseChoice(const nbgl_icon_details_t *icon,
     nbgl_pageConfirmationDescription_t info = {0};
     // check params
     if ((confirmText == NULL) || (cancelText == NULL)) {
+        LOG_WARN(USE_CASE_LOGGER, "nbgl_useCaseChoice(): confirmText or cancelText is NULL\n");
         return;
     }
     reset_callbacks_and_context();
@@ -4777,6 +4786,11 @@ void nbgl_useCaseKeypad(const char             *title,
     int                      status            = -1;
 
     if ((minDigits > KEYPAD_MAX_DIGITS) || (maxDigits > KEYPAD_MAX_DIGITS)) {
+        LOG_WARN(USE_CASE_LOGGER,
+                 "nbgl_useCaseKeypad(): digits out of range (%d/%d > %d)\n",
+                 minDigits,
+                 maxDigits,
+                 KEYPAD_MAX_DIGITS);
         return;
     }
 
@@ -4798,12 +4812,16 @@ void nbgl_useCaseKeypad(const char             *title,
     // add keypad
     status = nbgl_layoutAddKeypad(keypadContext.layoutCtx, keypadCallback, shuffled);
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeypad(): layout setup failed (status=%d)\n", status);
         return;
     }
     // add keypad content
     status = nbgl_layoutAddKeypadContent(
         keypadContext.layoutCtx, title, keypadContext.hidden, maxDigits, "");
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeypad(): layout setup failed (status=%d)\n", status);
         return;
     }
 
@@ -4876,6 +4894,8 @@ void nbgl_useCaseKeyboard(const nbgl_keyboardParams_t *params, nbgl_callback_t b
     // Add keyboard
     status = nbgl_layoutAddKeyboard(keyboardContext.layoutCtx, &kbdInfo);
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeyboard(): layout setup failed (status=%d)\n", status);
         return;
     }
     keyboardContext.keyboardIndex  = status;
@@ -4918,6 +4938,8 @@ void nbgl_useCaseKeyboard(const nbgl_keyboardParams_t *params, nbgl_callback_t b
     status = nbgl_layoutAddKeyboardContent(keyboardContext.layoutCtx,
                                            &keyboardContext.keyboardContent);
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeyboard(): layout setup failed (status=%d)\n", status);
         return;
     }
 

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -1463,6 +1463,9 @@ static void getContentPage(bool toogle_state, PageContent_t *contentPage)
     char                     **texts          = NULL;
     p_content = getContentElemAtIdx(context.currentPage, &elemIdx, &content);
     if (p_content == NULL) {
+        LOG_WARN(USE_CASE_LOGGER,
+                 "getContentPage(): p_content is NULL for page %d\n",
+                 context.currentPage);
         return;
     }
     switch (p_content->type) {

--- a/lib_nbgl/src/nbgl_use_case_nanos.c
+++ b/lib_nbgl/src/nbgl_use_case_nanos.c
@@ -382,6 +382,9 @@ static const char *getChoiceName(uint8_t choiceIndex)
 
     p_content = getContentElemAtIdx(context.currentPage, &elemIdx, &content);
     if (p_content == NULL) {
+        LOG_WARN(USE_CASE_LOGGER,
+                 "getChoiceName(): p_content is NULL for page %d\n",
+                 context.currentPage);
         return NULL;
     }
     switch (p_content->type) {
@@ -417,6 +420,9 @@ static void onChoiceSelected(uint8_t choiceIndex)
 
     p_content = getContentElemAtIdx(context.currentPage, &elemIdx, &content);
     if (p_content == NULL) {
+        LOG_WARN(USE_CASE_LOGGER,
+                 "onChoiceSelected(): p_content is NULL for page %d\n",
+                 context.currentPage);
         return;
     }
     switch (p_content->type) {
@@ -553,6 +559,9 @@ static void onSwitchAction(void)
 
     p_content = getContentElemAtIdx(context.currentPage, &elemIdx, &content);
     if ((p_content == NULL) || (p_content->type != SWITCHES_LIST)) {
+        LOG_WARN(USE_CASE_LOGGER,
+                 "onSwitchAction(): p_content is NULL or not a switches list for page %d\n",
+                 context.currentPage);
         return;
     }
     contentSwitch
@@ -3379,12 +3388,16 @@ void nbgl_useCaseKeypad(const char             *title,
     // add keypad
     status = nbgl_layoutAddKeypad(context.keypad.layoutCtx, keypadCallback, title, shuffled);
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeypad(): layout setup failed (status=%d)\n", status);
         return;
     }
     context.keypad.keypadIndex = status;
     // add digits
     status = nbgl_layoutAddKeypadContent(context.keypad.layoutCtx, hidden, maxDigits, "");
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeypad(): layout setup failed (status=%d)\n", status);
         return;
     }
 
@@ -3477,6 +3490,8 @@ void nbgl_useCaseKeyboard(const nbgl_keyboardParams_t *params, nbgl_callback_t b
     // Add keyboard
     status = nbgl_layoutAddKeyboard(context.keyboard.layoutCtx, &kbdInfo);
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeyboard(): layout setup failed (status=%d)\n", status);
         return;
     }
     context.keyboard.keyboardIndex = status;
@@ -3484,6 +3499,8 @@ void nbgl_useCaseKeyboard(const nbgl_keyboardParams_t *params, nbgl_callback_t b
     // add empty entered text
     status = nbgl_layoutAddEnteredText(context.keyboard.layoutCtx, "", true);
     if (status < 0) {
+        LOG_WARN(
+            USE_CASE_LOGGER, "nbgl_useCaseKeyboard(): layout setup failed (status=%d)\n", status);
         return;
     }
     context.keyboard.textIndex = status;

--- a/tests/screenshots/src/main/nbgl_front.c
+++ b/tests/screenshots/src/main/nbgl_front.c
@@ -129,6 +129,15 @@ void nbgl_frontRefreshArea(const nbgl_area_t  *area,
     ((nbgl_area_t *) area)->x0 -= FULL_SCREEN_WIDTH - SCREEN_WIDTH;
 }
 
+/**
+ * @brief Draws a run-length encoded (RLE) bitmap with the given parameters.
+ *
+ * @param area position, size and color of the bitmap to draw
+ * @param buffer RLE-compressed bitmap buffer
+ * @param buffer_len size of the compressed buffer in bytes
+ * @param fore_color foreground color to apply on the image
+ * @param nb_skipped_bytes number of bytes to skip at the beginning of the buffer
+ */
 void nbgl_frontDrawImageRle(const nbgl_area_t *area,
                             const uint8_t     *buffer,
                             uint32_t           buffer_len,
@@ -141,6 +150,12 @@ void nbgl_frontDrawImageRle(const nbgl_area_t *area,
     ((nbgl_area_t *) area)->x0 -= FULL_SCREEN_WIDTH - SCREEN_WIDTH;
 }
 
+/**
+ * @brief Enables or disables area masking for a given mask index.
+ *
+ * @param mask_index index of the mask to control
+ * @param masked_area_or_null area to mask, or NULL to disable masking for this index
+ */
 void nbgl_frontControlAreaMasking(uint8_t mask_index, nbgl_area_t *masked_area_or_null)
 {
     if (masked_area_or_null == NULL) {


### PR DESCRIPTION
## Description


This PR groups the results of a full security and correctness audit of `lib_nbgl`, plus few doc fixes.

**Documentation (first 2 commits)**

The docstrings and the generated documentation were updated and refreshed.

**Security fixes (4 issues)**

- _HIGH_ — Buffer over-read in `nbgl_layoutAddTagValueList`: when `aliasValue` is set, the code failed to allocate an extra child slot for the alias text area, causing an out-of-bounds write into the adjacent pool slot.
- _MEDIUM_ — Buffer overrun in `keyboardCallback`: the entered text was written to the buffer before checking its length against `entryMaxLen`, allowing a one-byte overflow.
- _LOW_ — Unsigned integer underflow in `updateSuggestionButtons`: arithmetic on `currentLeftButtonIndex` could wrap around when the index was zero.
- _LOW_ — Truncated address not flagged in `prepareAddressConfirmationPages`: when a long address was split across pages, `hideEndOfLastLine` was hardcoded to `false` instead of reflecting whether the address had been truncated.

**Silent error returns (LOG_WARN)**

About 100 early returns across 11 files had no log at all, making failures invisible. A `LOG_WARN` was added before each one.

**Logic bugs (8 fixes)**

- Wrong variable used for `foregroundColor` on the action button in `HEADER_EXTENDED_BACK`.
- Container allocated with 5 child slots instead of 6 in the same header type.
- Deprecated field (`textEntry->obj`) used in `nbgl_layoutUpdateEnteredText` instead of navigating the live widget tree.
- Unchecked NULL returns after `addTextEntry`, `addSuggestionButtons`, and `addConfirmationButton` in the keyboard layout.
- Uninitialized `previousHeight` variable in three page-sizing helpers, causing wrong page counts on the first call.
- No page-count guard in `displayTagValueListModal`, allowing the loop to write past `MAX_MODAL_PAGE_NB`.
- Type confusion in `nbgl_layoutUpdateHiddenDigits`: the underline `LINE` object at `children[nbDigits]` was reinterpreted as an `IMAGE` and its `foregroundColor` field was overwritten.
- Missing NULL and type guards for `mainContainer`, its inner text-entry container, and `suggestionsContainer` in nbgl_layoutUpdateKeyboardContent.
- Back button widget allocated and added to the header container even when `backToken == NBGL_INVALID_TOKEN`, causing the renderer to display a left arrow on screens that intentionally have no back navigation.

## Tests

Tested with the full ledger-app-tester, modified to force using the branch including the modifications
https://github.com/LedgerHQ/ledger-app-tester/pull/163
**Note**: remaining issues are not linked to the modifications and also present on main, except for app-ethereum snapshots, where it highlights a bug, now fixed by this PR

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [X] Documentation
- [ ] Other (for changes that might not fit in any category)


## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26
