### PR TITLE
Exclude some plugins to be built during CI

### DIFF
--- a/.github/workflows/scripts/get_c_apps.py
+++ b/.github/workflows/scripts/get_c_apps.py
@@ -8,7 +8,7 @@ if len(sys.argv) != 2:
     sys.exit(1)
 
 # Excluded C apps
-excluded_apps = [""]
+excluded_apps = ["app-plugin-rarible", "app-plugin-okx"]
 
 # Retrieve all public apps on LedgerHQ GitHub organization
 token = sys.argv[1]


### PR DESCRIPTION
## Description

Exclude those plugins from being built during the CI

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Tests
- [ ] Documentation
- [x] Other (for changes that might not fit in any category)

## Auto cherry-pick in API_LEVEL

If requested to port the commits from this PR on a dedicated _API_LEVEL_ branch,
select the targeted one(s), or add new references if not listed:

[x] TARGET_API_LEVEL: API_LEVEL_26
[x] TARGET_API_LEVEL: API_LEVEL_27

This will only create the PR with cherry-picks, ready to be reviewed and merged.

