### PR TITLE
Remove unused attribute from get_der_value_as_uint8

### DIFF
--- a/lib_tlv/tlv_library.c
+++ b/lib_tlv/tlv_library.c
@@ -267,21 +267,6 @@ static bool get_der_value_as_uint16(const buffer_t *payload, size_t *offset, uin
     return true;
 }
 
-/** Parse DER-encoded value and fits it in uint8_t or fails
- */
-__attribute__((unused)) static bool get_der_value_as_uint8(const buffer_t *payload,
-                                                           size_t         *offset,
-                                                           uint8_t        *value)
-{
-    uint32_t tmp_value;
-    if (!get_der_value_as_uint32(payload, offset, &tmp_value) || (tmp_value > UINT8_MAX)) {
-        return false;
-    }
-
-    *value = (uint8_t) tmp_value;
-    return true;
-}
-
 static bool set_tag(TLV_reception_t *received_tags_flags, TLV_tag_t tag)
 {
     TLV_flag_t flag = received_tags_flags->tag_to_flag_function(tag);


### PR DESCRIPTION
Description

Please provide a detailed description of what was done in this PR.
(And mention any links to an issue [docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
Changes include

    Bugfix (non-breaking change that solves an issue)
    New feature (non-breaking change that adds functionality)
    Breaking change (change that is not backwards-compatible and/or changes current functionality)
    Tests
    Documentation
    Other (for changes that might not fit in any category)

Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.
Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated API_LEVEL branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

    The merge will ALWAYS be a manual operation.
    It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
    In case of failure, there is no other solution than redo the operation manually...