### PR TITLE
Align mem_utils_calloc size

### DIFF
--- a/lib_alloc/app_mem_utils.c
+++ b/lib_alloc/app_mem_utils.c
@@ -132,7 +132,7 @@ void mem_utils_free(void *ptr, const char *file, int line)
  * @param[in] line line in the source file requesting the allocation (for profiling only)
  * @return true if the allocation was successful, false otherwise
  */
-bool mem_utils_calloc(void **buffer, uint16_t size, bool permanent, const char *file, int line)
+bool mem_utils_calloc(void **buffer, size_t size, bool permanent, const char *file, int line)
 {
     if (size == 0) {
         // Nothing to allocate, but cleanup was done if needed

--- a/lib_alloc/app_mem_utils.h
+++ b/lib_alloc/app_mem_utils.h
@@ -27,4 +27,4 @@ void *mem_utils_realloc(void *ptr, size_t size, const char *file, int line);
 void  mem_utils_free(void *ptr, const char *file, int line);
 void  mem_utils_free_and_null(void **buffer, const char *file, int line);
 char *mem_utils_strdup(const char *s, const char *file, int line);
-bool  mem_utils_calloc(void **buffer, uint16_t size, bool permanent, const char *file, int line);
+bool  mem_utils_calloc(void **buffer, size_t size, bool permanent, const char *file, int line);


### PR DESCRIPTION
## Description

Align mem_utils_calloc size

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

## Additional comments

Please post additional comments in this section if you have them, otherwise delete it.

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26
[X] TARGET_API_LEVEL: API_LEVEL_27

This will only create the PR with cherry-picks, ready to be reviewed and merged.

Remember:

- The merge will ALWAYS be a manual operation.
- It is possible the cherry-picks don't apply correctly, mainly if previous commits have been forgotten.
- In case of failure, there is no other solution than redo the operation manually...
