### PR TITLE
Fix incremental build

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -163,30 +163,6 @@ ifneq ($(wildcard $(APP_MANIFEST_FILE)),)
     endef
 endif
 
-# Build-time check: warn when a header basename is reachable via -I from BOTH an APP
-# and an SDK include directory but from DIFFERENT directories (a real shadow risk).
-# Run in a recipe so that include dirs added by the app AFTER this file is included
-# (INCLUDES_PATH += ..., APP_SOURCE_PATH += ...) are covered.
-# Notes:
-#  - Directories present on BOTH sides are subtracted from the SDK side first: a header
-#    found in a shared dir is the same file, not a shadow (e.g. the generated glyphs.h
-#    in $(GLYPH_SRC_DIR), reachable by both SDK and APP). This keeps the warning
-#    signal to genuine cross-directory collisions only.
-#  - The bare $(BOLOS_SDK) root is excluded: a header sitting directly at the SDK root
-#    is still reachable via -I$(BOLOS_SDK) for SDK builds, so a collision there is a
-#    deliberate blind spot.
-#  - hdr() relies on word-splitting, so include paths containing spaces are not handled.
-.PHONY: check-duplicate-headers
-check-duplicate-headers:
-	$(L)hdr() { for d in $$1; do ls "$$d"/*.h 2>/dev/null; done | sed 's#.*/##' | sort -u; }; \
-	dup=$$(comm -12 \
-	    <(hdr "$(filter-out $(INCLUDES_PATH_APP_BASE) $(BOLOS_SDK),$(INCLUDES_PATH_SDK_BASE))") \
-	    <(hdr "$(INCLUDES_PATH_APP_BASE)")); \
-	[ -z "$$dup" ] || echo "[WARNING] Header(s) present in both SDK and APP include dirs:" $$dup
-
-# Run the duplicate check once at the start of every build.
-prepare: check-duplicate-headers
-
 include $(BOLOS_SDK)/Makefile.rules_generic
 
 list-defines:

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -67,9 +67,23 @@ clean_target:
 BUILD_DEPENDENCIES  = $(GLYPH_DESTH) $(GLYPH_DESTC) Makefile
 BUILD_DEPENDENCIES += $(APP_CUSTOM_BUILD_DEPENDENCIES)
 
+# Warn when a header basename is reachable via -I from BOTH an APP and an SDK include
+# directory but from DIFFERENT directories (a real shadow risk). Inlined here rather
+# than a .PHONY prerequisite: a phony prereq would mark prepare as "updated now" on
+# every run, forcing all downstream .o files to always rebuild.
+# Notes:
+#  - Directories on BOTH sides are subtracted from the SDK side first so a header in a
+#    shared dir (e.g. the generated glyphs.h in $(GLYPH_SRC_DIR)) is not reported.
+#  - The bare $(BOLOS_SDK) root is excluded (deliberate blind spot).
+#  - hdr() relies on word-splitting; include paths with spaces are not handled.
 prepare:
 	$(L)echo Prepare directories
 	@mkdir -p $(BIN_DIR) $(OBJ_DIR) $(OBJECTS_DIR) $(DBG_DIR) $(DEP_DIR) $(DEPEND_DIR) $(GEN_SRC_DIR) bin debug
+	$(L)hdr() { for d in $$1; do ls "$$d"/*.h 2>/dev/null; done | sed 's#.*/##' | sort -u; }; \
+	dup=$$(comm -12 \
+	    <(hdr "$(filter-out $(INCLUDES_PATH_APP_BASE) $(BOLOS_SDK),$(INCLUDES_PATH_SDK_BASE))") \
+	    <(hdr "$(INCLUDES_PATH_APP_BASE)")); \
+	[ -z "$$dup" ] || echo "[WARNING] Header(s) present in both SDK and APP include dirs:" $$dup
 
 $(BUILD_DEPENDENCIES): prepare
 


### PR DESCRIPTION
## Description

All `.o` files were generated du to `check-duplicate-headers`, which was a prerequisite of `prepare`, itself call for each build.

Fix by inlining the duplicate check inside the `prepare` target

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.