### PR TITLE
Update default Rust toolchain support for Zondax apps

### DIFF
--- a/.github/workflows/build_all_c_apps.yml
+++ b/.github/workflows/build_all_c_apps.yml
@@ -56,7 +56,7 @@ jobs:
       # toolchain that differs from the one the builder image exports through
       # RUSTUP_TOOLCHAIN. A set RUSTUP_TOOLCHAIN overrides that pin and breaks
       # the build, so it is unset before make for these apps (see build steps).
-      RUSTUP_TOOLCHAIN_UNSET_APPS: "app-namada app-stacks"
+      RUSTUP_TOOLCHAIN_UNSET_APPS: "app-namada"
 
     steps:
       - name: Clone App


### PR DESCRIPTION
## Description

Some Zondax apps require to unset RUSTUP_TOOLCHAIN (which sets default Rust toolchain to use when building Rust code): app-stacks has been fixed and does not require anymore such exception.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26
[x] TARGET_API_LEVEL: API_LEVEL_27