### PR TITLE
Address book

### DIFF
--- a/app_features/address_book/include/address_book_crypto.h
+++ b/app_features/address_book/include/address_book_crypto.h
@@ -26,25 +26,20 @@
 
 #ifdef HAVE_ADDRESS_BOOK
 
-bool address_book_generate_group_handle(const path_bip32_t *bip32_path,
-                                        uint8_t             group_handle[GROUP_HANDLE_SIZE]);
+bool address_book_generate_group_handle(uint8_t group_handle[GROUP_HANDLE_SIZE]);
 
-bool address_book_verify_group_handle(const path_bip32_t *bip32_path,
-                                      const uint8_t       group_handle[GROUP_HANDLE_SIZE],
-                                      uint8_t             gid_out[GID_SIZE]);
+bool address_book_verify_group_handle(const uint8_t group_handle[GROUP_HANDLE_SIZE],
+                                      uint8_t       gid_out[GID_SIZE]);
 
-bool address_book_compute_hmac_proof(const path_bip32_t *bip32_path,
-                                     const uint8_t       gid[GID_SIZE],
-                                     const char         *name,
-                                     uint8_t             hmac_out[CX_SHA256_SIZE]);
+bool address_book_compute_hmac_proof(const uint8_t gid[GID_SIZE],
+                                     const char   *name,
+                                     uint8_t       hmac_out[CX_SHA256_SIZE]);
 
-bool address_book_verify_hmac_proof(const path_bip32_t *bip32_path,
-                                    const uint8_t       gid[GID_SIZE],
-                                    const char         *name,
-                                    const uint8_t       hmac_expected[CX_SHA256_SIZE]);
+bool address_book_verify_hmac_proof(const uint8_t gid[GID_SIZE],
+                                    const char   *name,
+                                    const uint8_t hmac_expected[CX_SHA256_SIZE]);
 
-bool address_book_compute_hmac_rest(const path_bip32_t *bip32_path,
-                                    const uint8_t       gid[GID_SIZE],
+bool address_book_compute_hmac_rest(const uint8_t       gid[GID_SIZE],
                                     const char         *scope,
                                     const uint8_t      *identifier,
                                     uint8_t             identifier_len,
@@ -52,8 +47,7 @@ bool address_book_compute_hmac_rest(const path_bip32_t *bip32_path,
                                     uint64_t            chain_id,
                                     uint8_t             hmac_out[CX_SHA256_SIZE]);
 
-bool address_book_verify_hmac_rest(const path_bip32_t *bip32_path,
-                                   const uint8_t       gid[GID_SIZE],
+bool address_book_verify_hmac_rest(const uint8_t       gid[GID_SIZE],
                                    const char         *scope,
                                    const uint8_t      *identifier,
                                    uint8_t             identifier_len,

--- a/app_features/address_book/include/identity.h
+++ b/app_features/address_book/include/identity.h
@@ -21,9 +21,10 @@
  * @brief Register / Edit Contact Name / Edit Scope / Edit Identifier
  *
  * An Identity is a contact identified by a name, an IDENTIFIER (blockchain
- * address or public key, up to 80 bytes), an optional SCOPE (context
- * string, e.g. "Ethereum"), and a derivation path used to derive the HMAC key
- * for the Proof of Registration.
+ * address or public key, up to 80 bytes), and an optional SCOPE (context
+ * string, e.g. "Ethereum"). HMAC keys are derived from a hardcoded BIP32 path
+ * (g_identity_bip32_path); the TAG_DERIVATION_PATH TLV field is accepted for
+ * backward compatibility but ignored.
  *
  * Active under HAVE_ADDRESS_BOOK (no sub-flag required).
  */
@@ -59,12 +60,13 @@
  *       it is never displayed to the user.
  */
 typedef struct {
-    uint8_t             gid[GID_SIZE];  ///< Device-generated group ID (first 32B of group_handle)
-    char                contact_name[CONTACT_NAME_LENGTH];
-    char                scope[SCOPE_LENGTH];
-    uint8_t             identifier[IDENTIFIER_MAX_LENGTH];
-    uint8_t             identifier_len;
-    path_bip32_t        bip32_path;  ///< Used to derive the HMAC key for the Proof of Registration
+    uint8_t      gid[GID_SIZE];  ///< Device-generated group ID (first 32B of group_handle)
+    char         contact_name[CONTACT_NAME_LENGTH];
+    char         scope[SCOPE_LENGTH];
+    uint8_t      identifier[IDENTIFIER_MAX_LENGTH];
+    uint8_t      identifier_len;
+    path_bip32_t bip32_path;  ///< Optional: derives HMAC key; will be changed by another mechanism
+                              ///< in OS side
     blockchain_family_e blockchain_family;
     uint64_t            chain_id;  ///< Mandatory when blockchain_family == FAMILY_ETHEREUM
 } identity_t;
@@ -85,7 +87,7 @@ typedef struct {
     uint8_t      gid[GID_SIZE];                          ///< Group ID extracted from group_handle
     char         contact_name[CONTACT_NAME_LENGTH];      ///< New contact name
     char         old_contact_name[CONTACT_NAME_LENGTH];  ///< old contact name
-    path_bip32_t bip32_path;                             ///< BIP32 derivation path
+    path_bip32_t bip32_path;                             ///< Optional: BIP32 derivation path
 } edit_contact_name_t;
 
 /**

--- a/app_features/address_book/src/address_book_crypto.c
+++ b/app_features/address_book/src/address_book_crypto.c
@@ -140,6 +140,13 @@ static size_t serialize_hmac_msg(uint8_t            *msg,
     return offset;
 }
 
+// m/44'/60'/0'/0/0 — hardcoded for all Identity HMAC derivations
+// TODO: to be removed when the OS doesn't need it any more for the HMAC derivation
+static const path_bip32_t s_identity_path = {
+    .length = 5,
+    .path   = {0x8000002C, 0x8000003C, 0x80000000, 0x00000000, 0x00000000},
+};
+
 /* Exported functions --------------------------------------------------------*/
 
 /**
@@ -203,16 +210,19 @@ bool address_book_send_register_identity_response(const uint8_t group_handle[GRO
  * @param[out] group_handle  Output buffer (64 bytes): gid || MAC
  * @return true if successful, false otherwise
  */
-bool address_book_generate_group_handle(const path_bip32_t *bip32_path,
-                                        uint8_t             group_handle[GROUP_HANDLE_SIZE])
+bool address_book_generate_group_handle(uint8_t group_handle[GROUP_HANDLE_SIZE])
 {
     bool     success = false;
     uint8_t *gid     = group_handle;
     uint8_t *mac     = group_handle + GID_SIZE;
 
     cx_rng_no_throw(gid, GID_SIZE);
-    if (!sys_address_book_hmac(
-            bip32_path->path, bip32_path->length, ADDRESS_BOOK_SALT_GROUP, gid, GID_SIZE, mac)) {
+    if (!sys_address_book_hmac(s_identity_path.path,
+                               s_identity_path.length,
+                               ADDRESS_BOOK_SALT_GROUP,
+                               gid,
+                               GID_SIZE,
+                               mac)) {
         goto end;
     }
     success = true;
@@ -232,16 +242,19 @@ end:
  * @param[out] gid_out       Extracted gid (32 bytes), only valid on success
  * @return true if the handle is authentic, false otherwise
  */
-bool address_book_verify_group_handle(const path_bip32_t *bip32_path,
-                                      const uint8_t       group_handle[GROUP_HANDLE_SIZE],
-                                      uint8_t             gid_out[GID_SIZE])
+bool address_book_verify_group_handle(const uint8_t group_handle[GROUP_HANDLE_SIZE],
+                                      uint8_t       gid_out[GID_SIZE])
 {
     bool           success = false;
     const uint8_t *gid     = group_handle;
     const uint8_t *mac     = group_handle + GID_SIZE;
 
-    if (!sys_address_book_hmac_verify(
-            bip32_path->path, bip32_path->length, ADDRESS_BOOK_SALT_GROUP, gid, GID_SIZE, mac)) {
+    if (!sys_address_book_hmac_verify(s_identity_path.path,
+                                      s_identity_path.length,
+                                      ADDRESS_BOOK_SALT_GROUP,
+                                      gid,
+                                      GID_SIZE,
+                                      mac)) {
         PRINTF("[Address Book] Group handle MAC verification failed\n");
         goto end;
     }
@@ -264,10 +277,9 @@ end:
  * @param[out] hmac_out    Output buffer for the 32-byte HMAC
  * @return true if successful, false otherwise
  */
-bool address_book_compute_hmac_proof(const path_bip32_t *bip32_path,
-                                     const uint8_t       gid[GID_SIZE],
-                                     const char         *name,
-                                     uint8_t             hmac_out[CX_SHA256_SIZE])
+bool address_book_compute_hmac_proof(const uint8_t gid[GID_SIZE],
+                                     const char   *name,
+                                     uint8_t       hmac_out[CX_SHA256_SIZE])
 {
     uint8_t msg[HMAC_PROOF_MSG_SIZE] = {0};
     bool    success                  = false;
@@ -276,8 +288,8 @@ bool address_book_compute_hmac_proof(const path_bip32_t *bip32_path,
     if (msg_len == SIZE_MAX) {
         goto end;
     }
-    if (!sys_address_book_hmac(bip32_path->path,
-                               bip32_path->length,
+    if (!sys_address_book_hmac(s_identity_path.path,
+                               s_identity_path.length,
                                ADDRESS_BOOK_SALT_IDENTITY,
                                msg,
                                msg_len,
@@ -300,10 +312,9 @@ end:
  * @param[in] hmac_expected 32-byte HMAC to verify against
  * @return true if valid, false otherwise
  */
-bool address_book_verify_hmac_proof(const path_bip32_t *bip32_path,
-                                    const uint8_t       gid[GID_SIZE],
-                                    const char         *name,
-                                    const uint8_t       hmac_expected[CX_SHA256_SIZE])
+bool address_book_verify_hmac_proof(const uint8_t gid[GID_SIZE],
+                                    const char   *name,
+                                    const uint8_t hmac_expected[CX_SHA256_SIZE])
 {
     uint8_t msg[HMAC_PROOF_MSG_SIZE] = {0};
     bool    success                  = false;
@@ -312,8 +323,8 @@ bool address_book_verify_hmac_proof(const path_bip32_t *bip32_path,
     if (msg_len == SIZE_MAX) {
         goto end;
     }
-    if (!sys_address_book_hmac_verify(bip32_path->path,
-                                      bip32_path->length,
+    if (!sys_address_book_hmac_verify(s_identity_path.path,
+                                      s_identity_path.length,
                                       ADDRESS_BOOK_SALT_IDENTITY,
                                       msg,
                                       msg_len,
@@ -345,8 +356,7 @@ end:
  * @param[out] hmac_out       Output buffer for the 32-byte HMAC
  * @return true if successful, false otherwise
  */
-bool address_book_compute_hmac_rest(const path_bip32_t *bip32_path,
-                                    const uint8_t       gid[GID_SIZE],
+bool address_book_compute_hmac_rest(const uint8_t       gid[GID_SIZE],
                                     const char         *scope,
                                     const uint8_t      *identifier,
                                     uint8_t             identifier_len,
@@ -362,8 +372,8 @@ bool address_book_compute_hmac_rest(const path_bip32_t *bip32_path,
     if (msg_len == SIZE_MAX) {
         goto end;
     }
-    if (!sys_address_book_hmac(bip32_path->path,
-                               bip32_path->length,
+    if (!sys_address_book_hmac(s_identity_path.path,
+                               s_identity_path.length,
                                ADDRESS_BOOK_SALT_IDENTITY,
                                msg,
                                msg_len,
@@ -390,8 +400,7 @@ end:
  * @param[in] hmac_expected 32-byte HMAC to verify against
  * @return true if valid, false otherwise
  */
-bool address_book_verify_hmac_rest(const path_bip32_t *bip32_path,
-                                   const uint8_t       gid[GID_SIZE],
+bool address_book_verify_hmac_rest(const uint8_t       gid[GID_SIZE],
                                    const char         *scope,
                                    const uint8_t      *identifier,
                                    uint8_t             identifier_len,
@@ -407,8 +416,8 @@ bool address_book_verify_hmac_rest(const path_bip32_t *bip32_path,
     if (msg_len == SIZE_MAX) {
         goto end;
     }
-    if (!sys_address_book_hmac_verify(bip32_path->path,
-                                      bip32_path->length,
+    if (!sys_address_book_hmac_verify(s_identity_path.path,
+                                      s_identity_path.length,
                                       ADDRESS_BOOK_SALT_IDENTITY,
                                       msg,
                                       msg_len,

--- a/app_features/address_book/src/identity_edit_contact_name.c
+++ b/app_features/address_book/src/identity_edit_contact_name.c
@@ -23,8 +23,8 @@
  * to transmit the identifier, scope, or network fields.
  *
  * Flow:
- *  1. Parse TLV payload (gid + new_name + previous_name +
- *     derivation_path + hmac_proof)
+ *  1. Parse TLV payload (gid + new_name + previous_name
+ *     [+ derivation_path] + hmac_proof)
  *  2. Verify HMAC_PROOF over (gid, previous_name)
  *  3. Display UI: old name → new name
  *  4. On confirm: compute new HMAC_PROOF over (gid, new_name) and send
@@ -172,7 +172,9 @@ static bool handle_group_handle(const tlv_data_t *data, s_edit_contact_name_ctx 
  */
 static bool handle_derivation_path(const tlv_data_t *data, s_edit_contact_name_ctx *context)
 {
-    return address_book_handle_derivation_path(data, &context->edit->bip32_path);
+    UNUSED(data);
+    UNUSED(context);
+    return true;
 }
 
 /**
@@ -210,7 +212,6 @@ static bool verify_fields(const s_edit_contact_name_ctx *context)
                                           TAG_CONTACT_NAME,
                                           TAG_PREVIOUS_NAME,
                                           TAG_GROUP_HANDLE,
-                                          TAG_DERIVATION_PATH,
                                           TAG_HMAC_PROOF);
     if (!result) {
         PRINTF("[Edit Contact Name] Missing mandatory fields!\n");
@@ -245,11 +246,11 @@ static bool build_and_send_response(void)
 {
     uint8_t hmac_proof[CX_SHA256_SIZE] = {0};
 
-    if (!address_book_compute_hmac_proof(&g_ab_payload.edit_contact_name.bip32_path,
-                                         g_ab_payload.edit_contact_name.gid,
+    if (!address_book_compute_hmac_proof(g_ab_payload.edit_contact_name.gid,
                                          g_ab_payload.edit_contact_name.contact_name,
                                          hmac_proof)) {
         PRINTF("[Edit Contact Name] Error: Failed to compute new HMAC_PROOF\n");
+        explicit_bzero(hmac_proof, sizeof(hmac_proof));
         return false;
     }
 
@@ -336,16 +337,13 @@ bolos_err_t edit_contact_name(uint8_t *buffer_in, size_t buffer_in_length)
     print_payload(&ctx);
 
     // Verify the group handle and extract the gid
-    if (!address_book_verify_group_handle(&g_ab_payload.edit_contact_name.bip32_path,
-                                          ctx.group_handle,
-                                          g_ab_payload.edit_contact_name.gid)) {
+    if (!address_book_verify_group_handle(ctx.group_handle, g_ab_payload.edit_contact_name.gid)) {
         PRINTF("[Edit Contact Name] Group handle verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
     // Verify the wallet holds a valid HMAC_PROOF for the previous name
-    if (!address_book_verify_hmac_proof(&g_ab_payload.edit_contact_name.bip32_path,
-                                        g_ab_payload.edit_contact_name.gid,
+    if (!address_book_verify_hmac_proof(g_ab_payload.edit_contact_name.gid,
                                         g_ab_payload.edit_contact_name.old_contact_name,
                                         ctx.hmac_proof)) {
         PRINTF("[Edit Contact Name] HMAC_PROOF verification failed\n");

--- a/app_features/address_book/src/identity_edit_identifier.c
+++ b/app_features/address_book/src/identity_edit_identifier.c
@@ -25,7 +25,7 @@
  *  1. Receive fully assembled payload (multi-chunk reassembly handled by
  *     address_book.c)
  *  2. Parse TLV payload (contact_name + scope + new_identifier +
- *     old_identifier + gid + derivation_path +
+ *     old_identifier + gid [+ derivation_path] +
  *     hmac_proof + hmac_rest)
  *  3. Verify HMAC_PROOF over (gid, contact_name)
  *  4. Verify HMAC_REST over (gid, scope, old_identifier, family[, chain_id])
@@ -222,7 +222,9 @@ static bool handle_group_handle(const tlv_data_t *data, s_edit_ctx *context)
  */
 static bool handle_derivation_path(const tlv_data_t *data, s_edit_ctx *context)
 {
-    return address_book_handle_derivation_path(data, &context->edit->identity.bip32_path);
+    UNUSED(data);
+    UNUSED(context);
+    return true;
 }
 
 /**
@@ -303,7 +305,6 @@ static bool verify_fields(const s_edit_ctx *context)
                                           TAG_ACCOUNT_IDENTIFIER,
                                           TAG_PREVIOUS_IDENTIFIER,
                                           TAG_GROUP_HANDLE,
-                                          TAG_DERIVATION_PATH,
                                           TAG_BLOCKCHAIN_FAMILY,
                                           TAG_HMAC_PROOF,
                                           TAG_HMAC_REST);
@@ -355,8 +356,7 @@ static bool build_and_send_response(void)
 {
     uint8_t hmac_rest[CX_SHA256_SIZE] = {0};
 
-    if (!address_book_compute_hmac_rest(&g_ab_payload.edit_identifier.identity.bip32_path,
-                                        g_ab_payload.edit_identifier.identity.gid,
+    if (!address_book_compute_hmac_rest(g_ab_payload.edit_identifier.identity.gid,
                                         g_ab_payload.edit_identifier.identity.scope,
                                         g_ab_payload.edit_identifier.identity.identifier,
                                         g_ab_payload.edit_identifier.identity.identifier_len,
@@ -364,9 +364,9 @@ static bool build_and_send_response(void)
                                         g_ab_payload.edit_identifier.identity.chain_id,
                                         hmac_rest)) {
         PRINTF("[Edit Identifier] Error: Failed to compute new HMAC_REST\n");
+        explicit_bzero(hmac_rest, sizeof(hmac_rest));
         return false;
     }
-
     bool ok = address_book_send_hmac_proof(TYPE_EDIT_IDENTIFIER, hmac_rest);
     explicit_bzero(hmac_rest, sizeof(hmac_rest));
     return ok;
@@ -446,16 +446,14 @@ bolos_err_t edit_identifier(uint8_t *buffer_in, size_t buffer_in_length)
     print_payload(&ctx);
 
     // Verify the group handle and extract the gid
-    if (!address_book_verify_group_handle(&g_ab_payload.edit_identifier.identity.bip32_path,
-                                          ctx.group_handle,
+    if (!address_book_verify_group_handle(ctx.group_handle,
                                           g_ab_payload.edit_identifier.identity.gid)) {
         PRINTF("[Edit Identifier] Group handle verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
     // Verify that the wallet holds a valid HMAC_PROOF for the contact name
-    if (!address_book_verify_hmac_proof(&g_ab_payload.edit_identifier.identity.bip32_path,
-                                        g_ab_payload.edit_identifier.identity.gid,
+    if (!address_book_verify_hmac_proof(g_ab_payload.edit_identifier.identity.gid,
                                         g_ab_payload.edit_identifier.identity.contact_name,
                                         ctx.hmac_proof)) {
         PRINTF("[Edit Identifier] HMAC_PROOF verification failed\n");
@@ -463,8 +461,7 @@ bolos_err_t edit_identifier(uint8_t *buffer_in, size_t buffer_in_length)
     }
 
     // Verify that the wallet holds a valid HMAC_REST for the previous identifier
-    if (!address_book_verify_hmac_rest(&g_ab_payload.edit_identifier.identity.bip32_path,
-                                       g_ab_payload.edit_identifier.identity.gid,
+    if (!address_book_verify_hmac_rest(g_ab_payload.edit_identifier.identity.gid,
                                        g_ab_payload.edit_identifier.identity.scope,
                                        g_ab_payload.edit_identifier.old_identifier,
                                        g_ab_payload.edit_identifier.old_identifier_len,

--- a/app_features/address_book/src/identity_edit_scope.c
+++ b/app_features/address_book/src/identity_edit_scope.c
@@ -25,7 +25,7 @@
  *  1. Receive fully assembled payload (multi-chunk reassembly handled by
  *     address_book.c)
  *  2. Parse TLV payload (contact_name + new_scope + old_scope +
- *     identifier + gid + derivation_path + chain_id +
+ *     identifier + gid [+ derivation_path] + chain_id +
  *     blockchain_family + hmac_proof + hmac_rest)
  *  3. Verify HMAC_PROOF over (gid, contact_name)
  *  4. Verify HMAC_REST over (gid, old_scope, identifier, family[, chain_id])
@@ -221,7 +221,9 @@ static bool handle_group_handle(const tlv_data_t *data, s_edit_scope_ctx *contex
  */
 static bool handle_derivation_path(const tlv_data_t *data, s_edit_scope_ctx *context)
 {
-    return address_book_handle_derivation_path(data, &context->edit->identity.bip32_path);
+    UNUSED(data);
+    UNUSED(context);
+    return true;
 }
 
 /**
@@ -302,7 +304,6 @@ static bool verify_fields(const s_edit_scope_ctx *context)
                                           TAG_ACCOUNT_IDENTIFIER,
                                           TAG_PREVIOUS_SCOPE,
                                           TAG_GROUP_HANDLE,
-                                          TAG_DERIVATION_PATH,
                                           TAG_BLOCKCHAIN_FAMILY,
                                           TAG_HMAC_PROOF,
                                           TAG_HMAC_REST);
@@ -353,8 +354,7 @@ static bool build_and_send_response(void)
 {
     uint8_t hmac_rest[CX_SHA256_SIZE] = {0};
 
-    if (!address_book_compute_hmac_rest(&g_ab_payload.edit_scope.identity.bip32_path,
-                                        g_ab_payload.edit_scope.identity.gid,
+    if (!address_book_compute_hmac_rest(g_ab_payload.edit_scope.identity.gid,
                                         g_ab_payload.edit_scope.identity.scope,
                                         g_ab_payload.edit_scope.identity.identifier,
                                         g_ab_payload.edit_scope.identity.identifier_len,
@@ -362,9 +362,9 @@ static bool build_and_send_response(void)
                                         g_ab_payload.edit_scope.identity.chain_id,
                                         hmac_rest)) {
         PRINTF("[Edit Scope] Error: Failed to compute new HMAC_REST\n");
+        explicit_bzero(hmac_rest, sizeof(hmac_rest));
         return false;
     }
-
     bool ok = address_book_send_hmac_proof(TYPE_EDIT_SCOPE, hmac_rest);
     explicit_bzero(hmac_rest, sizeof(hmac_rest));
     return ok;
@@ -456,16 +456,13 @@ bolos_err_t edit_scope(uint8_t *buffer_in, size_t buffer_in_length)
     print_payload(&ctx);
 
     // Verify the group handle and extract the gid
-    if (!address_book_verify_group_handle(&g_ab_payload.edit_scope.identity.bip32_path,
-                                          ctx.group_handle,
-                                          g_ab_payload.edit_scope.identity.gid)) {
+    if (!address_book_verify_group_handle(ctx.group_handle, g_ab_payload.edit_scope.identity.gid)) {
         PRINTF("[Edit Scope] Group handle verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
     // Verify that the wallet holds a valid HMAC_PROOF for the contact name
-    if (!address_book_verify_hmac_proof(&g_ab_payload.edit_scope.identity.bip32_path,
-                                        g_ab_payload.edit_scope.identity.gid,
+    if (!address_book_verify_hmac_proof(g_ab_payload.edit_scope.identity.gid,
                                         g_ab_payload.edit_scope.identity.contact_name,
                                         ctx.hmac_proof)) {
         PRINTF("[Edit Scope] HMAC_PROOF verification failed\n");
@@ -473,8 +470,7 @@ bolos_err_t edit_scope(uint8_t *buffer_in, size_t buffer_in_length)
     }
 
     // Verify that the wallet holds a valid HMAC_REST for the previous scope
-    if (!address_book_verify_hmac_rest(&g_ab_payload.edit_scope.identity.bip32_path,
-                                       g_ab_payload.edit_scope.identity.gid,
+    if (!address_book_verify_hmac_rest(g_ab_payload.edit_scope.identity.gid,
                                        g_ab_payload.edit_scope.old_scope,
                                        g_ab_payload.edit_scope.identity.identifier,
                                        g_ab_payload.edit_scope.identity.identifier_len,

--- a/app_features/address_book/src/identity_provide_contact.c
+++ b/app_features/address_book/src/identity_provide_contact.c
@@ -26,7 +26,7 @@
  *  1. Receive fully assembled payload (multi-chunk reassembly handled by
  *     address_book.c)
  *  2. Parse TLV payload (contact_name + scope + identifier +
- *     group_handle + derivation_path + blockchain_family [+ chain_id] +
+ *     group_handle [+ derivation_path] + blockchain_family [+ chain_id] +
  *     hmac_proof + hmac_rest)
  *  3. Verify group_handle → extract gid
  *  4. Verify HMAC_PROOF over (gid, contact_name)
@@ -197,7 +197,9 @@ static bool handle_group_handle(const tlv_data_t *data, s_provide_contact_ctx *c
  */
 static bool handle_derivation_path(const tlv_data_t *data, s_provide_contact_ctx *context)
 {
-    return address_book_handle_derivation_path(data, &context->identity->bip32_path);
+    UNUSED(data);
+    UNUSED(context);
+    return true;
 }
 
 /**
@@ -278,7 +280,6 @@ static bool verify_fields(const s_provide_contact_ctx *context)
                                           TAG_SCOPE,
                                           TAG_ACCOUNT_IDENTIFIER,
                                           TAG_GROUP_HANDLE,
-                                          TAG_DERIVATION_PATH,
                                           TAG_BLOCKCHAIN_FAMILY,
                                           TAG_HMAC_PROOF,
                                           TAG_HMAC_REST);
@@ -348,16 +349,13 @@ bolos_err_t provide_contact(uint8_t *buffer_in, size_t buffer_in_length)
     print_payload(&ctx);
 
     // Verify the group handle and extract the gid
-    if (!address_book_verify_group_handle(&g_ab_payload.provide_contact.bip32_path,
-                                          ctx.group_handle,
-                                          g_ab_payload.provide_contact.gid)) {
+    if (!address_book_verify_group_handle(ctx.group_handle, g_ab_payload.provide_contact.gid)) {
         PRINTF("[Provide Contact] Group handle verification failed\n");
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
     // Verify HMAC_PROOF over (gid, contact_name)
-    if (!address_book_verify_hmac_proof(&g_ab_payload.provide_contact.bip32_path,
-                                        g_ab_payload.provide_contact.gid,
+    if (!address_book_verify_hmac_proof(g_ab_payload.provide_contact.gid,
                                         g_ab_payload.provide_contact.contact_name,
                                         ctx.hmac_proof)) {
         PRINTF("[Provide Contact] HMAC_PROOF verification failed\n");
@@ -365,8 +363,7 @@ bolos_err_t provide_contact(uint8_t *buffer_in, size_t buffer_in_length)
     }
 
     // Verify HMAC_REST over (gid, scope, identifier, family[, chain_id])
-    if (!address_book_verify_hmac_rest(&g_ab_payload.provide_contact.bip32_path,
-                                       g_ab_payload.provide_contact.gid,
+    if (!address_book_verify_hmac_rest(g_ab_payload.provide_contact.gid,
                                        g_ab_payload.provide_contact.scope,
                                        g_ab_payload.provide_contact.identifier,
                                        g_ab_payload.provide_contact.identifier_len,
@@ -377,7 +374,7 @@ bolos_err_t provide_contact(uint8_t *buffer_in, size_t buffer_in_length)
         return SWO_SECURITY_CONDITION_NOT_SATISFIED;
     }
 
-    // Pass verified contact to the coin app for storage
+    // Pass contact to the coin app for storage
     if (!handle_provide_identity(&g_ab_payload.provide_contact)) {
         PRINTF("[Provide Contact] Rejected by coin application\n");
         return SWO_WRONG_PARAMETER_VALUE;

--- a/app_features/address_book/src/identity_register.c
+++ b/app_features/address_book/src/identity_register.c
@@ -19,7 +19,7 @@
  * @brief Register Identity flow (P1=0x01, struct type 0x2d)
  *
  * Flow:
- *  1. Parse TLV payload (name + scope + identifier + derivation_path)
+ *  1. Parse TLV payload (name + scope + identifier [+ derivation_path])
  *  2. Coin-app validation: handle_check_register_identity()
  *  3. Display UI: contact name + identifier
  *  4. On confirm: compute HMAC Proof of Registration and send to host
@@ -171,7 +171,9 @@ static bool handle_identifier(const tlv_data_t *data, s_identity_ctx *context)
  */
 static bool handle_derivation_path(const tlv_data_t *data, s_identity_ctx *context)
 {
-    return address_book_handle_derivation_path(data, &context->state->identity.bip32_path);
+    UNUSED(data);
+    UNUSED(context);
+    return true;
 }
 
 /**
@@ -252,7 +254,6 @@ static bool verify_fields(const s_identity_ctx *context)
                                           TAG_CONTACT_NAME,
                                           TAG_SCOPE,
                                           TAG_ACCOUNT_IDENTIFIER,
-                                          TAG_DERIVATION_PATH,
                                           TAG_BLOCKCHAIN_FAMILY);
     if (!result) {
         PRINTF("Missing mandatory fields in Register Identity descriptor!\n");
@@ -284,8 +285,6 @@ static bool verify_fields(const s_identity_ctx *context)
 static void print_payload(const s_identity_ctx *context)
 {
     UNUSED(context);
-    char out[50] = {0};
-
     PRINTF("****************************************************************************\n");
     PRINTF("[Register Identity] - Retrieved Descriptor:\n");
     PRINTF("[Register Identity] -    Contact name:        %s\n",
@@ -293,15 +292,6 @@ static void print_payload(const s_identity_ctx *context)
     if (context->state->identity.scope[0] != '\0') {
         PRINTF("[Register Identity] -    Contact scope:       %s\n",
                context->state->identity.scope);
-    }
-    if (bip32_path_format_simple(&context->state->identity.bip32_path, out, sizeof(out))) {
-        PRINTF("[Register Identity] -    Derivation path[%d]: %s\n",
-               context->state->identity.bip32_path.length,
-               out);
-    }
-    else {
-        PRINTF("[Register Identity] -    Derivation path length[%d] (failed to format)\n",
-               context->state->identity.bip32_path.length);
     }
     PRINTF("[Register Identity] -    Blockchain family:   %s\n",
            FAMILY_AS_STR(context->state->identity.blockchain_family));
@@ -334,8 +324,7 @@ static bool build_and_send_response(void)
     if (g_ab_payload.reg.active) {
         // group_handle and HMAC_PROOF were already verified before the UI — use the
         // pre-extracted GID directly and only compute the new HMAC_REST.
-        if (!address_book_compute_hmac_rest(&g_ab_payload.reg.identity.bip32_path,
-                                            g_ab_payload.reg.gid,
+        if (!address_book_compute_hmac_rest(g_ab_payload.reg.gid,
                                             g_ab_payload.reg.identity.scope,
                                             g_ab_payload.reg.identity.identifier,
                                             g_ab_payload.reg.identity.identifier_len,
@@ -350,22 +339,18 @@ static bool build_and_send_response(void)
         memmove(hmac_proof, g_ab_payload.reg.hmac_proof, CX_SHA256_SIZE);
     }
     else {
-        if (!address_book_generate_group_handle(&g_ab_payload.reg.identity.bip32_path,
-                                                group_handle)) {
+        if (!address_book_generate_group_handle(group_handle)) {
             PRINTF("[Register Identity] Error: Failed to generate group handle\n");
             goto end;
         }
         // group_handle layout: gid(32) | MAC(K_group, gid)(32) — use only the GID prefix here
         const uint8_t *gid = group_handle;
-        if (!address_book_compute_hmac_proof(&g_ab_payload.reg.identity.bip32_path,
-                                             gid,
-                                             g_ab_payload.reg.identity.contact_name,
-                                             hmac_proof)) {
+        if (!address_book_compute_hmac_proof(
+                gid, g_ab_payload.reg.identity.contact_name, hmac_proof)) {
             PRINTF("[Register Identity] Error: Failed to compute HMAC_PROOF\n");
             goto end;
         }
-        if (!address_book_compute_hmac_rest(&g_ab_payload.reg.identity.bip32_path,
-                                            gid,
+        if (!address_book_compute_hmac_rest(gid,
                                             g_ab_payload.reg.identity.scope,
                                             g_ab_payload.reg.identity.identifier,
                                             g_ab_payload.reg.identity.identifier_len,
@@ -461,14 +446,12 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
     // immediately; only internal crypto operations remain post-confirm.
     if (TLV_CHECK_RECEIVED_TAGS(ctx.received_tags, TAG_GROUP_HANDLE)) {
         g_ab_payload.reg.active = true;
-        if (!address_book_verify_group_handle(&g_ab_payload.reg.identity.bip32_path,
-                                              g_ab_payload.reg.group_handle,
+        if (!address_book_verify_group_handle(g_ab_payload.reg.group_handle,
                                               g_ab_payload.reg.gid)) {
             PRINTF("[Register Identity] Error: Group handle verification failed\n");
             return SWO_SECURITY_CONDITION_NOT_SATISFIED;
         }
-        if (!address_book_verify_hmac_proof(&g_ab_payload.reg.identity.bip32_path,
-                                            g_ab_payload.reg.gid,
+        if (!address_book_verify_hmac_proof(g_ab_payload.reg.gid,
                                             g_ab_payload.reg.identity.contact_name,
                                             g_ab_payload.reg.hmac_proof)) {
             PRINTF("[Register Identity] Error: HMAC_PROOF verification failed\n");

--- a/app_features/address_book/src/identity_register.c
+++ b/app_features/address_book/src/identity_register.c
@@ -410,10 +410,13 @@ static void review_choice(bool confirm)
 /**
  * @brief Display the Register Identity review screen
  */
-static void ui_display(void)
+static void ui_display(const s_identity_ctx *context)
 {
     memset(&g_ab_ui.list, 0, sizeof(g_ab_ui.list));
-    g_ab_ui.list.nbPairs  = 4;  // name + scope + identifier + network
+    g_ab_ui.list.nbPairs = 3;  // name + scope + identifier
+    if (context->state->identity.blockchain_family == FAMILY_ETHEREUM) {
+        g_ab_ui.list.nbPairs++;  // network
+    }
     g_ab_ui.list.callback = get_register_identity_tagValue;
     address_book_display_review(&LARGE_ADDRESS_BOOK_ICON,
                                 "Review contact details",
@@ -480,7 +483,7 @@ bolos_err_t register_identity(uint8_t *buffer_in, size_t buffer_in_length)
     }
 
     // Display confirmation UI
-    ui_display();
+    ui_display(&ctx);
     return SWO_NO_RESPONSE;
 }
 

--- a/fuzzing/sdk-fuzz/harness/fuzz_address_book_crypto.c
+++ b/fuzzing/sdk-fuzz/harness/fuzz_address_book_crypto.c
@@ -183,34 +183,34 @@ int fuzz_entry(const uint8_t *data, size_t size)
     switch (L.sel % N_VARIANTS) {
         /* ── address_book_generate_group_handle ── */
         case 0:
-            address_book_generate_group_handle(&bip32, gh_out);
+            address_book_generate_group_handle(gh_out);
             break;
 
         /* ── address_book_verify_group_handle ── */
         case 1:
-            address_book_verify_group_handle(&bip32, L.group_handle, gid_out);
+            address_book_verify_group_handle(L.group_handle, gid_out);
             break;
 
         /* ── address_book_compute_hmac_proof (identity) ── */
         case 2:
-            address_book_compute_hmac_proof(&bip32, L.gid, L.name, out32);
+            address_book_compute_hmac_proof(L.gid, L.name, out32);
             break;
 
         /* ── address_book_verify_hmac_proof (identity) ── */
         case 3:
-            address_book_verify_hmac_proof(&bip32, L.gid, L.name, L.hmac_expected);
+            address_book_verify_hmac_proof(L.gid, L.name, L.hmac_expected);
             break;
 
         /* ── address_book_compute_hmac_rest ── */
         case 4:
             address_book_compute_hmac_rest(
-                &bip32, L.gid, L.scope, L.identifier, id_len, fam, chain_id, out32);
+                L.gid, L.scope, L.identifier, id_len, fam, chain_id, out32);
             break;
 
         /* ── address_book_verify_hmac_rest ── */
         case 5:
             address_book_verify_hmac_rest(
-                &bip32, L.gid, L.scope, L.identifier, id_len, fam, chain_id, L.hmac_expected);
+                L.gid, L.scope, L.identifier, id_len, fam, chain_id, L.hmac_expected);
             break;
 
         /* ── address_book_send_hmac_proof ── */
@@ -245,15 +245,15 @@ int fuzz_entry(const uint8_t *data, size_t size)
             uint8_t hmac_proof[CX_SHA256_SIZE]      = {0};
             uint8_t hmac_rest[CX_SHA256_SIZE]       = {0};
 
-            if (!address_book_generate_group_handle(&bip32, group_handle)) {
+            if (!address_book_generate_group_handle(group_handle)) {
                 break;
             }
             const uint8_t *gid = group_handle; /* first 32 bytes */
-            if (!address_book_compute_hmac_proof(&bip32, gid, L.name, hmac_proof)) {
+            if (!address_book_compute_hmac_proof(gid, L.name, hmac_proof)) {
                 break;
             }
             if (!address_book_compute_hmac_rest(
-                    &bip32, gid, L.scope, L.identifier, id_len, fam, chain_id, hmac_rest)) {
+                    gid, L.scope, L.identifier, id_len, fam, chain_id, hmac_rest)) {
                 break;
             }
             address_book_send_register_identity_response(group_handle, hmac_proof, hmac_rest);
@@ -269,10 +269,10 @@ int fuzz_entry(const uint8_t *data, size_t size)
          * register_identity() when TAG_GROUP_HANDLE is present. */
         case 11: {
             uint8_t gid_buf[GID_SIZE] = {0};
-            if (!address_book_verify_group_handle(&bip32, L.group_handle, gid_buf)) {
+            if (!address_book_verify_group_handle(L.group_handle, gid_buf)) {
                 break;
             }
-            address_book_verify_hmac_proof(&bip32, gid_buf, L.name, L.hmac_proof);
+            address_book_verify_hmac_proof(gid_buf, L.name, L.hmac_proof);
             break;
         }
 

--- a/unit-tests/address_book/test_address_book_provide_contact.c
+++ b/unit-tests/address_book/test_address_book_provide_contact.c
@@ -20,7 +20,7 @@
  *  - Missing ACCOUNT_IDENTIFIER       → SWO_INCORRECT_DATA
  *  - Missing GROUP_HANDLE             → SWO_INCORRECT_DATA
  *  - GROUP_HANDLE wrong size          → SWO_INCORRECT_DATA
- *  - Missing DERIVATION_PATH          → SWO_INCORRECT_DATA
+ *  - Missing DERIVATION_PATH          → SWO_SUCCESS (optional, silently ignored)
  *  - Missing BLOCKCHAIN_FAMILY        → SWO_INCORRECT_DATA
  *  - FAMILY_ETHEREUM without CHAIN_ID → SWO_INCORRECT_DATA
  *  - Missing HMAC_PROOF               → SWO_INCORRECT_DATA
@@ -415,13 +415,13 @@ static void test_pc_missing_derivation_path(void)
                                        true,
                                        true,
                                        64,
-                                       false, /* no deriv_path */
+                                       false, /* no deriv_path — optional, ignored */
                                        true,
                                        0x00,
                                        false,
                                        true,
                                        true);
-    TEST_ASSERT_EQUAL_INT(SWO_INCORRECT_DATA, provide_contact(buf, len));
+    TEST_ASSERT_EQUAL_INT(SWO_SUCCESS, provide_contact(buf, len));
 }
 
 static void test_pc_missing_blockchain_family(void)


### PR DESCRIPTION
## Description

- Fix Identity `nbPairs` for app without network
- hardcode Identity BIP32 path, make `TAG_DERIVATION_PATH` optional

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [ ] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[X] TARGET_API_LEVEL: API_LEVEL_26
[X] TARGET_API_LEVEL: API_LEVEL_27

This will only create the PR with cherry-picks, ready to be reviewed and merged.