### PR TITLE
Fix stack protector

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -100,8 +100,13 @@ LDFLAGS  += -nostdlib -nodefaultlibs
 ENABLE_STACK_PROTECTOR ?= 0
 ifneq ($(ENABLE_STACK_PROTECTOR),0)
 	LDLIBS   += -Wl,--wrap=__stack_chk_fail -Wl,--wrap=__stack_chk_init
+	# Enter at __stack_chk_init (overrides ENTRY(main)) so the canary is randomized,
+	# including in sideloads; the init then reaches main via `b main`.
+	LDFLAGS  += -Wl,--defsym,__entry=__stack_chk_init
 	AFLAGS   += -fstack-protector-strong -Wno-unused-command-line-argument
 	CFLAGS   += -fstack-protector-strong
+else
+	LDFLAGS  += -Wl,--defsym,__entry=main
 endif
 
 ENABLE_LINK_TIME_OPTIMIZATION ?= 0

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -169,15 +169,6 @@ LINK_DEPENDENCIES += $(APP_CUSTOM_LINK_DEPENDENCIES)
 $(BIN_DIR)/app.elf: $(LINK_DEPENDENCIES)
 	@echo "[LINK] $(BIN_DIR)/app.elf"
 	$(L)$(call link_cmdline,$(OBJECT_FILES) $(LDLIBS),$(BIN_DIR)/app.elf)
-ifneq ($(ENABLE_STACK_PROTECTOR),0)
-	@# Ensure __stack_chk_guard remains the very first symbol in .bss.
-	@BSS=$$(llvm-nm $(BIN_DIR)/app.elf | grep ' _bss$$' | cut -d' ' -f1); \
-	GUARD=$$(llvm-nm $(BIN_DIR)/app.elf | grep ' __stack_chk_guard$$' | cut -d' ' -f1); \
-	if [ -z "$$GUARD" ] || [ "$$GUARD" != "$$BSS" ]; then \
-		echo "[ERROR] __stack_chk_guard ($$GUARD) must be the first symbol in .bss ($$BSS)"; \
-		exit 1; \
-	fi
-endif
 	$(L)llvm-objcopy -O ihex -S $(BIN_DIR)/app.elf $(BIN_DIR)/app.hex
 	$(L)llvm-objdump -S -d $(BIN_DIR)/app.elf > $(DBG_DIR)/app.asm
 

--- a/src/os.c
+++ b/src/os.c
@@ -198,7 +198,7 @@ int bytes_to_lowercase_hex(char *out, size_t outl, const void *value, size_t len
     return 0;
 }
 
-// BSS start and end defines addresses
+// BSS wipe bounds
 extern void *_bss;
 extern void *_ebss;
 

--- a/src/pic.c
+++ b/src/pic.c
@@ -39,7 +39,7 @@ void *pic(void *link_address)
 #elif defined(ST33) || defined(ST33K1M5)
 
 #if !defined(HAVE_BOLOS) || defined(BOLOS_OS_UPGRADER_APP)
-extern void _bss;
+extern void _ram;
 extern void _estack;
 
 void *pic(void *link_address)
@@ -55,7 +55,7 @@ void *pic(void *link_address)
 
 #ifndef BOLOS_OS_UPGRADER_APP
     // check if in the LINKED RAM zone
-    __asm volatile("movw %0, #:lower16:_bss\n\tmovt %0, #:upper16:_bss" : "=r"(n));
+    __asm volatile("movw %0, #:lower16:_ram\n\tmovt %0, #:upper16:_ram" : "=r"(n));
     __asm volatile("movw %0, #:lower16:_estack\n\tmovt %0, #:upper16:_estack" : "=r"(en));
     if (link_address >= n && link_address <= en) {
         __asm volatile("mov %0, r9" : "=r"(en));

--- a/src/stack_protector_init.S
+++ b/src/stack_protector_init.S
@@ -41,21 +41,4 @@ __wrap___stack_chk_init:
 // place the constants pool after the unconditional branch, out of the exec path
 .ltorg
 
-#else
-
-// Force the following linker error if -fstack-protector is enabled for CFLAGS
-// but not for AFLAGS:
-//
-//     ld.lld: error: duplicate symbol: __stack_chk_fail
-//
-// It ensures that __stack_chk_init is always defined (and consequently
-// __stack_chk_guard is always initialized to a random value) when SSP is
-// enabled.
-//
-// This code will never end up in an app since the link step will fail.
-.weak __stack_chk_fail
-.thumb_func
-__stack_chk_fail:
-    udf 255
-
 #endif

--- a/src/stack_protector_init.S
+++ b/src/stack_protector_init.S
@@ -7,9 +7,12 @@
 
 .section .boot.ssp_init, "ax"
 
+.extern main
 .global __wrap___stack_chk_init
 .thumb_func
 __wrap___stack_chk_init:
+    // Relies on the OS contract for arg0 (r0): 0 on a standalone launch,
+    // non-zero (the libargs_t*) on a libcall.
     // if r0 != 0, skip initialization and jump directly to main
     // (don't overwrite parent canary during a libcall)
     cmp r0, #0
@@ -31,13 +34,12 @@ __wrap___stack_chk_init:
     // restore arguments
     pop {r0-r3}
 
-    // jump to the main function
-    b 1f
-
-// skip the constants pool
-.ltorg
-
+    // canary initialized; fall through to the shared exit below
 1:
+    b main
+
+// place the constants pool after the unconditional branch, out of the exec path
+.ltorg
 
 #else
 
@@ -51,7 +53,7 @@ __wrap___stack_chk_init:
 // enabled.
 //
 // This code will never end up in an app since the link step will fail.
-.global __stack_chk_fail
+.weak __stack_chk_fail
 .thumb_func
 __stack_chk_fail:
     udf 255

--- a/target/apex_m/script.ld
+++ b/target/apex_m/script.ld
@@ -49,7 +49,7 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0DE0001 */
     KEEP(*(.boot.ssp_init))
     /* main; reached via b main, adjacency not required */
     *(.boot*)
@@ -133,7 +133,7 @@ SECTIONS
   } > SRAM = 0x00
 
   /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
-  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
+  ASSERT( __stack_chk_guard == ORIGIN(SRAM), "__stack_chk_guard must be at the RAM base" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/apex_m/script.ld
+++ b/target/apex_m/script.ld
@@ -33,7 +33,8 @@ PAGE_SIZE  = 512;
 STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
-ENTRY(main);
+/* __entry == __stack_chk_init if SSP is enabled, else main */
+ENTRY(__entry);
 
 SECTIONS
 {
@@ -50,7 +51,7 @@ SECTIONS
 
     /* ensure __stack_chk_init is always @ 0xC0D00000 */
     KEEP(*(.boot.ssp_init))
-    /* ensure main directly follows __stack_chk_init */
+    /* main; reached via b main, adjacency not required */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -107,10 +108,11 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
+    _ram = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 
@@ -129,6 +131,9 @@ SECTIONS
     PROVIDE(_estack = .);
 
   } > SRAM = 0x00
+
+  /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
+  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/apex_p/script.ld
+++ b/target/apex_p/script.ld
@@ -49,7 +49,7 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0DE0001 */
     KEEP(*(.boot.ssp_init))
     /* main; reached via b main, adjacency not required */
     *(.boot*)
@@ -133,7 +133,7 @@ SECTIONS
   } > SRAM = 0x00
 
   /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
-  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
+  ASSERT( __stack_chk_guard == ORIGIN(SRAM), "__stack_chk_guard must be at the RAM base" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/apex_p/script.ld
+++ b/target/apex_p/script.ld
@@ -33,7 +33,8 @@ PAGE_SIZE  = 512;
 STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
-ENTRY(main);
+/* __entry == __stack_chk_init if SSP is enabled, else main */
+ENTRY(__entry);
 
 SECTIONS
 {
@@ -50,7 +51,7 @@ SECTIONS
 
     /* ensure __stack_chk_init is always @ 0xC0D00000 */
     KEEP(*(.boot.ssp_init))
-    /* ensure main directly follows __stack_chk_init */
+    /* main; reached via b main, adjacency not required */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -107,10 +108,11 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
+    _ram = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 
@@ -129,6 +131,9 @@ SECTIONS
     PROVIDE(_estack = .);
 
   } > SRAM = 0x00
+
+  /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
+  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/flex/script.ld
+++ b/target/flex/script.ld
@@ -33,7 +33,8 @@ PAGE_SIZE  = 512;
 STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
-ENTRY(main);
+/* __entry == __stack_chk_init if SSP is enabled, else main */
+ENTRY(__entry);
 
 SECTIONS
 {
@@ -50,7 +51,7 @@ SECTIONS
 
     /* ensure __stack_chk_init is always @ 0xC0D00000 */
     KEEP(*(.boot.ssp_init))
-    /* ensure main directly follows __stack_chk_init */
+    /* main; reached via b main, adjacency not required */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -110,10 +111,11 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
+    _ram = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 
@@ -132,6 +134,9 @@ SECTIONS
     PROVIDE(_estack = .);
 
   } > SRAM = 0x00
+
+  /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
+  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/flex/script.ld
+++ b/target/flex/script.ld
@@ -49,7 +49,7 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0DE0001 */
     KEEP(*(.boot.ssp_init))
     /* main; reached via b main, adjacency not required */
     *(.boot*)
@@ -136,7 +136,7 @@ SECTIONS
   } > SRAM = 0x00
 
   /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
-  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
+  ASSERT( __stack_chk_guard == ORIGIN(SRAM), "__stack_chk_guard must be at the RAM base" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -33,7 +33,8 @@ PAGE_SIZE  = 512;
 STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
-ENTRY(main);
+/* __entry == __stack_chk_init if SSP is enabled, else main */
+ENTRY(__entry);
 
 SECTIONS
 {
@@ -50,7 +51,7 @@ SECTIONS
 
     /* ensure __stack_chk_init is always @ 0xC0D00000 */
     KEEP(*(.boot.ssp_init))
-    /* ensure main directly follows __stack_chk_init */
+    /* main; reached via b main, adjacency not required */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -109,10 +110,11 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
+    _ram = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 
@@ -131,6 +133,9 @@ SECTIONS
     PROVIDE(_estack = .);
 
   } > SRAM = 0x00
+
+  /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
+  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/nanos2/script.ld
+++ b/target/nanos2/script.ld
@@ -49,7 +49,7 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0DE0001 */
     KEEP(*(.boot.ssp_init))
     /* main; reached via b main, adjacency not required */
     *(.boot*)
@@ -135,7 +135,7 @@ SECTIONS
   } > SRAM = 0x00
 
   /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
-  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
+  ASSERT( __stack_chk_guard == ORIGIN(SRAM), "__stack_chk_guard must be at the RAM base" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -49,7 +49,7 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0DE0001 */
     KEEP(*(.boot.ssp_init))
     /* main; reached via b main, adjacency not required */
     *(.boot*)
@@ -135,7 +135,7 @@ SECTIONS
   } > SRAM
 
   /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
-  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
+  ASSERT( __stack_chk_guard == ORIGIN(SRAM), "__stack_chk_guard must be at the RAM base" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/nanox/script.ld
+++ b/target/nanox/script.ld
@@ -33,7 +33,8 @@ PAGE_SIZE  = 256;
 STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
-ENTRY(main);
+/* __entry == __stack_chk_init if SSP is enabled, else main */
+ENTRY(__entry);
 
 SECTIONS
 {
@@ -50,7 +51,7 @@ SECTIONS
 
     /* ensure __stack_chk_init is always @ 0xC0D00000 */
     KEEP(*(.boot.ssp_init))
-    /* ensure main directly follows __stack_chk_init */
+    /* main; reached via b main, adjacency not required */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -109,10 +110,11 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
+    _ram = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
 
@@ -131,6 +133,9 @@ SECTIONS
     PROVIDE(_estack = .);
 
   } > SRAM
+
+  /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
+  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -49,7 +49,7 @@ SECTIONS
     _text = .;
     _nvram_start = .;
 
-    /* ensure __stack_chk_init is always @ 0xC0D00000 */
+    /* ensure __stack_chk_init is always @ 0xC0DE0001 */
     KEEP(*(.boot.ssp_init))
     /* main; reached via b main, adjacency not required */
     *(.boot*)
@@ -135,7 +135,7 @@ SECTIONS
   } > SRAM = 0x00
 
   /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
-  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
+  ASSERT( __stack_chk_guard == ORIGIN(SRAM), "__stack_chk_guard must be at the RAM base" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 

--- a/target/stax/script.ld
+++ b/target/stax/script.ld
@@ -33,7 +33,8 @@ PAGE_SIZE  = 512;
 STACK_MIN_SIZE = DEFINED(stack_min_size) ? stack_min_size : 1500;
 END_STACK  = ORIGIN(SRAM) + LENGTH(SRAM);
 
-ENTRY(main);
+/* __entry == __stack_chk_init if SSP is enabled, else main */
+ENTRY(__entry);
 
 SECTIONS
 {
@@ -50,7 +51,7 @@ SECTIONS
 
     /* ensure __stack_chk_init is always @ 0xC0D00000 */
     KEEP(*(.boot.ssp_init))
-    /* ensure main directly follows __stack_chk_init */
+    /* main; reached via b main, adjacency not required */
     *(.boot*)
 
     /* place the other code and rodata defined BUT nvram variables that are displaced in a r/w area */
@@ -110,13 +111,13 @@ SECTIONS
     /**
      * Place RAM uninitialized variables
      */
-    _bss = .;
+    _ram = .;
     __stack_chk_guard = .;
     PROVIDE(__stack_chk_guard = .);
     . += 4;
+    _bss = .;
     *(.bss*)
     _ebss = .;
-
 
     /**
      * Reserve stack size
@@ -132,6 +133,9 @@ SECTIONS
     PROVIDE(_estack = .);
 
   } > SRAM = 0x00
+
+  /* SSP: canary is written via r9 (RAM base), so guard must be first in SRAM */
+  ASSERT( __stack_chk_guard == _ram, "__stack_chk_guard must be at the RAM base (_ram)" )
 
   ASSERT( (_estack - _stack) >= STACK_MIN_SIZE, "stack section too small" )
 


### PR DESCRIPTION
## Description

There were two problems in the initial stack protector implementation :
- canary was not correctly initialized because entry point was forced with `ENTRY(main);`
- during libcalls, caller's BSS was entirely wiped included canary.
The second problem could not be detected during tests as canary was not initialized.

The idea of this fix is to have the correct entry point whether building with SSP.
Also, moving canary out of bss with appropriate pic adaptation.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26
[x] TARGET_API_LEVEL: API_LEVEL_27

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
